### PR TITLE
Add editing config to shell instruction.

### DIFF
--- a/lib/mix/tasks/phoenix/pow.phoenix.install.ex
+++ b/lib/mix/tasks/phoenix/pow.phoenix.install.ex
@@ -66,10 +66,10 @@ defmodule Mix.Tasks.Pow.Phoenix.Install do
     First, update config/config.ex with the following:
 
     config :my_app, :pow,
-      user: MyApp.Users.User,
-      repo: MyApp.Repo
+      user: #{inspect(context_base)}.Users.User,
+      repo: #{inspect(context_base)}.Repo
 
-    Next, the #{web_prefix}/endpoint.ex file needs the `Pow.Plug.Session` plug:
+    Next, update #{web_prefix}/endpoint.ex with the `Pow.Plug.Session` plug:
 
     defmodule #{inspect(web_base)}.Endpoint do
       use Phoenix.Endpoint, otp_app: :#{Macro.underscore(context_base)}
@@ -78,7 +78,7 @@ defmodule Mix.Tasks.Pow.Phoenix.Install do
 
       plug Plug.Session,
         store: :cookie,
-        key: "_my_project_demo_key",
+        key: "_#{Macro.underscore(context_base)}_key",
         signing_salt: "secret"
 
       plug Pow.Plug.Session, otp_app: :#{Macro.underscore(context_base)}
@@ -86,7 +86,7 @@ defmodule Mix.Tasks.Pow.Phoenix.Install do
       # ...
     end
 
-    Last, your router.ex should include the Pow routes:
+    Last, update #{web_prefix}/router.ex with the Pow routes:
 
     defmodule #{inspect(web_base)}.Router do
       use #{inspect(web_base)}, :router

--- a/lib/mix/tasks/phoenix/pow.phoenix.install.ex
+++ b/lib/mix/tasks/phoenix/pow.phoenix.install.ex
@@ -61,9 +61,15 @@ defmodule Mix.Tasks.Pow.Phoenix.Install do
     Mix.shell.info("""
     Pow has been installed in your phoenix app!
 
-    There's two files you'll need to configure first before you can use Pow.
+    There are three files you'll need to configure first before you can use Pow.
 
-    First, the #{web_prefix}/endpoint.ex file needs the `Pow.Plug.Session` plug:
+    First, update config/config.ex with the following:
+
+    config :my_app, :pow,
+      user: MyApp.Users.User,
+      repo: MyApp.Repo
+
+    Next, the #{web_prefix}/endpoint.ex file needs the `Pow.Plug.Session` plug:
 
     defmodule #{inspect(web_base)}.Endpoint do
       use Phoenix.Endpoint, otp_app: :#{Macro.underscore(context_base)}
@@ -80,7 +86,7 @@ defmodule Mix.Tasks.Pow.Phoenix.Install do
       # ...
     end
 
-    Next, your router.ex should include the Pow routes:
+    Last, your router.ex should include the Pow routes:
 
     defmodule #{inspect(web_base)}.Router do
       use #{inspect(web_base)}, :router

--- a/test/mix/tasks/phoenix/pow.phoenix.install_test.exs
+++ b/test/mix/tasks/phoenix/pow.phoenix.install_test.exs
@@ -29,8 +29,9 @@ defmodule Mix.Tasks.Pow.Phoenix.InstallTest do
       refute File.exists?(@views_path)
 
       assert_received {:mix_shell, :info, [msg]}
+      assert msg =~ "config :my_app, :pow,"
+      assert msg =~ "user: Pow.Users.User,"
       assert msg =~ "plug Pow.Plug.Session, otp_app: :pow"
-
       assert msg =~ "use Pow.Phoenix.Router"
       assert msg =~ "pow_routes()"
     end)


### PR DESCRIPTION
This is simply updates `print_shell_instruction/1`.

But I cannot sure which is the suitable way to add config for `:pow` among these options:

1) Automatically append `:pow` config to `config/config.ex`.
2) Let user to put `:pow` config manually BEFORE pow installation.
3) Let user to put `:pow` config manually AFTER pow installation.

Option 1 is a common way used in mix installation. (Though I believe it'd be better if there's a function to insert or delete key/value in `config/config.ex`)