### PR TITLE
Use config as last argument

### DIFF
--- a/lib/extensions/email_confirmation/ecto/context.ex
+++ b/lib/extensions/email_confirmation/ecto/context.ex
@@ -10,15 +10,15 @@ defmodule PowEmailConfirmation.Ecto.Context do
   @doc """
   Finds a user by the `email_confirmation_token` column.
   """
-  @spec get_by_confirmation_token(Config.t(), binary()) :: map() | nil
-  def get_by_confirmation_token(config, token),
-    do: Context.get_by(config, email_confirmation_token: token)
+  @spec get_by_confirmation_token(binary(), Config.t()) :: map() | nil
+  def get_by_confirmation_token(token, config),
+    do: Context.get_by([email_confirmation_token: token], config)
 
   @doc """
   Updates `email_confirmed_at` if it hasn't already been set.
   """
-  @spec confirm_email(Config.t(), map()) :: {:ok, map()} | {:error, Changeset.t()}
-  def confirm_email(config, user) do
+  @spec confirm_email(map(), Config.t()) :: {:ok, map()} | {:error, Changeset.t()}
+  def confirm_email(user, config) do
     user
     |> Schema.confirm_email_changeset()
     |> Context.do_update(config)

--- a/lib/extensions/email_confirmation/plug.ex
+++ b/lib/extensions/email_confirmation/plug.ex
@@ -8,8 +8,8 @@ defmodule PowEmailConfirmation.Plug do
   def confirm_email(conn, token) do
     config = Plug.fetch_config(conn)
 
-    config
-    |> Context.get_by_confirmation_token(token)
+    token
+    |> Context.get_by_confirmation_token(config)
     |> maybe_confirm_email(conn, config)
   end
 
@@ -17,8 +17,8 @@ defmodule PowEmailConfirmation.Plug do
     {:error, nil, conn}
   end
   defp maybe_confirm_email(user, conn, config) do
-    config
-    |> Context.confirm_email(user)
+    user
+    |> Context.confirm_email(config)
     |> case do
       {:error, changeset} -> {:error, changeset, conn}
       {:ok, user}         -> {:ok, user, maybe_renew_conn(conn, user, config)}

--- a/lib/extensions/persistent_session/plug/cookie.ex
+++ b/lib/extensions/persistent_session/plug/cookie.ex
@@ -136,7 +136,7 @@ defmodule PowPersistentSession.Plug.Cookie do
 
   defp maybe_fetch_user(:not_found, _config), do: nil
   defp maybe_fetch_user(user_id, config) do
-    Pow.Operations.get_by(config, id: user_id)
+    Pow.Operations.get_by([id: user_id], config)
   end
 
   defp maybe_renew(conn, config) do

--- a/lib/extensions/reset_password/ecto/context.ex
+++ b/lib/extensions/reset_password/ecto/context.ex
@@ -6,11 +6,11 @@ defmodule PowResetPassword.Ecto.Context do
   alias Pow.Config
   alias Pow.Ecto.Context
 
-  @spec get_by_email(Config.t(), binary()) :: map() | nil
-  def get_by_email(config, email), do: Context.get_by(config, email: email)
+  @spec get_by_email(binary(), Config.t()) :: map() | nil
+  def get_by_email(email, config), do: Context.get_by([email: email], config)
 
-  @spec update_password(Config.t(), map(), map()) :: {:ok, map()} | {:error, Changeset.t()}
-  def update_password(config, user, params) do
+  @spec update_password(map(), map(), Config.t()) :: {:ok, map()} | {:error, Changeset.t()}
+  def update_password(user, params, config) do
     user
     |> user.__struct__.pow_password_changeset(params)
     |> Changeset.validate_required([:password])

--- a/lib/extensions/reset_password/plug.ex
+++ b/lib/extensions/reset_password/plug.ex
@@ -43,9 +43,11 @@ defmodule PowResetPassword.Plug do
 
   @spec create_reset_token(Conn.t(), map()) :: {:ok, map(), Conn.t()} | {:error, map(), Conn.t()}
   def create_reset_token(conn, params) do
-    email  = Map.get(params, "email")
     config = Pow.Plug.fetch_config(conn)
-    user   = Context.get_by_email(config, email)
+    user   =
+      params
+      |> Map.get("email")
+      |> Context.get_by_email(config)
 
     maybe_create_reset_token(conn, user, config)
   end
@@ -81,12 +83,12 @@ defmodule PowResetPassword.Plug do
 
   @spec update_user_password(Conn.t(), map()) :: {:ok, map(), Conn.t()} | {:error, map(), Conn.t()}
   def update_user_password(conn, params) do
-    user   = reset_password_user(conn)
     config = Pow.Plug.fetch_config(conn)
     token  = conn.params["id"]
 
-    config
-    |> Context.update_password(user, params)
+    conn
+    |> reset_password_user()
+    |> Context.update_password(params, config)
     |> maybe_expire_token(conn, token, config)
   end
 

--- a/lib/pow/ecto/context.ex
+++ b/lib/pow/ecto/context.ex
@@ -60,23 +60,23 @@ defmodule Pow.Ecto.Context do
       def get_by(clauses), do: pow_get_by(clauses)
 
       def pow_authenticate(params) do
-        unquote(__MODULE__).authenticate(@pow_config, params)
+        unquote(__MODULE__).authenticate(params, @pow_config)
       end
 
       def pow_create(params) do
-        unquote(__MODULE__).create(@pow_config, params)
+        unquote(__MODULE__).create(params, @pow_config)
       end
 
       def pow_update(user, params) do
-        unquote(__MODULE__).update(@pow_config, user, params)
+        unquote(__MODULE__).update(user, params, @pow_config)
       end
 
       def pow_delete(user) do
-        unquote(__MODULE__).delete(@pow_config, user)
+        unquote(__MODULE__).delete(user, @pow_config)
       end
 
       def pow_get_by(clauses) do
-        unquote(__MODULE__).get_by(@pow_config, clauses)
+        unquote(__MODULE__).get_by(clauses, @pow_config)
       end
 
       defoverridable unquote(__MODULE__)
@@ -89,15 +89,15 @@ defmodule Pow.Ecto.Context do
   User schema module and repo module will be fetched from the config. The user
   id field is fetched from the user schema module.
   """
-  @spec authenticate(Config.t(), map()) :: user() | nil
-  def authenticate(config, params) do
+  @spec authenticate(map(), Config.t()) :: user() | nil
+  def authenticate(params, config) do
     user_mod      = user_schema_mod(config)
     user_id_field = user_mod.pow_user_id_field()
     login_value   = params[Atom.to_string(user_id_field)]
     password      = params["password"]
 
-    config
-    |> get_by([{user_id_field, login_value}])
+    [{user_id_field, login_value}]
+    |> get_by(config)
     |> maybe_verify_password(password)
   end
 
@@ -115,8 +115,8 @@ defmodule Pow.Ecto.Context do
 
   User schema module and repo module will be fetched from config.
   """
-  @spec create(Config.t(), map()) :: {:ok, user()} | {:error, Changeset.t()}
-  def create(config, params) do
+  @spec create(map(), Config.t()) :: {:ok, user()} | {:error, Changeset.t()}
+  def create(params, config) do
     user_mod = user_schema_mod(config)
 
     user_mod.__struct__()
@@ -130,8 +130,8 @@ defmodule Pow.Ecto.Context do
   User schema module will be fetched from provided user and repo will be
   fetched from the config.
   """
-  @spec update(Config.t(), user(), map()) :: {:ok, user()} | {:error, Changeset.t()}
-  def update(config, user, params) do
+  @spec update(user(), map(), Config.t()) :: {:ok, user()} | {:error, Changeset.t()}
+  def update(user, params, config) do
     user
     |> user.__struct__.changeset(params)
     |> do_update(config)
@@ -142,8 +142,8 @@ defmodule Pow.Ecto.Context do
 
   Repo module will be fetched from the config.
   """
-  @spec delete(Config.t(), user()) :: {:ok, user()} | {:error, Changeset.t()}
-  def delete(config, user) do
+  @spec delete(user(), Config.t()) :: {:ok, user()} | {:error, Changeset.t()}
+  def delete(user, config) do
     repo(config).delete(user)
   end
 
@@ -152,8 +152,8 @@ defmodule Pow.Ecto.Context do
 
   User schema module and repo module will be fetched from the config.
   """
-  @spec get_by(Config.t(), Keyword.t() | map()) :: user() | nil
-  def get_by(config, clauses) do
+  @spec get_by(Keyword.t() | map(), Config.t()) :: user() | nil
+  def get_by(clauses, config) do
     user_mod = user_schema_mod(config)
     clauses  = normalize_user_id_field_value(user_mod, clauses)
 

--- a/lib/pow/operations.ex
+++ b/lib/pow/operations.ex
@@ -13,12 +13,12 @@ defmodule Pow.Operations do
   It'll use the schema module fetched from the config through
   `Pow.Ecto.Context.user_schema_mod/1`.
   """
-  @spec changeset(Config.t(), map()) :: map() | nil
-  def changeset(config, params) do
+  @spec changeset(map(), Config.t()) :: map() | nil
+  def changeset(params, config) do
     user_mod = Context.user_schema_mod(config)
     user     = user_mod.__struct__()
 
-    changeset(config, user, params)
+    changeset(user, params, config)
   end
 
   @doc """
@@ -26,8 +26,8 @@ defmodule Pow.Operations do
 
   It'll call the `changeset/2` method on the user struct.
   """
-  @spec changeset(Config.t(), map(), map()) :: map()
-  def changeset(_config, user, params) do
+  @spec changeset(map(), map(), Config.t()) :: map()
+  def changeset(user, params, _config) do
     user.__struct__.changeset(user, params)
   end
 
@@ -37,10 +37,10 @@ defmodule Pow.Operations do
   This calls `Pow.Ecto.Context.authenticate/2` or `authenticate/1` on a custom
   context module.
   """
-  @spec authenticate(Config.t(), map()) :: map() | nil
-  def authenticate(config, params) do
+  @spec authenticate(map(), Config.t()) :: map() | nil
+  def authenticate(params, config) do
     case context_module(config) do
-      Context -> Context.authenticate(config, params)
+      Context -> Context.authenticate(params, config)
       module  -> module.authenticate(params)
     end
   end
@@ -51,10 +51,10 @@ defmodule Pow.Operations do
   This calls `Pow.Ecto.Context.create/2` or `create/1` on a custom context
   module.
   """
-  @spec create(Config.t(), map()) :: {:ok, map()} | {:error, map()}
-  def create(config, params) do
+  @spec create(map(), Config.t()) :: {:ok, map()} | {:error, map()}
+  def create(params, config) do
     case context_module(config) do
-      Context -> Context.create(config, params)
+      Context -> Context.create(params, config)
       module  -> module.create(params)
     end
   end
@@ -65,10 +65,10 @@ defmodule Pow.Operations do
   This calls `Pow.Ecto.Context.update/3` or `update/2` on a custom context
   module.
   """
-  @spec update(Config.t(), map(), map()) :: {:ok, map()} | {:error, map()}
-  def update(config, user, params) do
+  @spec update(map(), map(), Config.t()) :: {:ok, map()} | {:error, map()}
+  def update(user, params, config) do
     case context_module(config) do
-      Context -> Context.update(config, user, params)
+      Context -> Context.update(user, params, config)
       module  -> module.update(user, params)
     end
   end
@@ -79,10 +79,10 @@ defmodule Pow.Operations do
   This calls `Pow.Ecto.Context.delete/2` or `delete/1` on a custom context
   module.
   """
-  @spec delete(Config.t(), map()) :: {:ok, map()} | {:error, map()}
-  def delete(config, user) do
+  @spec delete(map(), Config.t()) :: {:ok, map()} | {:error, map()}
+  def delete(user, config) do
     case context_module(config) do
-      Context -> Context.delete(config, user)
+      Context -> Context.delete(user, config)
       module  -> module.delete(user)
     end
   end
@@ -93,10 +93,10 @@ defmodule Pow.Operations do
   This calls `Pow.Ecto.Context.get_by/2` or `get_by/1` on a custom context
   module.
   """
-  @spec get_by(Config.t(), Keyword.t() | map()) :: map() | nil
-  def get_by(config, clauses) do
+  @spec get_by(Keyword.t() | map(), Config.t()) :: map() | nil
+  def get_by(clauses, config) do
     case context_module(config) do
-      Context -> Context.get_by(config, clauses)
+      Context -> Context.get_by(clauses, config)
       module  -> module.get_by(clauses)
     end
   end

--- a/lib/pow/plug.ex
+++ b/lib/pow/plug.ex
@@ -63,8 +63,8 @@ defmodule Pow.Plug do
   def authenticate_user(conn, params) do
     config = fetch_config(conn)
 
-    config
-    |> Operations.authenticate(params)
+    params
+    |> Operations.authenticate(config)
     |> case do
       nil  -> {:error, conn}
       user -> {:ok, get_mod(config).do_create(conn, user)}
@@ -89,8 +89,8 @@ defmodule Pow.Plug do
     config = fetch_config(conn)
 
     case current_user(conn) do
-      nil  -> Operations.changeset(config, params)
-      user -> Operations.changeset(config, user, params)
+      nil  -> Operations.changeset(params, config)
+      user -> Operations.changeset(user, params, config)
     end
   end
 
@@ -103,8 +103,8 @@ defmodule Pow.Plug do
   def create_user(conn, params) do
     config = fetch_config(conn)
 
-    config
-    |> Operations.create(params)
+    params
+    |> Operations.create(config)
     |> maybe_create_auth(conn, config)
   end
 
@@ -115,11 +115,11 @@ defmodule Pow.Plug do
   """
   @spec update_user(Conn.t(), map()) :: {:ok, map(), Conn.t()} | {:error, map(), Conn.t()}
   def update_user(conn, params) do
-    config   = fetch_config(conn)
-    user     = current_user(conn)
+    config = fetch_config(conn)
 
-    config
-    |> Operations.update(user, params)
+    conn
+    |> current_user()
+    |> Operations.update(params, config)
     |> maybe_create_auth(conn, config)
   end
 
@@ -130,11 +130,11 @@ defmodule Pow.Plug do
   """
   @spec delete_user(Conn.t()) :: {:ok, map(), Conn.t()} | {:error, map(), Conn.t()}
   def delete_user(conn) do
-    config   = fetch_config(conn)
-    user     = current_user(conn)
+    config = fetch_config(conn)
 
-    config
-    |> Operations.delete(user)
+    conn
+    |> current_user()
+    |> Operations.delete(config)
     |> case do
       {:ok, user}         -> {:ok, user, get_mod(config).do_delete(conn)}
       {:error, changeset} -> {:error, changeset, conn}

--- a/test/extensions/email_confirmation/ecto/context_test.exs
+++ b/test/extensions/email_confirmation/ecto/context_test.exs
@@ -10,7 +10,7 @@ defmodule PowEmailConfirmation.Ecto.ContextTest do
 
   describe "confirm_email/2" do
     test "confirms with no :unconfirmed_email" do
-      assert {:ok, user} = Context.confirm_email(@config, @user)
+      assert {:ok, user} = Context.confirm_email(@user, @config)
       assert user.email_confirmed_at
       assert user.email == "test@example.com"
     end
@@ -19,20 +19,20 @@ defmodule PowEmailConfirmation.Ecto.ContextTest do
       previously_confirmed_at = DateTime.from_iso8601("2018-01-01 00:00:00")
       user                    = %{@user | email_confirmed_at: previously_confirmed_at}
 
-      assert {:ok, user} = Context.confirm_email(@config, user)
+      assert {:ok, user} = Context.confirm_email(user, @config)
       assert user.email_confirmed_at == previously_confirmed_at
     end
 
     test "changes :email to :unconfirmed_email" do
       user = %{@user | unconfirmed_email: "new@example.com"}
-      assert {:ok, user} = Context.confirm_email(@config, user)
+      assert {:ok, user} = Context.confirm_email(user, @config)
       assert user.email == "new@example.com"
       refute user.unconfirmed_email
     end
 
     test "handles unique index" do
       user = %{@user | unconfirmed_email: "taken@example.com"}
-      assert {:error, changeset} = Context.confirm_email(@config, user)
+      assert {:error, changeset} = Context.confirm_email(user, @config)
       assert changeset.errors[:email] == {"has already been taken", []}
     end
   end

--- a/test/extensions/reset_password/ecto/context_test.exs
+++ b/test/extensions/reset_password/ecto/context_test.exs
@@ -12,8 +12,8 @@ defmodule PowResetPassword.Ecto.ContextTest do
 
   describe "get_by_email/2" do
     test "email is case insensitive when it's the user id field" do
-      assert Context.get_by_email(@config, "test@example.com")
-      assert Context.get_by_email(@config, "TEST@EXAMPLE.COM")
+      assert Context.get_by_email("test@example.com", @config)
+      assert Context.get_by_email("TEST@EXAMPLE.COM", @config)
     end
   end
 
@@ -21,15 +21,15 @@ defmodule PowResetPassword.Ecto.ContextTest do
     test "updates with compiled password hash methods" do
       config = @config ++ [password_hash_methods: {&(&1 <> "123"), &(&1 == &2 <> "123")}]
 
-      assert {:ok, user} = Context.update_password(config, @user, %{password: @password, confirm_password: @password})
+      assert {:ok, user} = Context.update_password(@user, %{password: @password, confirm_password: @password}, config)
       assert Password.pbkdf2_verify(@password, user.password_hash)
     end
 
     test "requires password input" do
-      assert {:error, changeset} = Context.update_password(@config, @user, %{})
+      assert {:error, changeset} = Context.update_password(@user, %{}, @config)
       assert changeset.errors[:password] == {"can't be blank", [validation: :required]}
 
-      assert {:error, changeset} = Context.update_password(@config, @user, %{password: "", confirm_password: ""})
+      assert {:error, changeset} = Context.update_password(@user, %{password: "", confirm_password: ""}, @config)
       assert changeset.errors[:password] == {"can't be blank", [validation: :required]}
     end
   end


### PR DESCRIPTION
As suggested by @jung-hunsoo, this makes so config becomes the last argument in all methods calls.

This makes a lot more sense as can be seen in this transformation:

```elixir
# Current
email  = Map.get(params, "email")
user   = Context.get_by_email(config, email)

# New
params
|> Map.get("email")
|> Context.get_by_email(config)
```