### PR TITLE
Rename plug module

### DIFF
--- a/guides/COHERENCE_MIGRATION.md
+++ b/guides/COHERENCE_MIGRATION.md
@@ -158,7 +158,7 @@ Set up `routes.ex`
   ```
 
 Change `Routes.session_path` to `Routes.pow_session_path`, and
-`Routes.registration_path` to `Routes.pow_registration_path`. Any references to `Coherence.current_user/1`, can be changed to `Pow.Plug.current_user/1`.
+`Routes.registration_path` to `Routes.pow_registration_path`. Any references to `Coherence.current_user/1`, can be changed to `Pow.Plug.Helpers.current_user/1`.
 
 That's it! You can now test out your Pow'ered app, and then remove all unused fields/tables after.
 

--- a/lib/extensions/email_confirmation/phoenix/controllers/confirmation_controller.ex
+++ b/lib/extensions/email_confirmation/phoenix/controllers/confirmation_controller.ex
@@ -7,7 +7,7 @@ defmodule PowEmailConfirmation.Phoenix.ConfirmationController do
   alias PowEmailConfirmation.Plug
 
   @spec process_show(Conn.t(), map()) :: {:ok | :error, map(), Conn.t()}
-  def process_show(conn, %{"id" => token}), do: Plug.confirm_email(conn, token)
+  def process_show(conn, %{"id" => token}), do: Plug.Helpers.confirm_email(conn, token)
 
   @spec respond_show({:ok | :error, map(), Conn.t()}) :: Conn.t()
   def respond_show({:ok, _user, conn}) do
@@ -22,7 +22,7 @@ defmodule PowEmailConfirmation.Phoenix.ConfirmationController do
   end
 
   defp redirect_to(conn) do
-    case Pow.Plug.current_user(conn) do
+    case Pow.Plug.Helpers.current_user(conn) do
       nil   -> router_helpers(conn).pow_session_path(conn, :new)
       _user -> router_helpers(conn).pow_registration_path(conn, :edit)
     end

--- a/lib/extensions/email_confirmation/phoenix/controllers/controller_callbacks.ex
+++ b/lib/extensions/email_confirmation/phoenix/controllers/controller_callbacks.ex
@@ -7,14 +7,14 @@ defmodule PowEmailConfirmation.Phoenix.ControllerCallbacks do
   alias PowEmailConfirmation.Phoenix.{ConfirmationController, Mailer}
 
   def before_process(Pow.Phoenix.RegistrationController, :update, conn, _config) do
-    user = Plug.current_user(conn)
+    user = Plug.Helpers.current_user(conn)
 
     Conn.put_private(conn, :pow_user_before_update, user)
   end
 
   def before_respond(Pow.Phoenix.SessionController, :create, {:ok, conn}, _config) do
     conn
-    |> Plug.current_user()
+    |> Plug.Helpers.current_user()
     |> halt_unconfirmed(conn, {:ok, conn})
   end
   def before_respond(Pow.Phoenix.RegistrationController, :create, {:ok, user, conn}, _config) do
@@ -38,7 +38,7 @@ defmodule PowEmailConfirmation.Phoenix.ControllerCallbacks do
   defp halt_unconfirmed(%{email_confirmed_at: nil, email_confirmation_token: token} = user, conn, _success_response) when not is_nil(token) do
     send_confirmation_email(user, conn)
 
-    {:ok, conn} = Plug.clear_authenticated_user(conn)
+    {:ok, conn} = Plug.Helpers.clear_authenticated_user(conn)
     error       = ConfirmationController.messages(conn).email_confirmation_required(conn)
     path        = Controller.router_helpers(conn).pow_session_path(conn, :new)
     conn        =

--- a/lib/extensions/email_confirmation/plug/helpers.ex
+++ b/lib/extensions/email_confirmation/plug/helpers.ex
@@ -1,4 +1,4 @@
-defmodule PowEmailConfirmation.Plug do
+defmodule PowEmailConfirmation.Plug.Helpers do
   @moduledoc """
   Plug helper methods.
   """
@@ -13,7 +13,7 @@ defmodule PowEmailConfirmation.Plug do
   """
   @spec confirm_email(Conn.t(), binary()) :: {:ok, map(), Conn.t()} | {:error, map(), Conn.t()}
   def confirm_email(conn, token) do
-    config = Plug.fetch_config(conn)
+    config = Plug.Helpers.fetch_config(conn)
 
     token
     |> Context.get_by_confirmation_token(config)
@@ -35,7 +35,7 @@ defmodule PowEmailConfirmation.Plug do
   defp maybe_renew_conn(conn, %{id: user_id} = user, config) do
     mod = config[:mod]
 
-    case Plug.current_user(conn) do
+    case Plug.Helpers.current_user(conn) do
       %{id: ^user_id} -> mod.do_create(conn, user)
       _any            -> conn
     end

--- a/lib/extensions/persistent_session/phoenix/controllers/controller_callbacks.ex
+++ b/lib/extensions/persistent_session/phoenix/controllers/controller_callbacks.ex
@@ -12,15 +12,15 @@ defmodule PowPersistentSession.Phoenix.ControllerCallbacks do
   end
 
   def before_respond(Pow.Phoenix.SessionController, :create, {:ok, conn}, _config) do
-    user = Pow.Plug.current_user(conn)
+    user = Pow.Plug.Helpers.current_user(conn)
 
     case conn.private[:store_persistent_session?] do
-      "true" -> {:ok, Plug.create(conn, user)}
+      "true" -> {:ok, Plug.Helpers.create(conn, user)}
       _any   -> {:ok, conn}
     end
   end
 
   def before_respond(Pow.Phoenix.SessionController, :delete, {:ok, conn}, _config) do
-    {:ok, Plug.delete(conn)}
+    {:ok, Plug.Helpers.delete(conn)}
   end
 end

--- a/lib/extensions/persistent_session/plug/base.ex
+++ b/lib/extensions/persistent_session/plug/base.ex
@@ -35,7 +35,7 @@ defmodule PowPersistentSession.Plug.Base do
       def call(conn, config) do
         config =
           conn
-          |> Plug.fetch_config()
+          |> Plug.Helpers.fetch_config()
           |> Config.merge(config)
 
         conn

--- a/lib/extensions/persistent_session/plug/cookie.ex
+++ b/lib/extensions/persistent_session/plug/cookie.ex
@@ -97,7 +97,7 @@ defmodule PowPersistentSession.Plug.Cookie do
   """
   @spec authenticate(Conn.t(), Config.t()) :: Conn.t()
   def authenticate(conn, config) do
-    user = Plug.current_user(conn)
+    user = Plug.Helpers.current_user(conn)
 
     conn
     |> Conn.fetch_cookies()

--- a/lib/extensions/persistent_session/plug/helpers.ex
+++ b/lib/extensions/persistent_session/plug/helpers.ex
@@ -1,4 +1,4 @@
-defmodule PowPersistentSession.Plug do
+defmodule PowPersistentSession.Plug.Helpers do
   @moduledoc """
   Plug helper methods.
   """

--- a/lib/extensions/reset_password/phoenix/controllers/reset_password_controller.ex
+++ b/lib/extensions/reset_password/phoenix/controllers/reset_password_controller.ex
@@ -13,7 +13,7 @@ defmodule PowResetPassword.Phoenix.ResetPasswordController do
 
   @spec process_new(Conn.t(), map()) :: {:ok, map(), Conn.t()}
   def process_new(conn, _params) do
-    {:ok, Plug.change_user(conn), conn}
+    {:ok, Plug.Helpers.change_user(conn), conn}
   end
 
   @spec respond_new({:ok, map(), Conn.t()}) :: Conn.t()
@@ -25,7 +25,7 @@ defmodule PowResetPassword.Phoenix.ResetPasswordController do
 
   @spec process_create(Conn.t(), map()) :: {:ok | :error, map(), Conn.t()}
   def process_create(conn, %{"user" => user_params}) do
-    Plug.create_reset_token(conn, user_params)
+    Plug.Helpers.create_reset_token(conn, user_params)
   end
 
   @spec respond_create({:ok | :error, map(), Conn.t()}) :: Conn.t()
@@ -45,7 +45,7 @@ defmodule PowResetPassword.Phoenix.ResetPasswordController do
 
   @spec process_edit(Conn.t(), map()) :: {:ok, map(), Conn.t()}
   def process_edit(conn, _params) do
-    {:ok, Plug.change_user(conn), conn}
+    {:ok, Plug.Helpers.change_user(conn), conn}
   end
 
   @spec respond_edit({:ok, map(), Conn.t()}) :: Conn.t()
@@ -57,7 +57,7 @@ defmodule PowResetPassword.Phoenix.ResetPasswordController do
 
   @spec process_update(Conn.t(), map()) :: {:ok | :error, map(), Conn.t()}
   def process_update(conn, %{"user" => user_params}) do
-    Plug.update_user_password(conn, user_params)
+    Plug.Helpers.update_user_password(conn, user_params)
   end
 
   @spec respond_update({:ok, map(), Conn.t()}) :: Conn.t()
@@ -73,7 +73,7 @@ defmodule PowResetPassword.Phoenix.ResetPasswordController do
   end
 
   defp load_user_from_reset_token(%{params: %{"id" => token}} = conn, _opts) do
-    case Plug.user_from_token(conn, token) do
+    case Plug.Helpers.user_from_token(conn, token) do
       nil ->
         conn
         |> put_flash(:error, messages(conn).invalid_token(conn))
@@ -81,7 +81,7 @@ defmodule PowResetPassword.Phoenix.ResetPasswordController do
         |> halt()
 
       user ->
-        Plug.assign_reset_password_user(conn, user)
+        Plug.Helpers.assign_reset_password_user(conn, user)
     end
   end
 

--- a/lib/extensions/reset_password/plug/helpers.ex
+++ b/lib/extensions/reset_password/plug/helpers.ex
@@ -1,4 +1,4 @@
-defmodule PowResetPassword.Plug do
+defmodule PowResetPassword.Plug.Helpers do
   @moduledoc """
   Plug helper methods.
   """
@@ -17,7 +17,7 @@ defmodule PowResetPassword.Plug do
       |> case do
         nil ->
           conn
-          |> Pow.Plug.fetch_config()
+          |> Pow.Plug.Helpers.fetch_config()
           |> Context.user_schema_mod()
           |> struct()
 
@@ -58,7 +58,7 @@ defmodule PowResetPassword.Plug do
   """
   @spec create_reset_token(Conn.t(), map()) :: {:ok, map(), Conn.t()} | {:error, map(), Conn.t()}
   def create_reset_token(conn, params) do
-    config = Pow.Plug.fetch_config(conn)
+    config = Pow.Plug.Helpers.fetch_config(conn)
     user   =
       params
       |> Map.get("email")
@@ -88,7 +88,7 @@ defmodule PowResetPassword.Plug do
   def user_from_token(conn, token) do
     {store, store_config} =
       conn
-      |> Pow.Plug.fetch_config()
+      |> Pow.Plug.Helpers.fetch_config()
       |> store()
 
     store_config
@@ -104,7 +104,7 @@ defmodule PowResetPassword.Plug do
   """
   @spec update_user_password(Conn.t(), map()) :: {:ok, map(), Conn.t()} | {:error, map(), Conn.t()}
   def update_user_password(conn, params) do
-    config = Pow.Plug.fetch_config(conn)
+    config = Pow.Plug.Helpers.fetch_config(conn)
     token  = conn.params["id"]
 
     conn

--- a/lib/pow/phoenix/controllers/controller.ex
+++ b/lib/pow/phoenix/controllers/controller.ex
@@ -79,7 +79,7 @@ defmodule Pow.Phoenix.Controller do
   @spec action(atom(), Conn.t(), map()) :: Conn.t()
   def action(controller, %{private: private} = conn, params) do
     action    = private.phoenix_action
-    config    = Plug.fetch_config(conn)
+    config    = Plug.Helpers.fetch_config(conn)
     callbacks = Config.get(config, :controller_callbacks)
 
     conn
@@ -109,7 +109,7 @@ defmodule Pow.Phoenix.Controller do
   @spec messages(Conn.t(), atom()) :: atom()
   def messages(conn, fallback) do
     conn
-    |> Plug.fetch_config()
+    |> Plug.Helpers.fetch_config()
     |> Config.get(:messages_backend, fallback)
   end
 
@@ -119,7 +119,7 @@ defmodule Pow.Phoenix.Controller do
   @spec routes(Conn.t(), atom()) :: atom()
   def routes(conn, fallback) do
     conn
-    |> Plug.fetch_config()
+    |> Plug.Helpers.fetch_config()
     |> Config.get(:routes_backend, fallback)
   end
 

--- a/lib/pow/phoenix/controllers/registration_controller.ex
+++ b/lib/pow/phoenix/controllers/registration_controller.ex
@@ -12,7 +12,7 @@ defmodule Pow.Phoenix.RegistrationController do
 
   @spec process_new(Conn.t(), map()) :: {:ok, map(), Conn.t()}
   def process_new(conn, _params) do
-    {:ok, Plug.change_user(conn), conn}
+    {:ok, Plug.Helpers.change_user(conn), conn}
   end
 
   @spec respond_new({:ok, map(), Conn.t()}) :: Conn.t()
@@ -24,7 +24,7 @@ defmodule Pow.Phoenix.RegistrationController do
 
   @spec process_create(Conn.t(), map()) :: {:ok | :error, map(), Conn.t()}
   def process_create(conn, %{"user" => user_params}) do
-    Plug.create_user(conn, user_params)
+    Plug.Helpers.create_user(conn, user_params)
   end
 
   @spec respond_create({:ok | :error, map(), Conn.t()}) :: Conn.t()
@@ -41,7 +41,7 @@ defmodule Pow.Phoenix.RegistrationController do
 
   @spec process_edit(Conn.t(), map()) :: {:ok, map(), Conn.t()}
   def process_edit(conn, _params) do
-    {:ok, Plug.change_user(conn), conn}
+    {:ok, Plug.Helpers.change_user(conn), conn}
   end
 
   @spec respond_edit({:ok, map(), Conn.t()}) :: Conn.t()
@@ -53,7 +53,7 @@ defmodule Pow.Phoenix.RegistrationController do
 
   @spec process_update(Conn.t(), map()) :: {:ok | :error, map(), Conn.t()}
   def process_update(conn, %{"user" => user_params}) do
-    Plug.update_user(conn, user_params)
+    Plug.Helpers.update_user(conn, user_params)
   end
 
   @spec respond_update({:ok, map(), Conn.t()}) :: Conn.t()
@@ -70,7 +70,7 @@ defmodule Pow.Phoenix.RegistrationController do
 
   @spec process_delete(Conn.t(), map()) :: {:ok | :error, map(), Conn.t()}
   def process_delete(conn, _params) do
-    Plug.delete_user(conn)
+    Plug.Helpers.delete_user(conn)
   end
 
   @spec respond_delete({:ok | :error, map(), Conn.t()}) :: Conn.t()

--- a/lib/pow/phoenix/controllers/session_controller.ex
+++ b/lib/pow/phoenix/controllers/session_controller.ex
@@ -18,7 +18,7 @@ defmodule Pow.Phoenix.SessionController do
   @doc false
   @spec process_new(Conn.t(), map()) :: {:ok, map(), Conn.t()}
   def process_new(conn, _params) do
-    {:ok, Plug.change_user(conn), conn}
+    {:ok, Plug.Helpers.change_user(conn), conn}
   end
 
   @doc false
@@ -32,7 +32,7 @@ defmodule Pow.Phoenix.SessionController do
   @doc false
   @spec process_create(Conn.t(), map()) :: {:ok | :error, Conn.t()}
   def process_create(conn, %{"user" => user_params}) do
-    Plug.authenticate_user(conn, user_params)
+    Plug.Helpers.authenticate_user(conn, user_params)
   end
 
   @doc false
@@ -44,14 +44,14 @@ defmodule Pow.Phoenix.SessionController do
   end
   def respond_create({:error, conn}) do
     conn
-    |> assign(:changeset, Plug.change_user(conn, conn.params["user"]))
+    |> assign(:changeset, Plug.Helpers.change_user(conn, conn.params["user"]))
     |> put_flash(:error, messages(conn).invalid_credentials(conn))
     |> render("new.html")
   end
 
   @doc false
   @spec process_delete(Conn.t(), map()) :: {:ok, Conn.t()}
-  def process_delete(conn, _params), do: Plug.clear_authenticated_user(conn)
+  def process_delete(conn, _params), do: Plug.Helpers.clear_authenticated_user(conn)
 
   @doc false
   @spec respond_delete({:ok, Conn.t()}) :: Conn.t()

--- a/lib/pow/phoenix/mailer.ex
+++ b/lib/pow/phoenix/mailer.ex
@@ -40,7 +40,7 @@ defmodule Pow.Phoenix.Mailer do
 
   @spec deliver(Conn.t(), Mail.t()) :: any()
   def deliver(conn, email) do
-    config = Pow.Plug.fetch_config(conn)
+    config = Pow.Plug.Helpers.fetch_config(conn)
     mailer = Pow.Config.get(config, :mailer_backend) || raise_no_mailer_backend_set()
 
     email

--- a/lib/pow/phoenix/mailer/mail.ex
+++ b/lib/pow/phoenix/mailer/mail.ex
@@ -19,7 +19,7 @@ defmodule Pow.Phoenix.Mailer.Mail do
   def new(conn, user, {view_module, template}, assigns) do
     web_module =
       conn
-      |> Plug.fetch_config()
+      |> Plug.Helpers.fetch_config()
       |> Config.get(:web_mailer_module)
 
     view_module = Pow.Phoenix.ViewHelpers.build_view_module(view_module, web_module)

--- a/lib/pow/phoenix/views/view_helpers.ex
+++ b/lib/pow/phoenix/views/view_helpers.ex
@@ -50,7 +50,7 @@ defmodule Pow.Phoenix.ViewHelpers do
     base            = base_module(endpoint_module)
     web_module      =
       conn
-      |> Plug.fetch_config()
+      |> Plug.Helpers.fetch_config()
       |> Config.get(:web_module)
 
     view   = build_view_module(view_module, web_module)

--- a/lib/pow/plug.ex
+++ b/lib/pow/plug.ex
@@ -1,0 +1,35 @@
+defmodule Pow.Plug do
+  @moduledoc false
+
+  @deprecation_msg "Pow.Plug will be removed in the next version, please use Pow.Plug.Helpers instead."
+
+  @deprecated @deprecation_msg
+  defdelegate current_user(conn), to: Pow.Plug.Helpers
+
+  @deprecated @deprecation_msg
+  defdelegate assign_current_user(conn, user, config), to: Pow.Plug.Helpers
+
+  @deprecated @deprecation_msg
+  defdelegate put_config(conn, config), to: Pow.Plug.Helpers
+
+  @deprecated @deprecation_msg
+  defdelegate fetch_config(conn), to: Pow.Plug.Helpers
+
+  @deprecated @deprecation_msg
+  defdelegate authenticate_user(conn, params), to: Pow.Plug.Helpers
+
+  @deprecated @deprecation_msg
+  defdelegate clear_authenticated_user(conn), to: Pow.Plug.Helpers
+
+  @deprecated @deprecation_msg
+  defdelegate change_user(conn, params), to: Pow.Plug.Helpers
+
+  @deprecated @deprecation_msg
+  defdelegate create_user(conn, params), to: Pow.Plug.Helpers
+
+  @deprecated @deprecation_msg
+  defdelegate update_user(conn, params), to: Pow.Plug.Helpers
+
+  @deprecated @deprecation_msg
+  defdelegate delete_user(conn), to: Pow.Plug.Helpers
+end

--- a/lib/pow/plug/base.ex
+++ b/lib/pow/plug/base.ex
@@ -27,7 +27,7 @@ defmodule Pow.Plug.Base do
       end
   """
   alias Plug.Conn
-  alias Pow.{Config, Plug}
+  alias Pow.{Config, Plug.Helpers}
 
   @callback init(Config.t()) :: Config.t()
   @callback call(Conn.t(), Config.t()) :: Conn.t()
@@ -54,11 +54,11 @@ defmodule Pow.Plug.Base do
       connection.
       """
       def call(conn, config) do
-        config = Pow.Config.put(config, :mod, __MODULE__)
-        conn   = Pow.Plug.put_config(conn, config)
+        config = Config.put(config, :mod, __MODULE__)
+        conn   = Helpers.put_config(conn, config)
 
         conn
-        |> Pow.Plug.current_user()
+        |> Helpers.current_user()
         |> maybe_fetch_user(conn)
       end
 
@@ -101,11 +101,11 @@ defmodule Pow.Plug.Base do
       defp maybe_fetch_user(nil, conn), do: do_fetch(conn)
       defp maybe_fetch_user(_user, conn), do: conn
 
-      defp fetch_config(conn), do: Plug.fetch_config(conn)
+      defp fetch_config(conn), do: Helpers.fetch_config(conn)
 
-      defp assign_current_user({conn, user}, config), do: Plug.assign_current_user(conn, user, config)
+      defp assign_current_user({conn, user}, config), do: Helpers.assign_current_user(conn, user, config)
 
-      defp remove_current_user(conn, config), do: Plug.assign_current_user(conn, nil, config)
+      defp remove_current_user(conn, config), do: Helpers.assign_current_user(conn, nil, config)
 
       defoverridable Base
     end

--- a/lib/pow/plug/helpers.ex
+++ b/lib/pow/plug/helpers.ex
@@ -1,4 +1,4 @@
-defmodule Pow.Plug do
+defmodule Pow.Plug.Helpers do
   @moduledoc """
   Plug helper methods.
   """

--- a/lib/pow/plug/require_authenticated.ex
+++ b/lib/pow/plug/require_authenticated.ex
@@ -23,7 +23,7 @@ defmodule Pow.Plug.RequireAuthenticated do
   @spec call(Conn.t(), atom()) :: Conn.t()
   def call(conn, handler) do
     conn
-    |> Plug.current_user()
+    |> Plug.Helpers.current_user()
     |> maybe_halt(conn, handler)
   end
 

--- a/lib/pow/plug/require_not_authenticated.ex
+++ b/lib/pow/plug/require_not_authenticated.ex
@@ -23,7 +23,7 @@ defmodule Pow.Plug.RequireNotAuthenticated do
   @spec call(Conn.t(), atom()) :: Conn.t()
   def call(conn, handler) do
     conn
-    |> Plug.current_user()
+    |> Plug.Helpers.current_user()
     |> maybe_halt(conn, handler)
   end
 

--- a/test/extensions/email_confirmation/phoenix/controllers/confirmation_controller_test.exs
+++ b/test/extensions/email_confirmation/phoenix/controllers/confirmation_controller_test.exs
@@ -14,7 +14,7 @@ defmodule PowEmailConfirmation.Phoenix.ConfirmationControllerTest do
       assert user.email == "test@example.com"
       assert user.email_confirmed_at
       refute user.unconfirmed_email
-      refute Pow.Plug.current_user(conn)
+      refute Pow.Plug.Helpers.current_user(conn)
     end
 
     test "confirms with valid token and :unconfirmed_email", %{conn: conn} do
@@ -41,11 +41,11 @@ defmodule PowEmailConfirmation.Phoenix.ConfirmationControllerTest do
       session_id = conn.private[:plug_session][@session_key]
       conn       =
         conn
-        |> Pow.Plug.assign_current_user(%{id: 1}, [])
+        |> Pow.Plug.Helpers.assign_current_user(%{id: 1}, [])
         |> get(Routes.pow_email_confirmation_confirmation_path(conn, :show, "valid"))
 
       assert redirected_to(conn) == Routes.pow_registration_path(conn, :edit)
-      assert Pow.Plug.current_user(conn)
+      assert Pow.Plug.Helpers.current_user(conn)
       refute conn.private[:plug_session][@session_key] == session_id
     end
 
@@ -53,11 +53,11 @@ defmodule PowEmailConfirmation.Phoenix.ConfirmationControllerTest do
       session_id = conn.private[:plug_session][@session_key]
       conn       =
         conn
-        |> Pow.Plug.assign_current_user(%{id: 2}, [])
+        |> Pow.Plug.Helpers.assign_current_user(%{id: 2}, [])
         |> get(Routes.pow_email_confirmation_confirmation_path(conn, :show, "valid"))
 
       assert redirected_to(conn) == Routes.pow_registration_path(conn, :edit)
-      assert Pow.Plug.current_user(conn)
+      assert Pow.Plug.Helpers.current_user(conn)
       assert conn.private[:plug_session][@session_key] == session_id
     end
   end

--- a/test/extensions/email_confirmation/phoenix/controllers/controller_callbacks_test.exs
+++ b/test/extensions/email_confirmation/phoenix/controllers/controller_callbacks_test.exs
@@ -15,7 +15,7 @@ defmodule PowEmailConfirmation.Phoenix.ControllerCallbacksTest do
       assert get_flash(conn, :error) == "You'll need to confirm your e-mail before you can sign in. An e-mail confirmation link has been sent to you."
       assert redirected_to(conn) == Routes.pow_session_path(conn, :new)
 
-      refute Plug.current_user(conn)
+      refute Plug.Helpers.current_user(conn)
 
       assert_received {:mail_mock, mail}
       assert token = mail.user.email_confirmation_token
@@ -40,7 +40,7 @@ defmodule PowEmailConfirmation.Phoenix.ControllerCallbacksTest do
       assert get_flash(conn, :error) == "You'll need to confirm your e-mail before you can sign in. An e-mail confirmation link has been sent to you."
       assert redirected_to(conn) == Routes.pow_session_path(conn, :new)
 
-      refute Plug.current_user(conn)
+      refute Plug.Helpers.current_user(conn)
 
       assert_received {:mail_mock, mail}
       assert token = mail.user.email_confirmation_token
@@ -57,14 +57,14 @@ defmodule PowEmailConfirmation.Phoenix.ControllerCallbacksTest do
 
     setup %{conn: conn} do
       user = Ecto.put_meta(@user, state: :loaded)
-      conn = Plug.assign_current_user(conn, user, [])
+      conn = Plug.Helpers.assign_current_user(conn, user, [])
 
       {:ok, conn: conn}
     end
 
     test "when email changes", %{conn: conn} do
       conn = put conn, Routes.pow_registration_path(conn, :update, @change_email_params)
-      assert %{id: 1, email_confirmation_token: new_token} = Plug.current_user(conn)
+      assert %{id: 1, email_confirmation_token: new_token} = Plug.Helpers.current_user(conn)
 
       assert get_flash(conn, :info) == "Your account has been updated."
       assert new_token != @token
@@ -79,7 +79,7 @@ defmodule PowEmailConfirmation.Phoenix.ControllerCallbacksTest do
       conn = put conn, Routes.pow_registration_path(conn, :update, @params)
 
       assert get_flash(conn, :info) == "Your account has been updated."
-      assert %{id: 1, email_confirmation_token: @token} = Plug.current_user(conn)
+      assert %{id: 1, email_confirmation_token: @token} = Plug.Helpers.current_user(conn)
 
       refute_received {:mail_mock, _mail}
     end

--- a/test/extensions/persistent_session/plug/cookie_test.exs
+++ b/test/extensions/persistent_session/plug/cookie_test.exs
@@ -50,7 +50,7 @@ defmodule PowPersistentSession.Plug.CookieTest do
       |> store_persistent(ets, id, user)
       |> Cookie.call(Cookie.init([]))
 
-    assert Plug.current_user(conn) == user
+    assert Plug.Helpers.current_user(conn) == user
     assert %{value: new_id, max_age: @max_age, path: "/"} = conn.resp_cookies["persistent_session_cookie"]
     refute new_id == id
     assert PersistentSessionCache.get([backend: ets], id) == :not_found
@@ -69,7 +69,7 @@ defmodule PowPersistentSession.Plug.CookieTest do
       |> store_persistent(ets, id, user, "test_app_persistent_session_cookie")
       |> Cookie.call(Cookie.init(config))
 
-    assert Plug.current_user(conn) == user
+    assert Plug.Helpers.current_user(conn) == user
     assert %{value: new_id, max_age: @max_age, path: "/"} = conn.resp_cookies["test_app_persistent_session_cookie"]
     assert String.starts_with?(new_id, "test_app")
     assert PersistentSessionCache.get([backend: ets], new_id) == 1
@@ -81,7 +81,7 @@ defmodule PowPersistentSession.Plug.CookieTest do
     conn =
       conn
       |> store_persistent(ets, id, user)
-      |> Plug.assign_current_user(:user, [])
+      |> Plug.Helpers.assign_current_user(:user, [])
       |> Cookie.call(Cookie.init([]))
 
     assert %{value: new_id, max_age: @max_age, path: "/"} = conn.resp_cookies["persistent_session_cookie"]
@@ -97,7 +97,7 @@ defmodule PowPersistentSession.Plug.CookieTest do
       |> store_persistent(ets, id, user)
       |> Cookie.call(Cookie.init([]))
 
-    refute Plug.current_user(conn)
+    refute Plug.Helpers.current_user(conn)
     assert conn.resp_cookies["persistent_session_cookie"] == %{max_age: -1, path: "/", value: ""}
     assert PersistentSessionCache.get([backend: ets], id) == :not_found
   end
@@ -108,7 +108,7 @@ defmodule PowPersistentSession.Plug.CookieTest do
       |> persistent_cookie("persistent_session_cookie", "test")
       |> Cookie.call(Cookie.init([]))
 
-    refute Plug.current_user(conn)
+    refute Plug.Helpers.current_user(conn)
     assert conn.resp_cookies["persistent_session_cookie"] == %{max_age: -1, path: "/", value: ""}
   end
 end

--- a/test/extensions/reset_password/phoenix/controllers/reset_password_controller_test.exs
+++ b/test/extensions/reset_password/phoenix/controllers/reset_password_controller_test.exs
@@ -19,7 +19,7 @@ defmodule PowResetPassword.Phoenix.ResetPasswordControllerTest do
     test "already signed in", %{conn: conn} do
       conn =
         conn
-        |> Pow.Plug.assign_current_user(@user, [])
+        |> Pow.Plug.Helpers.assign_current_user(@user, [])
         |> get(Routes.pow_reset_password_reset_password_path(conn, :new))
 
       assert_authenticated_redirect(conn)
@@ -33,7 +33,7 @@ defmodule PowResetPassword.Phoenix.ResetPasswordControllerTest do
     test "already signed in", %{conn: conn} do
       conn =
         conn
-        |> Pow.Plug.assign_current_user(@user, [])
+        |> Pow.Plug.Helpers.assign_current_user(@user, [])
         |> get(Routes.pow_reset_password_reset_password_path(conn, :new))
 
       assert_authenticated_redirect(conn)
@@ -73,7 +73,7 @@ defmodule PowResetPassword.Phoenix.ResetPasswordControllerTest do
     test "already signed in", %{conn: conn} do
       conn =
         conn
-        |> Pow.Plug.assign_current_user(@user, [])
+        |> Pow.Plug.Helpers.assign_current_user(@user, [])
         |> get(Routes.pow_reset_password_reset_password_path(conn, :edit, @valid_token))
 
       assert_authenticated_redirect(conn)
@@ -113,7 +113,7 @@ defmodule PowResetPassword.Phoenix.ResetPasswordControllerTest do
     test "already signed in", %{conn: conn} do
       conn =
         conn
-        |> Pow.Plug.assign_current_user(@user, [])
+        |> Pow.Plug.Helpers.assign_current_user(@user, [])
         |> put(Routes.pow_reset_password_reset_password_path(conn, :update, @valid_token, @valid_params))
 
       assert_authenticated_redirect(conn)

--- a/test/pow/phoenix/controllers/registration_controller_test.exs
+++ b/test/pow/phoenix/controllers/registration_controller_test.exs
@@ -19,7 +19,7 @@ defmodule Pow.Phoenix.RegistrationControllerTest do
     test "already signed in", %{conn: conn} do
       conn =
         conn
-        |> Plug.assign_current_user(%{id: 1}, [])
+        |> Plug.Helpers.assign_current_user(%{id: 1}, [])
         |> get(Routes.pow_registration_path(conn, :new))
 
       assert_authenticated_redirect(conn)
@@ -33,7 +33,7 @@ defmodule Pow.Phoenix.RegistrationControllerTest do
     test "already signed in", %{conn: conn} do
       conn =
         conn
-        |> Plug.assign_current_user(%{id: 1}, [])
+        |> Plug.Helpers.assign_current_user(%{id: 1}, [])
         |> post(Routes.pow_registration_path(conn, :create, @valid_params))
 
       assert_authenticated_redirect(conn)
@@ -43,7 +43,7 @@ defmodule Pow.Phoenix.RegistrationControllerTest do
       conn = post conn, Routes.pow_registration_path(conn, :create, @valid_params)
       assert redirected_to(conn) == "/"
       assert get_flash(conn, :info) == "user_created"
-      assert %{id: 1} = Plug.current_user(conn)
+      assert %{id: 1} = Plug.Helpers.current_user(conn)
       assert conn.private[:plug_session]["auth"]
     end
 
@@ -56,7 +56,7 @@ defmodule Pow.Phoenix.RegistrationControllerTest do
       assert html =~ "<span class=\"help-block\">should be at least 10 character(s)</span>"
       assert errors = conn.assigns[:changeset].errors
       assert errors[:password]
-      refute Plug.current_user(conn)
+      refute Plug.Helpers.current_user(conn)
       refute conn.private[:plug_session]["auth"]
     end
   end
@@ -100,7 +100,7 @@ defmodule Pow.Phoenix.RegistrationControllerTest do
 
       assert redirected_to(conn) == Routes.pow_registration_path(conn, :edit)
       assert get_flash(conn, :info) == "Your account has been updated."
-      assert user = Plug.current_user(conn)
+      assert user = Plug.Helpers.current_user(conn)
       assert user.id == :updated
       assert conn.private[:plug_session]["auth"] != session_id
     end
@@ -119,7 +119,7 @@ defmodule Pow.Phoenix.RegistrationControllerTest do
       assert html =~ "<span class=\"help-block\">can&#39;t be blank</span>"
       assert errors = conn.assigns[:changeset].errors
       assert errors[:current_password]
-      assert %{id: 1} = Plug.current_user(conn)
+      assert %{id: 1} = Plug.Helpers.current_user(conn)
       assert conn.private[:plug_session]["auth"] == session_id
     end
   end
@@ -139,25 +139,25 @@ defmodule Pow.Phoenix.RegistrationControllerTest do
 
       assert redirected_to(conn) == Routes.pow_session_path(conn, :new)
       assert get_flash(conn, :info) == "Your account has been deleted. Sorry to see you go!"
-      refute Plug.current_user(conn)
+      refute Plug.Helpers.current_user(conn)
       refute conn.private[:plug_session]["auth"]
     end
 
     test "when fails", %{conn: conn} do
       conn =
         conn
-        |> Plug.assign_current_user(:fail_deletion, [])
+        |> Plug.Helpers.assign_current_user(:fail_deletion, [])
         |> delete(Routes.pow_registration_path(conn, :delete))
 
       assert redirected_to(conn) == Routes.pow_registration_path(conn, :edit)
       assert get_flash(conn, :error) == "Your account could not be deleted."
-      assert Plug.current_user(conn) == :fail_deletion
+      assert Plug.Helpers.current_user(conn) == :fail_deletion
     end
   end
 
   defp create_user_and_sign_in(conn) do
     conn = post conn, Routes.pow_registration_path(conn, :create, @valid_params)
-    assert %{id: 1} = Plug.current_user(conn)
+    assert %{id: 1} = Plug.Helpers.current_user(conn)
     assert conn.private[:plug_session]["auth"]
     :timer.sleep(10)
 

--- a/test/pow/phoenix/controllers/session_controller_test.exs
+++ b/test/pow/phoenix/controllers/session_controller_test.exs
@@ -6,7 +6,7 @@ defmodule Pow.Phoenix.SessionControllerTest do
     test "already signed in", %{conn: conn} do
       conn =
         conn
-        |> Plug.assign_current_user(%{id: 1}, [])
+        |> Plug.Helpers.assign_current_user(%{id: 1}, [])
         |> get(Routes.pow_session_path(conn, :new))
 
       assert_authenticated_redirect(conn)
@@ -39,7 +39,7 @@ defmodule Pow.Phoenix.SessionControllerTest do
     test "already signed in", %{conn: conn} do
       conn =
         conn
-        |> Plug.assign_current_user(%{id: 1}, [])
+        |> Plug.Helpers.assign_current_user(%{id: 1}, [])
         |> post(Routes.pow_session_path(conn, :create, @valid_params))
 
       assert_authenticated_redirect(conn)
@@ -49,7 +49,7 @@ defmodule Pow.Phoenix.SessionControllerTest do
       conn = post conn, Routes.pow_session_path(conn, :create, @valid_params)
       assert redirected_to(conn) == "/"
       assert get_flash(conn, :info) == "signed_in"
-      assert %{id: 1} = Plug.current_user(conn)
+      assert %{id: 1} = Plug.Helpers.current_user(conn)
       assert conn.private[:plug_session]["auth"]
     end
 
@@ -59,7 +59,7 @@ defmodule Pow.Phoenix.SessionControllerTest do
       assert get_flash(conn, :error) == "The provided login details did not work. Please verify your credentials, and try again."
       assert html =~ "<input class=\"form-control\" id=\"user_email\" name=\"user[email]\" type=\"text\" value=\"test@example.com\">"
       assert html =~ "<input class=\"form-control\" id=\"user_password\" name=\"user[password]\" type=\"password\">"
-      refute Plug.current_user(conn)
+      refute Plug.Helpers.current_user(conn)
       refute conn.private[:plug_session]["auth"]
       refute html =~ "request_path"
     end
@@ -68,7 +68,7 @@ defmodule Pow.Phoenix.SessionControllerTest do
       conn = post conn, Routes.pow_session_path(conn, :create, Map.put(@valid_params, "request_path", "/custom-url"))
       assert redirected_to(conn) == "/custom-url"
       assert get_flash(conn, :info) == "signed_in"
-      assert %{id: 1} = Plug.current_user(conn)
+      assert %{id: 1} = Plug.Helpers.current_user(conn)
       assert conn.private[:plug_session]["auth"]
     end
 
@@ -89,14 +89,14 @@ defmodule Pow.Phoenix.SessionControllerTest do
 
     test "removes authenticated", %{conn: conn} do
       conn = post conn, Routes.pow_session_path(conn, :create, @valid_params)
-      assert %{id: 1} = Plug.current_user(conn)
+      assert %{id: 1} = Plug.Helpers.current_user(conn)
       assert conn.private[:plug_session]["auth"]
       :timer.sleep(10)
 
       conn = delete(conn, Routes.pow_session_path(conn, :delete))
       assert redirected_to(conn) == Routes.pow_session_path(conn, :new)
       assert get_flash(conn, :info) == "signed_out"
-      refute Plug.current_user(conn)
+      refute Plug.Helpers.current_user(conn)
       refute conn.private[:plug_session]["auth"]
     end
   end

--- a/test/pow/plug/helpers_test.exs
+++ b/test/pow/plug/helpers_test.exs
@@ -1,6 +1,6 @@
-defmodule Pow.PlugTest do
+defmodule Pow.Plug.HelpersTest do
   use ExUnit.Case
-  doctest Pow.Plug
+  doctest Pow.Plug.Helpers
 
   alias Plug.Conn
   alias Pow.{Config, Config.ConfigError, Plug, Plug.Session}
@@ -21,33 +21,33 @@ defmodule Pow.PlugTest do
 
   test "current_user/1" do
     assert_raise ConfigError, "Pow configuration not found. Please set the Pow.Plug.Session plug beforehand.", fn ->
-      Plug.current_user(%Conn{private: %{}, assigns: %{}})
+      Plug.Helpers.current_user(%Conn{private: %{}, assigns: %{}})
     end
 
     user = %{id: 1}
     conn = %Conn{assigns: %{current_user: user}, private: %{pow_config: @default_config}}
-    assert Plug.current_user(conn) == user
+    assert Plug.Helpers.current_user(conn) == user
 
     conn = %Conn{assigns: %{current_user: user}, private: %{pow_config: @admin_config}}
-    assert is_nil(Plug.current_user(conn))
+    assert is_nil(Plug.Helpers.current_user(conn))
   end
 
   test "current_user/2" do
-    assert is_nil(Plug.current_user(%Conn{assigns: %{}}, @default_config))
+    assert is_nil(Plug.Helpers.current_user(%Conn{assigns: %{}}, @default_config))
 
     user = %{id: 1}
     conn = %Conn{assigns: %{current_user: user}}
 
-    assert Plug.current_user(conn, @default_config) == user
-    assert is_nil(Plug.current_user(conn, @admin_config))
+    assert Plug.Helpers.current_user(conn, @default_config) == user
+    assert is_nil(Plug.Helpers.current_user(conn, @admin_config))
   end
 
   test "assign_current_user/3" do
     user = %{id: 1}
     conn = %Conn{assigns: %{}}
-    assert Plug.assign_current_user(conn, %{id: 1}, @default_config) == %Conn{assigns: %{current_user: user}}
+    assert Plug.Helpers.assign_current_user(conn, %{id: 1}, @default_config) == %Conn{assigns: %{current_user: user}}
 
-    assert Plug.assign_current_user(conn, %{id: 1}, @admin_config) == %Conn{assigns: %{current_admin_user: user}}
+    assert Plug.Helpers.assign_current_user(conn, %{id: 1}, @admin_config) == %Conn{assigns: %{current_admin_user: user}}
   end
 
   test "authenticate_user/2", %{ets: ets} do
@@ -60,29 +60,29 @@ defmodule Pow.PlugTest do
       |> Session.call(opts)
 
     refute conn.private[:plug_session]["auth"]
-    refute Plug.current_user(conn)
+    refute Plug.Helpers.current_user(conn)
 
-    assert {:ok, loaded_conn} = Plug.authenticate_user(conn, %{"email" => "test@example.com", "password" => "secret"})
-    assert user = Plug.current_user(loaded_conn)
+    assert {:ok, loaded_conn} = Plug.Helpers.authenticate_user(conn, %{"email" => "test@example.com", "password" => "secret"})
+    assert user = Plug.Helpers.current_user(loaded_conn)
     assert user.id == 1
     assert loaded_conn.private[:plug_session]["auth"]
 
-    assert {:error, conn} = Plug.authenticate_user(conn, %{})
-    refute Plug.current_user(conn)
+    assert {:error, conn} = Plug.Helpers.authenticate_user(conn, %{})
+    refute Plug.Helpers.current_user(conn)
 
-    assert {:error, conn} = Plug.authenticate_user(conn, %{"email" => "test@example.com"})
-    refute Plug.current_user(conn)
+    assert {:error, conn} = Plug.Helpers.authenticate_user(conn, %{"email" => "test@example.com"})
+    refute Plug.Helpers.current_user(conn)
   end
 
   test "authenticate_user/2 with missing user" do
     assert_raise ConfigError, "No :user configuration option found for user schema module.", fn ->
-      Plug.authenticate_user(conn([]), %{})
+      Plug.Helpers.authenticate_user(conn([]), %{})
     end
   end
 
   test "authenticate_user/2 with invalid users_context" do
     assert_raise UndefinedFunctionError, fn ->
-      Plug.authenticate_user(conn(users_context: Invalid), %{})
+      Plug.Helpers.authenticate_user(conn(users_context: Invalid), %{})
     end
   end
 
@@ -95,23 +95,23 @@ defmodule Pow.PlugTest do
       |> ConnHelpers.init_session()
       |> Session.call(opts)
 
-    assert {:ok, conn} = Plug.authenticate_user(conn, %{"email" => "test@example.com", "password" => "secret"})
-    assert user = Plug.current_user(conn)
+    assert {:ok, conn} = Plug.Helpers.authenticate_user(conn, %{"email" => "test@example.com", "password" => "secret"})
+    assert user = Plug.Helpers.current_user(conn)
     assert session_id = conn.private[:plug_session]["auth"]
     assert {^user, _timestamp} = ets.get(nil, session_id)
 
-    {:ok, conn} = Plug.clear_authenticated_user(conn)
-    refute Plug.current_user(conn)
+    {:ok, conn} = Plug.Helpers.clear_authenticated_user(conn)
+    refute Plug.Helpers.current_user(conn)
     refute conn.private[:plug_session]["auth"]
     assert ets.get(nil, session_id) == :not_found
   end
 
   test "change_user/2" do
     conn = conn()
-    assert %Ecto.Changeset{} = Plug.change_user(conn)
+    assert %Ecto.Changeset{} = Plug.Helpers.change_user(conn)
 
-    conn = Plug.assign_current_user(conn, %User{id: 1}, @default_config)
-    changeset = Plug.change_user(conn)
+    conn = Plug.Helpers.assign_current_user(conn, %User{id: 1}, @default_config)
+    changeset = Plug.Helpers.change_user(conn)
     assert changeset.data.id == 1
   end
 
@@ -124,12 +124,12 @@ defmodule Pow.PlugTest do
       |> ConnHelpers.init_session()
       |> Session.call(opts)
 
-    assert {:error, _changeset, conn} = Plug.create_user(conn, %{})
-    refute Plug.current_user(conn)
+    assert {:error, _changeset, conn} = Plug.Helpers.create_user(conn, %{})
+    refute Plug.Helpers.current_user(conn)
     refute conn.private[:plug_session]["auth"]
 
-    assert {:ok, user, conn} = Plug.create_user(conn, %{"email" => "test@example.com", "password" => "secret"})
-    assert Plug.current_user(conn) == user
+    assert {:ok, user, conn} = Plug.Helpers.create_user(conn, %{"email" => "test@example.com", "password" => "secret"})
+    assert Plug.Helpers.current_user(conn) == user
     assert conn.private[:plug_session]["auth"]
   end
 
@@ -142,17 +142,17 @@ defmodule Pow.PlugTest do
       |> ConnHelpers.init_session()
       |> Session.call(opts)
 
-    {:ok, conn} = Plug.authenticate_user(conn, %{"email" => "test@example.com", "password" => "secret"})
-    user        = Plug.current_user(conn)
+    {:ok, conn} = Plug.Helpers.authenticate_user(conn, %{"email" => "test@example.com", "password" => "secret"})
+    user        = Plug.Helpers.current_user(conn)
     session_id  = conn.private[:plug_session]["auth"]
 
-    assert {:error, _changeset, conn} = Plug.update_user(conn, %{})
-    assert Plug.current_user(conn) == user
+    assert {:error, _changeset, conn} = Plug.Helpers.update_user(conn, %{})
+    assert Plug.Helpers.current_user(conn) == user
     assert conn.private[:plug_session]["auth"] == session_id
 
-    assert {:ok, updated_user, conn} = Plug.update_user(conn, %{"email" => "test@example.com", "password" => "secret"})
+    assert {:ok, updated_user, conn} = Plug.Helpers.update_user(conn, %{"email" => "test@example.com", "password" => "secret"})
     assert updated_user.id == :updated
-    assert Plug.current_user(conn) == updated_user
+    assert Plug.Helpers.current_user(conn) == updated_user
     refute updated_user == user
     refute conn.private[:plug_session]["auth"] == session_id
   end
@@ -166,11 +166,11 @@ defmodule Pow.PlugTest do
       |> ConnHelpers.init_session()
       |> Session.call(opts)
 
-    {:ok, conn} = Plug.authenticate_user(conn, %{"email" => "test@example.com", "password" => "secret"})
+    {:ok, conn} = Plug.Helpers.authenticate_user(conn, %{"email" => "test@example.com", "password" => "secret"})
 
-    assert {:ok, user, conn} = Plug.delete_user(conn)
+    assert {:ok, user, conn} = Plug.Helpers.delete_user(conn)
     assert user.id == :deleted
-    refute Plug.current_user(conn)
+    refute Plug.Helpers.current_user(conn)
     refute conn.private[:plug_session]["auth"]
   end
 

--- a/test/pow/plug/require_authenticated_test.exs
+++ b/test/pow/plug/require_authenticated_test.exs
@@ -10,7 +10,7 @@ defmodule Pow.Plug.RequireAuthenticatedTest do
     conn =
       :get
       |> ConnHelpers.conn("/")
-      |> Plug.put_config(current_user_assigns_key: :current_user)
+      |> Plug.Helpers.put_config(current_user_assigns_key: :current_user)
 
     {:ok, %{conn: conn}}
   end
@@ -41,7 +41,7 @@ defmodule Pow.Plug.RequireAuthenticatedTest do
     opts = RequireAuthenticated.init(@default_config)
     conn =
       conn
-      |> Plug.assign_current_user("user", [])
+      |> Plug.Helpers.assign_current_user("user", [])
       |> RequireAuthenticated.call(opts)
 
     refute conn.private[:not_authenticated]

--- a/test/pow/plug/require_not_authenticated_test.exs
+++ b/test/pow/plug/require_not_authenticated_test.exs
@@ -10,7 +10,7 @@ defmodule Pow.Plug.RequireNotAuthenticatedTest do
     conn =
       :get
       |> ConnHelpers.conn("/")
-      |> Plug.put_config(current_user_assigns_key: :current_user)
+      |> Plug.Helpers.put_config(current_user_assigns_key: :current_user)
 
     {:ok, %{conn: conn}}
   end
@@ -41,7 +41,7 @@ defmodule Pow.Plug.RequireNotAuthenticatedTest do
     opts = RequireNotAuthenticated.init(@default_config)
     conn =
       conn
-      |> Plug.assign_current_user("user", [])
+      |> Plug.Helpers.assign_current_user("user", [])
       |> RequireNotAuthenticated.call(opts)
 
     assert conn.private[:authenticated]

--- a/test/pow/plug/session_test.exs
+++ b/test/pow/plug/session_test.exs
@@ -35,7 +35,7 @@ defmodule Pow.Plug.SessionTest do
     opts = Session.init(@default_opts)
     conn =
       conn
-      |> Plug.assign_current_user("assigned", @default_opts)
+      |> Plug.Helpers.assign_current_user("assigned", @default_opts)
       |> Session.call(opts)
 
     assert conn.assigns[:current_user] == "assigned"
@@ -126,7 +126,7 @@ defmodule Pow.Plug.SessionTest do
 
     assert is_binary(session_id)
     assert etc_user == user
-    assert Plug.current_user(conn) == user
+    assert Plug.Helpers.current_user(conn) == user
 
     conn = Session.do_create(conn, user)
     new_session_id = get_session_id(conn)
@@ -136,7 +136,7 @@ defmodule Pow.Plug.SessionTest do
     assert new_session_id != session_id
     assert ets.get(nil, session_id) == :not_found
     assert etc_user == user
-    assert Plug.current_user(conn) == user
+    assert Plug.Helpers.current_user(conn) == user
   end
 
   test "create/2 creates new session id with `:otp_app` prepended", %{conn: conn} do
@@ -169,14 +169,14 @@ defmodule Pow.Plug.SessionTest do
 
     assert is_binary(session_id)
     assert etc_user == user
-    assert Plug.current_user(conn) == user
+    assert Plug.Helpers.current_user(conn) == user
 
     conn = Session.do_delete(conn)
 
     refute new_session_id = get_session_id(conn)
     assert is_nil(new_session_id)
     assert ets.get(nil, session_id) == :not_found
-    assert is_nil(Plug.current_user(conn))
+    assert is_nil(Plug.Helpers.current_user(conn))
   end
 
   describe "with EtsCache backend" do


### PR DESCRIPTION
Based on suggestions #11.

This is a stab at renaming the Plug modules to something that makes more sense. `Pow.Plug` becomes `Pow.Plug.Helpers`.

- [x] Add deprecated methods for the breaking changes.