### PR TITLE
Raise error on invalid scope alias

### DIFF
--- a/lib/pow/extension/phoenix/router.ex
+++ b/lib/pow/extension/phoenix/router.ex
@@ -28,7 +28,7 @@ defmodule Pow.Extension.Phoenix.Router do
         end
       end
   """
-  alias Pow.Extension.Config
+  alias Pow.{Extension.Config, Phoenix.Router}
 
   defmacro __using__(config \\ []) do
     __create_routers_module__(__CALLER__.module, config)
@@ -57,6 +57,8 @@ defmodule Pow.Extension.Phoenix.Router do
       def routes do
         for router <- @routers do
           quote do
+            Router.validate_scope!(@phoenix_router_scopes)
+
             require unquote(router)
             unquote(router).scoped_routes(@config)
           end

--- a/test/pow/extension/phoenix/router_test.exs
+++ b/test/pow/extension/phoenix/router_test.exs
@@ -20,6 +20,24 @@ defmodule Pow.Test.Extension.Phoenix.Router do
   end
 end
 
+
+module_raised_with =
+  try do
+    defmodule Pow.Test.Extension.Phoenix.RouterAliasScope do
+      @moduledoc false
+      use Phoenix.Router
+      use Pow.Phoenix.Router
+      use Pow.Extension.Phoenix.Router,
+        extensions: [Pow.Test.Extension.Phoenix.Router]
+
+      scope "/", Test do
+        pow_extension_routes()
+      end
+    end
+  rescue
+    e in ArgumentError -> e.message
+  end
+
 defmodule Pow.Extension.Phoenix.RouterTest do
   use Pow.Test.Ecto.TestCase
   doctest Pow.Extension.Phoenix.Router
@@ -32,5 +50,10 @@ defmodule Pow.Extension.Phoenix.RouterTest do
   test "has routes" do
     assert unquote(Routes.pow_session_path(@conn, :new)) == "/session/new"
     assert unquote(Routes.pow_test_path(@conn, :new)) = "/test/new"
+  end
+
+  test "validates no aliases" do
+    assert unquote(module_raised_with) =~ "Pow routes should not be defined inside scopes with aliases: Test"
+    assert unquote(module_raised_with) =~ "scope \"/\", Test do"
   end
 end

--- a/test/pow/phoenix/router_test.exs
+++ b/test/pow/phoenix/router_test.exs
@@ -1,0 +1,25 @@
+module_raised_with =
+  try do
+    defmodule Pow.Test.Phoenix.RouterAliasScope do
+      @moduledoc false
+      use Phoenix.Router
+      use Pow.Phoenix.Router
+
+      scope "/", Test do
+        pow_routes()
+      end
+    end
+  rescue
+    e in ArgumentError -> e.message
+  end
+
+
+defmodule Pow.Phoenix.RouterTest do
+  use ExUnit.Case
+  doctest Pow.Phoenix.Router
+
+  test "validates no aliases" do
+    assert unquote(module_raised_with) =~ "Pow routes should not be defined inside scopes with aliases: Test"
+    assert unquote(module_raised_with) =~ "scope \"/\", Test do"
+  end
+end


### PR DESCRIPTION
Experiment for a helper to #22 

This will raise an error when `pow_routes/0` is called inside an aliased scope. I'll need to add this to the extension routes as well. I'm not sure if this is necessary though.