### PR TITLE
Namespace configuration

### DIFF
--- a/guides/MULTIPLE_USERS_IN_SAME_SCOPE.md
+++ b/guides/MULTIPLE_USERS_IN_SAME_SCOPE.md
@@ -1,0 +1,64 @@
+# Set up Pow to handle multiple user structs in same scope
+
+Let's say that you would like to access both a user and admin session in the same scope.
+
+With Pow, you can namespace the configuration in a few steps. Note that the same can be done with less configuration in an umbrella setup using the `:otp_app` configuration.
+
+## Create admin and user schema
+
+```bash
+mix pow.ecto.install -r MyApp.Repo Admin admins
+mix pow.ecto.install -r MyApp.Repo User users
+```
+
+## Set up plugs
+
+Update `WEB_PATH/endpoint.ex` with the two namespaced configurations:
+
+```elixir
+plug Pow.Plug.Session,
+  repo: MyApp.Repo,
+  user: MyApp.User,
+  namespace: :user,
+  current_user_assigns_key: :current_user
+
+plug Pow.Plug.Session,
+  repo: MyApp.Repo,
+  user: MyApp.Admin,
+  namespace: :admin,
+  current_user_assigns_key: :current_admin
+```
+
+The user can be accessed in `assigns[:current_user]` and admin in `assigns[:current_admin]`.
+
+## Set up routes
+
+Update `WEB_PATH/router.ex` to access the namespaced configurations:
+
+```elixir
+scope "/user", private: %{pow_namespace: :user} do
+  pipe_through :browser
+
+  pow_routes()
+end
+
+scope "/admin", private: %{pow_namespace: :admin} do
+  pipe_through :browser
+
+  pow_routes()
+end
+```
+
+That's it! Your namespaced configuration is now working with the Pow controllers.
+
+## Modify templates
+
+If you wish to modify the templates, you'll need to generate them with the `namespace` argument:
+
+```bash
+mix pow.phoenix.gen.templates --namespace user
+```
+
+Then set up the configuration with `web_module: MyAppWeb`. The namespace will automatically be used from the configuration to discover the templates and views. The views will be generated as `MyAppWeb.Pow.NAMESPACE.VIEW`, and templates will be generated in `my_app_web/templates/pow/NAMESPACE`.
+
+This will work for extension and mailer templates too.

--- a/lib/extensions/persistent_session/plug/base.ex
+++ b/lib/extensions/persistent_session/plug/base.ex
@@ -12,6 +12,8 @@ defmodule PowPersistentSession.Plug.Base do
 
     * `:cache_store_backend` - the backend cache store. This value defaults to
       `EtsCache`.
+
+    * `:namespace` - the namespace to use for fetching Pow configuration.
   """
 
   alias Plug.Conn
@@ -35,12 +37,20 @@ defmodule PowPersistentSession.Plug.Base do
       def call(conn, config) do
         config =
           conn
+          |> maybe_set_pow_namespace(config)
           |> Plug.fetch_config()
           |> Config.merge(config)
 
         conn
         |> Conn.put_private(:pow_persistent_session, {__MODULE__, config})
         |> authenticate(config)
+      end
+
+      defp maybe_set_pow_namespace(conn, config) do
+        case Config.get(config, :namespace) do
+          nil       -> conn
+          namespace -> Conn.put_private(conn, :pow_namespace, namespace)
+        end
       end
     end
   end

--- a/lib/extensions/persistent_session/plug/cookie.ex
+++ b/lib/extensions/persistent_session/plug/cookie.ex
@@ -25,8 +25,8 @@ defmodule PowPersistentSession.Plug.Cookie do
     * `:cache_store_backend` - see `PowPersistentSession.Plug.Base`
 
     * `:persistent_session_cookie_key` - session key name. This defaults to
-      "persistent_session_cookie". If `:otp_app` is used it'll automatically
-      prepend the key with the `:otp_app` value.
+      "persistent_session_cookie". If `:namespace` or `:otp_app` is used it'll
+      automatically prepend the key with the value.
 
     * `:persistent_session_cookie_max_age` - max age for cookie in seconds. This
       defaults to 30 days in seconds.

--- a/lib/extensions/persistent_session/plug/cookie.ex
+++ b/lib/extensions/persistent_session/plug/cookie.ex
@@ -24,6 +24,8 @@ defmodule PowPersistentSession.Plug.Cookie do
 
     * `:cache_store_backend` - see `PowPersistentSession.Plug.Base`
 
+    * `:namespace` - see `PowPersistentSession.Plug.Base`
+
     * `:persistent_session_cookie_key` - session key name. This defaults to
       "persistent_session_cookie". If `:namespace` or `:otp_app` is used it'll
       automatically prepend the key with the value.

--- a/lib/mix/pow/phoenix.ex
+++ b/lib/mix/pow/phoenix.ex
@@ -35,8 +35,9 @@ defmodule Mix.Pow.Phoenix do
   @doc """
   Creates a view file for the web module.
   """
-  @spec create_view_file(atom(), binary(), atom(), binary()) :: :ok
-  def create_view_file(module, name, web_mod, web_prefix) do
+  @spec create_view_file(atom(), binary(), atom(), binary(), binary() | nil) :: :ok
+  def create_view_file(module, name, web_mod, web_prefix, namespace) do
+    module  = namespace_module(module, namespace)
     path    = Path.join([web_prefix, "views", Macro.underscore(module), "#{name}_view.ex"])
     content = """
     defmodule #{inspect(web_mod)}.#{inspect(module)}.#{Macro.camelize(name)}View do
@@ -50,9 +51,10 @@ defmodule Mix.Pow.Phoenix do
   @doc """
   Creates template files for the web module.
   """
-  @spec create_templates(atom(), binary(), binary(), [binary()]) :: :ok
-  def create_templates(module, name, web_prefix, actions) do
+  @spec create_templates(atom(), binary(), binary(), [binary()], binary() | nil) :: :ok
+  def create_templates(module, name, web_prefix, actions, namespace) do
     template_module = Module.concat([module, Phoenix, "#{Macro.camelize(name)}Template"])
+    module          = namespace_module(module, namespace)
     path            = Path.join([web_prefix, "templates", Macro.underscore(module), name])
 
     actions
@@ -64,4 +66,11 @@ defmodule Mix.Pow.Phoenix do
       Generator.create_file(file_path, content)
     end)
   end
+
+  @doc """
+  Adds namespace to module if namespace exists in config.
+  """
+  @spec namespace_module(atom(), binary() | nil) :: atom()
+  def namespace_module(module, nil), do: module
+  def namespace_module(module, namespace), do: Module.concat(module, Macro.camelize(namespace))
 end

--- a/lib/mix/pow/phoenix/mailer.ex
+++ b/lib/mix/pow/phoenix/mailer.ex
@@ -3,13 +3,15 @@ defmodule Mix.Pow.Phoenix.Mailer do
   Utilities module for mix phoenix mailer tasks.
   """
   alias Mix.Generator
+  alias Mix.Pow.Phoenix, as: MixPhoenix
 
   @doc """
   Creates a mailer view file for the web module.
   """
-  @spec create_view_file(atom(), binary(), atom(), binary(), [binary()]) :: :ok
-  def create_view_file(module, name, web_mod, web_prefix, mails) do
+  @spec create_view_file(atom(), binary(), atom(), binary(), [binary()], binary() | nil) :: :ok
+  def create_view_file(module, name, web_mod, web_prefix, mails, namespace) do
     subjects = subjects_methods(module, name, mails)
+    module   = MixPhoenix.namespace_module(module, namespace)
     path     = Path.join([web_prefix, "views", Macro.underscore(module), "#{name}_view.ex"])
     content  = """
     defmodule #{inspect(web_mod)}.#{inspect(module)}.#{Macro.camelize(name)}View do
@@ -25,9 +27,10 @@ defmodule Mix.Pow.Phoenix.Mailer do
   @doc """
   Creates mailer template files for the web module.
   """
-  @spec create_templates(atom(), binary(), binary(), [binary()]) :: :ok
-  def create_templates(module, name, web_prefix, mails) do
+  @spec create_templates(atom(), binary(), binary(), [binary()], binary() | nil) :: :ok
+  def create_templates(module, name, web_prefix, mails, namespace) do
     template_module = template_module(module, name)
+    module          = MixPhoenix.namespace_module(module, namespace)
     path            = Path.join([web_prefix, "templates", Macro.underscore(module), name])
 
     Enum.each(mails, fn mail ->

--- a/lib/mix/tasks/extension/phoenix/pow.extension.phoenix.gen.templates.ex
+++ b/lib/mix/tasks/extension/phoenix/pow.extension.phoenix.gen.templates.ex
@@ -18,12 +18,13 @@ defmodule Mix.Tasks.Pow.Extension.Phoenix.Gen.Templates do
 
     * `--extension PowResetPassword` extension to include in generation
     * `--context-app MyApp` app to use for path and module names
+    * `--namespace my_namespace` namespace to use for path and module names
   """
   use Mix.Task
 
   alias Mix.{Pow, Pow.Extension, Pow.Phoenix}
 
-  @switches [context_app: :string, extension: :keep]
+  @switches [context_app: :string, extension: :keep, namespace: :string]
   @default_opts []
   @mix_task "pow.extension.phoenix.gen.templates"
 
@@ -56,8 +57,8 @@ defmodule Mix.Tasks.Pow.Extension.Phoenix.Gen.Templates do
 
     Enum.each(extensions, fn {module, templates} ->
       Enum.each(templates, fn {name, actions} ->
-        Phoenix.create_view_file(module, name, web_module, web_prefix)
-        Phoenix.create_templates(module, name, web_prefix, actions)
+        Phoenix.create_view_file(module, name, web_module, web_prefix, config[:namespace])
+        Phoenix.create_templates(module, name, web_prefix, actions, config[:namespace])
       end)
     end)
 

--- a/lib/mix/tasks/extension/phoenix/pow.extension.phoenix.mailer.gen.templates.ex
+++ b/lib/mix/tasks/extension/phoenix/pow.extension.phoenix.mailer.gen.templates.ex
@@ -18,12 +18,13 @@ defmodule Mix.Tasks.Pow.Extension.Phoenix.Mailer.Gen.Templates do
 
     * `--extension PowResetPassword` extension to include in generation
     * `--context-app MyApp` app to use for path and module names
+    * `--namespace my_namespace` namespace to use for path and module names
   """
   use Mix.Task
 
   alias Mix.{Pow, Pow.Extension, Pow.Phoenix, Pow.Phoenix.Mailer}
 
-  @switches [context_app: :string, extension: :keep]
+  @switches [context_app: :string, extension: :keep, namespace: :string]
   @default_opts []
   @mix_task "pow.extension.phoenix.mailer.gen.templates"
 
@@ -60,8 +61,8 @@ defmodule Mix.Tasks.Pow.Extension.Phoenix.Mailer.Gen.Templates do
     Enum.each(extensions, fn {module, templates} ->
       Enum.each(templates, fn {name, mails} ->
         mails = Enum.map(mails, &String.to_atom/1)
-        Mailer.create_view_file(module, name, web_module, web_prefix, mails)
-        Mailer.create_templates(module, name, web_prefix, mails)
+        Mailer.create_view_file(module, name, web_module, web_prefix, mails, config[:namespace])
+        Mailer.create_templates(module, name, web_prefix, mails, config[:namespace])
       end)
     end)
 

--- a/lib/mix/tasks/phoenix/pow.phoenix.gen.templates.ex
+++ b/lib/mix/tasks/phoenix/pow.phoenix.gen.templates.ex
@@ -9,12 +9,13 @@ defmodule Mix.Tasks.Pow.Phoenix.Gen.Templates do
   ## Arguments
 
     * `--context-app MyApp` app to use for path and module names
+    * `--namespace my_namespace` namespace to use for path and module names
   """
   use Mix.Task
 
   alias Mix.{Pow, Pow.Phoenix}
 
-  @switches [context_app: :string]
+  @switches [context_app: :string, namespace: :string]
   @default_opts []
   @mix_task "pow.phoenix.gen.templates"
 
@@ -41,8 +42,8 @@ defmodule Mix.Tasks.Pow.Phoenix.Gen.Templates do
     web_prefix   = structure[:web_prefix]
 
     Enum.each(@templates, fn {name, actions} ->
-      Phoenix.create_view_file(Elixir.Pow, name, web_module, web_prefix)
-      Phoenix.create_templates(Elixir.Pow, name, web_prefix, actions)
+      Phoenix.create_view_file(Elixir.Pow, name, web_module, web_prefix, config[:namespace])
+      Phoenix.create_templates(Elixir.Pow, name, web_prefix, actions, config[:namespace])
     end)
 
     %{context_base: context_base, web_module: web_module}

--- a/lib/pow/phoenix/mailer/mail.ex
+++ b/lib/pow/phoenix/mailer/mail.ex
@@ -19,8 +19,9 @@ defmodule Pow.Phoenix.Mailer.Mail do
   def new(conn, user, {view_module, template}, assigns) do
     config     = Plug.fetch_config(conn)
     web_module = Config.get(config, :web_mailer_module)
+    namespace  = Config.get(config, :namespace)
 
-    view_module = Pow.Phoenix.ViewHelpers.build_view_module(view_module, web_module)
+    view_module = Pow.Phoenix.ViewHelpers.build_view_module(view_module, web_module, namespace)
 
     subject = subject(conn, view_module, template)
     text    = render(conn, view_module, "#{template}.text", assigns)

--- a/lib/pow/plug.ex
+++ b/lib/pow/plug.ex
@@ -57,7 +57,7 @@ defmodule Pow.Plug do
   @doc """
   Prepend namespace found in Plug Pow configuration to binary.
 
-  Will prepend `:otp_app` if exists in configuration.
+  Will prepend `:namespace` or `:otp_app` if exists in configuration.
   """
   @spec prepend_with_namespace(Config.t(), binary()) :: binary()
   def prepend_with_namespace(config, string) do
@@ -67,7 +67,7 @@ defmodule Pow.Plug do
     end
   end
 
-  defp fetch_namespace(config), do: Config.get(config, :otp_app)
+  defp fetch_namespace(config), do: Config.get(config, :namespace) || Config.get(config, :otp_app)
 
   @doc """
   Authenticates a user.

--- a/lib/pow/plug/session.ex
+++ b/lib/pow/plug/session.ex
@@ -21,6 +21,26 @@ defmodule Pow.Plug.Session do
         cache_store_backend: Pow.Store.Backend.EtsCache,
         users_context: Pow.Ecto.Users
 
+  ## Multiple sessions in same scope
+
+  You can add several sessions as long as you remember to keep them
+  isolated with the `:namespace` and `:current_user_assigns_key` keys:
+
+      plug Pow.Plug.Session,
+        repo: MyApp.Repo,
+        user: MyApp.User,
+        namespace: :user,
+        current_user_assigns_key: :current_user
+
+      plug Pow.Plug.Session,
+        repo: MyApp.Repo,
+        user: MyApp.Admin,
+        namespace: :admin,
+        current_user_assigns_key: :current_admin
+
+  You'll have to set the `:pow_config_namespace` private key in the connection for
+  `Pow.Plug.fetch_config/1` to fetch the config within that namespace.
+
   ## Configuration options
 
     * `:session_key` - session key name, defaults to "auth". If `:namespace`

--- a/lib/pow/plug/session.ex
+++ b/lib/pow/plug/session.ex
@@ -23,8 +23,9 @@ defmodule Pow.Plug.Session do
 
   ## Configuration options
 
-    * `:session_key` - session key name, defaults to "auth". If `:otp_app` is
-      used it'll automatically prepend the key with the `:otp_app` value.
+    * `:session_key` - session key name, defaults to "auth". If `:namespace`
+      or `:otp_app` is used, it'll automatically prepend the key with this
+      value.
 
     * `:session_store` - the credentials cache store. This value defaults to
       `{CredentialsCache, backend: EtsCache}`. The `EtsCache` backend store
@@ -35,6 +36,9 @@ defmodule Pow.Plug.Session do
 
     * `:session_ttl_renewal` - the ttl in milliseconds to trigger renewal of
       sessions. Defaults to 15 minutes in miliseconds.
+
+    * `:namespace` - the namespace to be prepended to all keys that are shared
+      in the same scope. Defaults to the `:otp_app` value.
   """
   use Pow.Plug.Base
 
@@ -71,8 +75,8 @@ defmodule Pow.Plug.Session do
   `Plug.Conn.put_session/3`. Any existing sessions will be deleted first with
   `delete/2`.
 
-  The unique session id will be prepended by the `:otp_app` configuration
-  value, if present.
+  The unique session id will be prepended by the `:namespace` or `:otp_app`
+  configuration value.
   """
   @spec create(Conn.t(), map(), Config.t()) :: {Conn.t(), map()}
   def create(conn, user, config) do

--- a/mix.exs
+++ b/mix.exs
@@ -73,6 +73,10 @@ defmodule Pow.MixProject do
           filename: "CoherenceMigration",
           title: "Migrating from Coherence"
         ],
+        "guides/MULITPLE_USERS_SAME_SCOPE.md": [
+          filename: "MultipleUsersSameScope",
+          title: "Multiple users in same scope"
+        ],
         "guides/SWOOSH_MAILER.md": [
           filename: "SwooshMailer",
           title: "Swoosh mailer"

--- a/test/extensions/persistent_session/plug/cookie_test.exs
+++ b/test/extensions/persistent_session/plug/cookie_test.exs
@@ -74,16 +74,17 @@ defmodule PowPersistentSession.Plug.CookieTest do
   end
 
   test "call/2 assigns user from cookie with prepended `:namespace`", %{config: config, ets: ets} do
-    user = %User{id: 1}
-    conn =
+    user   = %User{id: 1}
+    config = config ++ [namespace: :test]
+    conn   =
       :get
       |> ConnHelpers.conn("/")
       |> ConnHelpers.init_session()
       |> Session.call(config ++ [namespace: :test])
       |> store_persistent(ets, "test_test", user, "test_persistent_session_cookie")
-      |> Cookie.call(Cookie.init(config))
+      |> Cookie.call(Cookie.init(namespace: :test))
 
-    assert Plug.current_user(conn) == user
+    assert Plug.current_user(conn, config) == user
     assert %{value: new_id, max_age: @max_age, path: "/"} = conn.resp_cookies["test_persistent_session_cookie"]
     assert String.starts_with?(new_id, "test")
     assert PersistentSessionCache.get([backend: ets], new_id) == 1

--- a/test/mix/tasks/extension/phoenix/pow.extension.phoenix.gen.templates_test.exs
+++ b/test/mix/tasks/extension/phoenix/pow.extension.phoenix.gen.templates_test.exs
@@ -87,5 +87,28 @@ defmodule Mix.Tasks.Pow.Extension.Phoenix.Gen.TemplatesTest do
     end
   end
 
+  describe "with `:namespace` configuration" do
+    test "generates templates" do
+      File.cd!(@tmp_path, fn ->
+        Templates.run(@options ++ ~w(--namespace test))
+
+        for {module, expected_templates} <- @expected_template_files do
+          templates_path = Path.join(["lib", "pow_web", "templates", Macro.underscore(module), "test"])
+          dirs           = templates_path |> File.ls!() |> Enum.sort()
+
+          assert dirs == Map.keys(expected_templates)
+
+          views_path = Path.join(["lib", "pow_web", "views", Macro.underscore(module), "test"])
+
+          [base_name | _rest] = expected_templates |> Map.keys()
+          view_content        = views_path |> Path.join(base_name <> "_view.ex") |> File.read!()
+
+          assert view_content =~ "defmodule PowWeb.#{inspect(module)}.Test.#{Macro.camelize(base_name)}View do"
+          assert view_content =~ "use PowWeb, :view"
+        end
+      end)
+    end
+  end
+
   defp ls(path), do: path |> File.ls!() |> Enum.sort()
 end

--- a/test/mix/tasks/extension/phoenix/pow.extension.phoenix.mailer.gen.templates_test.exs
+++ b/test/mix/tasks/extension/phoenix/pow.extension.phoenix.mailer.gen.templates_test.exs
@@ -105,5 +105,27 @@ defmodule Mix.Tasks.Pow.Extension.Phoenix.Mailer.Gen.TemplatesTest do
     end
   end
 
+  describe "with `:namespace` configuration" do
+    test "generates mailer templates" do
+      File.cd!(@tmp_path, fn ->
+        Templates.run(@options ++ ~w(--namespace test))
+
+        for {module, expected_templates} <- @expected_template_files do
+          templates_path = Path.join(["lib", "pow_web", "templates", Macro.underscore(module), "test"])
+          dirs           = templates_path |> File.ls!() |> Enum.sort()
+
+          assert dirs == Map.keys(expected_templates)
+
+          views_path          = Path.join(["lib", "pow_web", "views", Macro.underscore(module), "test"])
+          [base_name | _rest] = expected_templates |> Map.keys()
+          view_content        = views_path |> Path.join(base_name <> "_view.ex") |> File.read!()
+
+          assert view_content =~ "defmodule PowWeb.#{inspect(module)}.Test.#{Macro.camelize(base_name)}View do"
+          assert view_content =~ "use PowWeb, :mailer_view"
+        end
+      end)
+    end
+  end
+
   defp ls(path), do: path |> File.ls!() |> Enum.sort()
 end

--- a/test/mix/tasks/phoenix/pow.phoenix.gen.templates_test.exs
+++ b/test/mix/tasks/phoenix/pow.phoenix.gen.templates_test.exs
@@ -77,5 +77,24 @@ defmodule Mix.Tasks.Pow.Phoenix.Gen.TemplatesTest do
     end)
   end
 
+  test "generates with `:namespace" do
+    options = ~w(--namespace test)
+
+    File.cd!(@tmp_path, fn ->
+      Templates.run(options)
+
+      templates_path = Path.join(["lib", "pow_web", "templates", "pow", "test"])
+      dirs           = templates_path |> File.ls!() |> Enum.sort()
+
+      assert dirs == Map.keys(@expected_template_files)
+
+      views_path   = Path.join(["lib", "pow_web", "views", "pow", "test"])
+      view_content = views_path |> Path.join("session_view.ex") |> File.read!()
+
+      assert view_content =~ "defmodule PowWeb.Pow.Test.SessionView do"
+      assert view_content =~ "use PowWeb, :view"
+    end)
+  end
+
   defp ls(path), do: path |> File.ls!() |> Enum.sort()
 end

--- a/test/pow/phoenix/mailer_test.exs
+++ b/test/pow/phoenix/mailer_test.exs
@@ -22,7 +22,7 @@ defmodule Pow.Phoenix.MailerTest do
   end
 
   test "deliver/2", %{conn: conn, email: email} do
-    assert_raise Pow.Config.ConfigError, "Pow configuration not found in connection. Please use a Pow plug that puts the Pow configuration in the plug connection.", fn ->
+    assert_raise Pow.Config.ConfigError, "Pow configuration not found in connection. Please use a Pow plug that puts the Pow configuration in the plug connection. If you use `:namespace`, please ensure that the same namespace is set as a `:pow_namespace` private key in the connection", fn ->
       Mailer.deliver(conn, email)
     end
 

--- a/test/pow/phoenix/views/view_helpers_test.exs
+++ b/test/pow/phoenix/views/view_helpers_test.exs
@@ -48,6 +48,16 @@ defmodule Pow.Phoenix.ViewHelpersTest do
     assert conn.private[:phoenix_layout] == {Pow.Test.Phoenix.LayoutView, :app}
   end
 
+  test "layout/1 with `:web_module` and `:namespace`", %{conn: conn} do
+    conn =
+      conn
+      |> Conn.put_private(:pow_config, web_module: Pow.Test.Phoenix, namespace: :test)
+      |> ViewHelpers.layout()
+
+    assert conn.private[:phoenix_view] == Pow.Test.Phoenix.Pow.Test.SessionView
+    assert conn.private[:phoenix_layout] == {Pow.Test.Phoenix.LayoutView, :app}
+  end
+
   test "layout/1 in extension", %{conn: conn} do
     conn =
       conn
@@ -68,6 +78,17 @@ defmodule Pow.Phoenix.ViewHelpersTest do
 
     assert conn.private[:phoenix_endpoint] == Pow.Test.Phoenix.Endpoint
     assert conn.private[:phoenix_view] == Pow.Test.Phoenix.PowTest.TestView
+    assert conn.private[:phoenix_layout] == {Pow.Test.Phoenix.LayoutView, :app}
+  end
+
+  test "layout/1 in extension with `:web_module` and `:namespace`", %{conn: conn} do
+    conn =
+      conn
+      |> Conn.put_private(:phoenix_view, PowTest.Phoenix.TestView)
+      |> Conn.put_private(:pow_config, web_module: Pow.Test.Phoenix, namespace: :test)
+      |> ViewHelpers.layout()
+
+    assert conn.private[:phoenix_view] == Pow.Test.Phoenix.PowTest.Test.TestView
     assert conn.private[:phoenix_layout] == {Pow.Test.Phoenix.LayoutView, :app}
   end
 end

--- a/test/pow/plug/session_test.exs
+++ b/test/pow/plug/session_test.exs
@@ -128,6 +128,15 @@ defmodule Pow.Plug.SessionTest do
     assert conn.assigns[:current_user] == "cached"
   end
 
+  test "call/2 with multiple `:namespace` configurations", %{conn: conn} do
+    opts = Session.init(@default_opts)
+    conn = Session.call(conn, opts ++ [namespace: :user])
+    conn = Session.call(conn, opts ++ [namespace: :admin])
+
+    assert conn.private[:pow_config_user]
+    assert conn.private[:pow_config_admin]
+  end
+
   test "create/2 creates new session id", %{conn: conn, ets: ets} do
     user = %{id: 1}
     opts = Session.init(@default_opts)

--- a/test/pow/plug/session_test.exs
+++ b/test/pow/plug/session_test.exs
@@ -111,6 +111,23 @@ defmodule Pow.Plug.SessionTest do
     assert conn.assigns[:current_user] == "cached"
   end
 
+  test "call/2 with prepended `:namespace` session key", %{conn: conn, ets: ets} do
+    ets.put(nil, "token", {"cached", :os.system_time(:millisecond)})
+
+    opts =
+      @default_opts
+      |> Keyword.delete(:session_key)
+      |> Keyword.put(:namespace, :test)
+      |> Session.init()
+    conn =
+      conn
+      |> Conn.fetch_session()
+      |> Conn.put_session("test_auth", "token")
+      |> Session.call(opts)
+
+    assert conn.assigns[:current_user] == "cached"
+  end
+
   test "create/2 creates new session id", %{conn: conn, ets: ets} do
     user = %{id: 1}
     opts = Session.init(@default_opts)


### PR DESCRIPTION
Adds namespace configuration.

If `:namespace` is used in the configuration, the Plug module will add it as a `:pow_config_NAMESPACE` private key in the connection. When fetched for controllers or through `Plug.current_user/1` helper, it's expected that a `:pow_namespace` private key exists in the connection.

A simple setup will look like this:

```elixir
# WEB_PATH/endpoint.ex

plug Pow.Plug.Session,
  repo: MyApp.Repo,
  user: MyApp.Admin,
  namespace: :admin,
  current_user_assigns_key: :current_admin

# WEB_PATH/router.ex

scope "/admin", private: %{pow_namespace: :admin} do
  pipe_through :browser

  pow_routes()
end
```

Resolves #19 

Still need to write about how to use require authenticated/unauthenticated in a namespace configuration setup. Also the routes are not yet done, and a full integration test needs to be added.