### PR TITLE
List all credentials keys

### DIFF
--- a/lib/pow/store/backend/mnesia_cache.ex
+++ b/lib/pow/store/backend/mnesia_cache.ex
@@ -50,6 +50,13 @@ defmodule Pow.Store.Backend.MnesiaCache do
     table_get(config, key)
   end
 
+  @spec keys(Config.t()) :: [any()]
+  def keys(config) do
+    table_keys(config)
+  end
+
+  # Callbacks
+
   @spec init(Config.t()) :: {:ok, map()}
   def init(config) do
     table_init(config)
@@ -129,6 +136,14 @@ defmodule Pow.Store.Backend.MnesiaCache do
     end)
   end
 
+  defp table_keys(config) do
+    namespace = mnesia_key(config, "")
+
+    @mnesia_cache_tab
+    |> :mnesia.dirty_all_keys()
+    |> Enum.filter(&String.starts_with?(&1, namespace))
+  end
+
   defp table_init(config) do
     nodes      = Config.get(config, :nodes, [node()])
     table_opts = Config.get(config, :table_opts, disc_copies: nodes)
@@ -161,8 +176,8 @@ defmodule Pow.Store.Backend.MnesiaCache do
   end
 
   defp init_invalidators(config) do
-    @mnesia_cache_tab
-    |> :mnesia.dirty_all_keys()
+    config
+    |> table_keys()
     |> Enum.map(&init_invalidator(config, &1))
     |> Enum.reject(&is_nil/1)
     |> Enum.into(%{})

--- a/lib/pow/store/base.ex
+++ b/lib/pow/store/base.ex
@@ -15,6 +15,7 @@ defmodule Pow.Store.Base do
   @callback put(Config.t(), binary(), any()) :: :ok
   @callback delete(Config.t(), binary()) :: :ok
   @callback get(Config.t(), binary()) :: any() | :not_found
+  @callback keys(Config.t()) :: [any()]
 
   @doc false
   defmacro __using__(defaults) do
@@ -32,6 +33,10 @@ defmodule Pow.Store.Base do
       @spec get(Config.t(), binary()) :: any() | :not_found
       def get(config, key),
         do: unquote(__MODULE__).get(config, backend_config(config), key)
+
+      @spec keys(Config.t()) :: [any()]
+      def keys(config),
+        do: unquote(__MODULE__).keys(config, backend_config(config))
 
       defp backend_config(config) do
         [
@@ -60,6 +65,12 @@ defmodule Pow.Store.Base do
   @spec get(Config.t(), Config.t(), binary()) :: any() | :not_found
   def get(config, backend_config, key) do
     store(config).get(backend_config, key)
+  end
+
+  @doc false
+  @spec keys(Config.t(), Config.t()) :: [any()]
+  def keys(config, backend_config) do
+    store(config).keys(backend_config)
   end
 
   defp store(config) do

--- a/lib/pow/store/credentials_cache.ex
+++ b/lib/pow/store/credentials_cache.ex
@@ -17,6 +17,20 @@ defmodule Pow.Store.CredentialsCache do
     namespace: "credentials"
 
   @doc """
+  List all user session keys stored for a certain user struct.
+
+  Each user session key can be used to look up all sessions for that user.
+  """
+  @spec user_session_keys(Config.t(), Config.t(), module()) :: [any()]
+  def user_session_keys(config, backend_config, struct) do
+    namespace = "#{Macro.underscore(struct)}_sessions_"
+
+    config
+    |> Base.keys(backend_config)
+    |> Enum.filter(&String.starts_with?(&1, namespace))
+  end
+
+  @doc """
   List all existing sessions for the user fetched from the backend store.
   """
   @spec sessions(Config.t(), Config.t(), map()) :: [binary()]

--- a/test/pow/store/backend/ets_cache_test.exs
+++ b/test/pow/store/backend/ets_cache_test.exs
@@ -18,6 +18,14 @@ defmodule Pow.Store.Backend.EtsCacheTest do
     assert EtsCache.get(@default_config, "key") == :not_found
   end
 
+  test "fetch keys" do
+    EtsCache.put(@default_config, "key1", "value")
+    EtsCache.put(@default_config, "key2", "value")
+    :timer.sleep(100)
+
+    assert Enum.sort(EtsCache.keys(@default_config)) == ["pow:test:key1", "pow:test:key2"]
+  end
+
   test "records auto purge" do
     config = Config.put(@default_config, :ttl, 100)
 

--- a/test/pow/store/backend/mnesia_cache_test.exs
+++ b/test/pow/store/backend/mnesia_cache_test.exs
@@ -33,6 +33,14 @@ defmodule Pow.Store.Backend.MnesiaCacheTest do
     assert MnesiaCache.get(@default_config, "key") == :not_found
   end
 
+  test "fetch keys" do
+    MnesiaCache.put(@default_config, "key1", "value")
+    MnesiaCache.put(@default_config, "key2", "value")
+    :timer.sleep(100)
+
+    assert MnesiaCache.keys(@default_config) == ["pow:test:key1", "pow:test:key2"]
+  end
+
   test "records auto purge with persistent storage", %{pid: pid} do
     config = Config.put(@default_config, :ttl, 100)
 

--- a/test/pow/store/credentials_cache_test.exs
+++ b/test/pow/store/credentials_cache_test.exs
@@ -30,6 +30,9 @@ defmodule Pow.Store.CredentialsCacheTest do
     assert CredentialsCache.get(config, backend_config, "key_3") == user_2
     assert CredentialsCache.get(config, backend_config, "key_4") == user_3
 
+    assert CredentialsCache.user_session_keys(config, backend_config, User) == ["pow/test/ecto/users/user_sessions_1", "pow/test/ecto/users/user_sessions_2"]
+    assert CredentialsCache.user_session_keys(config, backend_config, UsernameUser) == ["pow/test/ecto/users/username_user_sessions_1"]
+
     assert CredentialsCache.sessions(config, backend_config, user_1) == ["key_1", "key_2"]
     assert CredentialsCache.sessions(config, backend_config, user_2) == ["key_3"]
     assert CredentialsCache.sessions(config, backend_config, user_3) == ["key_4"]

--- a/test/support/ets_cache_mock.ex
+++ b/test/support/ets_cache_mock.ex
@@ -20,4 +20,13 @@ defmodule Pow.Test.EtsCacheMock do
   def put(_config, key, value) do
     :ets.insert(@tab, {key, value})
   end
+
+  def keys(_config) do
+    Stream.resource(
+      fn -> :ets.first(@tab) end,
+      fn :"$end_of_table" -> {:halt, nil}
+        previous_key -> {[previous_key], :ets.next(@tab, previous_key)} end,
+      fn _ -> :ok
+    end)
+  end
 end


### PR DESCRIPTION
Resolves #38. It's possible to pull all user session keys by calling:

```elixir
Pow.Store.CredentialsCache.user_session_keys(config, backend_config, struct)
```

This will list all keys containing sessions for a user, and can be used to find active users.