### PR TITLE
Truncate email_created_at to seconds

### DIFF
--- a/lib/extensions/email_confirmation/ecto/schema.ex
+++ b/lib/extensions/email_confirmation/ecto/schema.ex
@@ -48,7 +48,7 @@ defmodule PowEmailConfirmation.Ecto.Schema do
 
   defp confirm_email(changeset) do
     changes   = [
-      email_confirmed_at: DateTime.utc_now(),
+      email_confirmed_at: DateTime.truncate(DateTime.utc_now(), :second),
       email: changeset.data.unconfirmed_email || changeset.data.email,
       unconfirmed_email: nil]
 


### PR DESCRIPTION
Fixes `value #DateTime<2018-11-17 10:27:40.807Z> for MyApp.Users.User.email_confirmed_at in update does not match type :utc_datetime` when using Ecto 3.0
