### PR TITLE
Use ecto timestamp generation

### DIFF
--- a/lib/extensions/email_confirmation/ecto/schema.ex
+++ b/lib/extensions/email_confirmation/ecto/schema.ex
@@ -47,8 +47,8 @@ defmodule PowEmailConfirmation.Ecto.Schema do
   defp maybe_confirm_email(changeset), do: changeset
 
   defp confirm_email(changeset) do
-    changes   = [
-      email_confirmed_at: DateTime.utc_now(),
+    changes = [
+      email_confirmed_at: Pow.Ecto.Schema.__timestamp_for__(changeset.data.__struct__, :email_confirmed_at),
       email: changeset.data.unconfirmed_email || changeset.data.email,
       unconfirmed_email: nil]
 

--- a/lib/pow/ecto/schema.ex
+++ b/lib/pow/ecto/schema.ex
@@ -182,4 +182,28 @@ defmodule Pow.Ecto.Schema do
   def filter_new_fields(fields, existing_fields) when is_list(fields) do
     Enum.filter(fields, &not Enum.member?(existing_fields, {elem(&1, 0), elem(&1, 1)}))
   end
+
+  @doc false
+  def __timestamp_for__(struct, column) do
+    type = struct.__schema__(:type, column)
+
+    __timestamp__(type)
+  end
+
+  @doc false
+  def __timestamp__(:naive_datetime) do
+    %{NaiveDateTime.utc_now() | microsecond: {0, 0}}
+  end
+  def __timestamp__(:naive_datetime_usec) do
+    NaiveDateTime.utc_now()
+  end
+  def __timestamp__(:utc_datetime) do
+    DateTime.from_unix!(System.system_time(:second), :second)
+  end
+  def __timestamp__(:utc_datetime_usec) do
+    DateTime.from_unix!(System.system_time(:microsecond), :microsecond)
+  end
+  def __timestamp__(type) do
+    type.from_unix!(System.system_time(:microsecond), :microsecond)
+  end
 end


### PR DESCRIPTION
This replicates [the ecto 3.0 timestamps autogeneration](https://github.com/elixir-ecto/ecto/blob/63c92db1a8c6168ee461c6fb4fe64fad36cbe54c/lib/ecto/schema.ex#L1752-L1771) for the `:email_confirmed_at` column.