### PR TITLE
Make routes generation customizable

### DIFF
--- a/lib/extensions/email_confirmation/phoenix/controllers/confirmation_controller.ex
+++ b/lib/extensions/email_confirmation/phoenix/controllers/confirmation_controller.ex
@@ -4,7 +4,7 @@ defmodule PowEmailConfirmation.Phoenix.ConfirmationController do
     messages_backend_fallback: PowEmailConfirmation.Phoenix.Messages
 
   alias Plug.Conn
-  alias Pow.Phoenix.{Controller, RegistrationController, SessionController}
+  alias Pow.Phoenix.{RegistrationController, SessionController}
   alias PowEmailConfirmation.Plug
 
   @spec process_show(Conn.t(), map()) :: {:ok | :error, map(), Conn.t()}
@@ -24,8 +24,8 @@ defmodule PowEmailConfirmation.Phoenix.ConfirmationController do
 
   defp redirect_to(conn) do
     case Pow.Plug.current_user(conn) do
-      nil   -> Controller.router_path(conn, SessionController, :new)
-      _user -> Controller.router_path(conn, RegistrationController, :edit)
+      nil   -> routes(conn).router_path(conn, SessionController, :new)
+      _user -> routes(conn).router_path(conn, RegistrationController, :edit)
     end
   end
 end

--- a/lib/extensions/email_confirmation/phoenix/controllers/confirmation_controller.ex
+++ b/lib/extensions/email_confirmation/phoenix/controllers/confirmation_controller.ex
@@ -4,7 +4,6 @@ defmodule PowEmailConfirmation.Phoenix.ConfirmationController do
     messages_backend_fallback: PowEmailConfirmation.Phoenix.Messages
 
   alias Plug.Conn
-  alias Pow.Phoenix.{RegistrationController, SessionController}
   alias PowEmailConfirmation.Plug
 
   @spec process_show(Conn.t(), map()) :: {:ok | :error, map(), Conn.t()}
@@ -24,8 +23,8 @@ defmodule PowEmailConfirmation.Phoenix.ConfirmationController do
 
   defp redirect_to(conn) do
     case Pow.Plug.current_user(conn) do
-      nil   -> routes(conn).router_path(conn, SessionController, :new)
-      _user -> routes(conn).router_path(conn, RegistrationController, :edit)
+      nil   -> routes(conn).session_path(conn, :new)
+      _user -> routes(conn).registration_path(conn, :edit)
     end
   end
 end

--- a/lib/extensions/email_confirmation/phoenix/controllers/controller_callbacks.ex
+++ b/lib/extensions/email_confirmation/phoenix/controllers/controller_callbacks.ex
@@ -3,7 +3,7 @@ defmodule PowEmailConfirmation.Phoenix.ControllerCallbacks do
   use Pow.Extension.Phoenix.ControllerCallbacks.Base
 
   alias Plug.Conn
-  alias Pow.{Phoenix.Controller, Phoenix.SessionController, Plug}
+  alias Pow.{Phoenix.SessionController, Plug}
   alias PowEmailConfirmation.Phoenix.{ConfirmationController, Mailer}
 
   def before_process(Pow.Phoenix.RegistrationController, :update, conn, _config) do
@@ -40,7 +40,7 @@ defmodule PowEmailConfirmation.Phoenix.ControllerCallbacks do
 
     {:ok, conn} = Plug.clear_authenticated_user(conn)
     error       = ConfirmationController.messages(conn).email_confirmation_required(conn)
-    path        = Controller.router_path(conn, SessionController, :new)
+    path        = ConfirmationController.routes(conn).router_path(conn, SessionController, :new)
     conn        =
       conn
       |> Phoenix.Controller.put_flash(:error, error)
@@ -53,7 +53,7 @@ defmodule PowEmailConfirmation.Phoenix.ControllerCallbacks do
   @spec send_confirmation_email(map(), Conn.t()) :: any()
   def send_confirmation_email(user, conn) do
     token = user.email_confirmation_token
-    url   = Controller.router_url(conn, ConfirmationController, :show, [token])
+    url   = ConfirmationController.routes(conn).router_url(conn, ConfirmationController, :show, [token])
     email = Mailer.email_confirmation(conn, user, url)
 
     Pow.Phoenix.Mailer.deliver(conn, email)

--- a/lib/extensions/email_confirmation/phoenix/controllers/controller_callbacks.ex
+++ b/lib/extensions/email_confirmation/phoenix/controllers/controller_callbacks.ex
@@ -3,7 +3,7 @@ defmodule PowEmailConfirmation.Phoenix.ControllerCallbacks do
   use Pow.Extension.Phoenix.ControllerCallbacks.Base
 
   alias Plug.Conn
-  alias Pow.{Phoenix.SessionController, Plug}
+  alias Pow.Plug
   alias PowEmailConfirmation.Phoenix.{ConfirmationController, Mailer}
 
   def before_process(Pow.Phoenix.RegistrationController, :update, conn, _config) do
@@ -40,7 +40,7 @@ defmodule PowEmailConfirmation.Phoenix.ControllerCallbacks do
 
     {:ok, conn} = Plug.clear_authenticated_user(conn)
     error       = ConfirmationController.messages(conn).email_confirmation_required(conn)
-    path        = ConfirmationController.routes(conn).router_path(conn, SessionController, :new)
+    path        = ConfirmationController.routes(conn).session_path(conn, :new)
     conn        =
       conn
       |> Phoenix.Controller.put_flash(:error, error)
@@ -53,7 +53,7 @@ defmodule PowEmailConfirmation.Phoenix.ControllerCallbacks do
   @spec send_confirmation_email(map(), Conn.t()) :: any()
   def send_confirmation_email(user, conn) do
     token = user.email_confirmation_token
-    url   = ConfirmationController.routes(conn).router_url(conn, ConfirmationController, :show, [token])
+    url   = ConfirmationController.routes(conn).url_for(conn, ConfirmationController, :show, [token])
     email = Mailer.email_confirmation(conn, user, url)
 
     Pow.Phoenix.Mailer.deliver(conn, email)

--- a/lib/extensions/reset_password/phoenix/controllers/reset_password_controller.ex
+++ b/lib/extensions/reset_password/phoenix/controllers/reset_password_controller.ex
@@ -4,7 +4,6 @@ defmodule PowResetPassword.Phoenix.ResetPasswordController do
     messages_backend_fallback: PowResetPassword.Phoenix.Messages
 
   alias Plug.Conn
-  alias Pow.Phoenix.SessionController
   alias PowResetPassword.{Phoenix.Mailer, Plug}
 
   plug :require_not_authenticated
@@ -31,7 +30,7 @@ defmodule PowResetPassword.Phoenix.ResetPasswordController do
 
   @spec respond_create({:ok | :error, map(), Conn.t()}) :: Conn.t()
   def respond_create({:ok, %{token: token, user: user}, conn}) do
-    url = routes(conn).router_url(conn, __MODULE__, :edit, [token])
+    url = routes(conn).url_for(conn, __MODULE__, :edit, [token])
     deliver_email(conn, user, url)
 
     default_respond_create(conn)
@@ -41,7 +40,7 @@ defmodule PowResetPassword.Phoenix.ResetPasswordController do
   defp default_respond_create(conn) do
     conn
     |> put_flash(:info, messages(conn).email_has_been_sent(conn))
-    |> redirect(to: routes(conn).router_path(conn, SessionController, :new))
+    |> redirect(to: routes(conn).session_path(conn, :new))
   end
 
   @spec process_edit(Conn.t(), map()) :: {:ok, map(), Conn.t()}
@@ -65,7 +64,7 @@ defmodule PowResetPassword.Phoenix.ResetPasswordController do
   def respond_update({:ok, _user, conn}) do
     conn
     |> put_flash(:info, messages(conn).password_has_been_reset(conn))
-    |> redirect(to: routes(conn).router_path(conn, SessionController, :new))
+    |> redirect(to: routes(conn).session_path(conn, :new))
   end
   def respond_update({:error, changeset, conn}) do
     conn
@@ -78,7 +77,7 @@ defmodule PowResetPassword.Phoenix.ResetPasswordController do
       nil ->
         conn
         |> put_flash(:error, messages(conn).invalid_token(conn))
-        |> redirect(to: routes(conn).router_path(conn, __MODULE__, :new))
+        |> redirect(to: routes(conn).path_for(conn, __MODULE__, :new))
         |> halt()
 
       user ->
@@ -93,13 +92,13 @@ defmodule PowResetPassword.Phoenix.ResetPasswordController do
   end
 
   defp assign_create_path(conn, _opts) do
-    path = routes(conn).router_path(conn, __MODULE__, :create)
+    path = routes(conn).path_for(conn, __MODULE__, :create)
     Conn.assign(conn, :action, path)
   end
 
   defp assign_update_path(conn, _opts) do
     token = conn.params["id"]
-    path  = routes(conn).router_path(conn, __MODULE__, :update, [token])
+    path  = routes(conn).path_for(conn, __MODULE__, :update, [token])
     Conn.assign(conn, :action, path)
   end
 end

--- a/lib/extensions/reset_password/phoenix/controllers/reset_password_controller.ex
+++ b/lib/extensions/reset_password/phoenix/controllers/reset_password_controller.ex
@@ -4,7 +4,7 @@ defmodule PowResetPassword.Phoenix.ResetPasswordController do
     messages_backend_fallback: PowResetPassword.Phoenix.Messages
 
   alias Plug.Conn
-  alias Pow.Phoenix.{Controller, SessionController}
+  alias Pow.Phoenix.SessionController
   alias PowResetPassword.{Phoenix.Mailer, Plug}
 
   plug :require_not_authenticated
@@ -31,7 +31,7 @@ defmodule PowResetPassword.Phoenix.ResetPasswordController do
 
   @spec respond_create({:ok | :error, map(), Conn.t()}) :: Conn.t()
   def respond_create({:ok, %{token: token, user: user}, conn}) do
-    url = Controller.router_url(conn, __MODULE__, :edit, [token])
+    url = routes(conn).router_url(conn, __MODULE__, :edit, [token])
     deliver_email(conn, user, url)
 
     default_respond_create(conn)
@@ -41,7 +41,7 @@ defmodule PowResetPassword.Phoenix.ResetPasswordController do
   defp default_respond_create(conn) do
     conn
     |> put_flash(:info, messages(conn).email_has_been_sent(conn))
-    |> redirect(to: Controller.router_path(conn, SessionController, :new))
+    |> redirect(to: routes(conn).router_path(conn, SessionController, :new))
   end
 
   @spec process_edit(Conn.t(), map()) :: {:ok, map(), Conn.t()}
@@ -65,7 +65,7 @@ defmodule PowResetPassword.Phoenix.ResetPasswordController do
   def respond_update({:ok, _user, conn}) do
     conn
     |> put_flash(:info, messages(conn).password_has_been_reset(conn))
-    |> redirect(to: Controller.router_path(conn, SessionController, :new))
+    |> redirect(to: routes(conn).router_path(conn, SessionController, :new))
   end
   def respond_update({:error, changeset, conn}) do
     conn
@@ -78,7 +78,7 @@ defmodule PowResetPassword.Phoenix.ResetPasswordController do
       nil ->
         conn
         |> put_flash(:error, messages(conn).invalid_token(conn))
-        |> redirect(to: Controller.router_path(conn, __MODULE__, :new))
+        |> redirect(to: routes(conn).router_path(conn, __MODULE__, :new))
         |> halt()
 
       user ->
@@ -93,13 +93,13 @@ defmodule PowResetPassword.Phoenix.ResetPasswordController do
   end
 
   defp assign_create_path(conn, _opts) do
-    path = Controller.router_path(conn, __MODULE__, :create)
+    path = routes(conn).router_path(conn, __MODULE__, :create)
     Conn.assign(conn, :action, path)
   end
 
   defp assign_update_path(conn, _opts) do
     token = conn.params["id"]
-    path  = Controller.router_path(conn, __MODULE__, :update, [token])
+    path  = routes(conn).router_path(conn, __MODULE__, :update, [token])
     Conn.assign(conn, :action, path)
   end
 end

--- a/lib/pow/phoenix/controllers/controller.ex
+++ b/lib/pow/phoenix/controllers/controller.ex
@@ -135,30 +135,6 @@ defmodule Pow.Phoenix.Controller do
     Module.concat([private.phoenix_router, Helpers])
   end
 
-  @doc """
-  Generates a path route.
-  """
-  @spec router_path(Conn.t(), atom(), atom(), list(), Keyword.t()) :: binary()
-  def router_path(conn, plug, verb, vars \\ [], query_params \\ []) do
-    gen_route(:path, conn, plug, verb, vars, query_params)
-  end
-
-  @doc """
-  Generates a url route.
-  """
-  @spec router_url(Conn.t(), atom(), atom(), list(), Keyword.t()) :: binary()
-  def router_url(conn, plug, verb, vars \\ [], query_params \\ []) do
-    gen_route(:url, conn, plug, verb, vars, query_params)
-  end
-
-  defp gen_route(type, conn, plug, verb, vars, query_params) do
-    helper = :"#{route_helper(plug)}_#{type}"
-    router = Module.concat([conn.private.phoenix_router, Helpers])
-    args   = [conn, verb] ++ vars ++ [query_params]
-
-    apply(router, helper, args)
-  end
-
   @spec route_helper(atom()) :: binary()
   def route_helper(plug) do
     as             = Phoenix.Naming.resource_name(plug, "Controller")

--- a/lib/pow/phoenix/controllers/registration_controller.ex
+++ b/lib/pow/phoenix/controllers/registration_controller.ex
@@ -3,7 +3,7 @@ defmodule Pow.Phoenix.RegistrationController do
   use Pow.Phoenix.Controller
 
   alias Plug.Conn
-  alias Pow.{Phoenix.Controller, Plug}
+  alias Pow.Plug
 
   plug :require_not_authenticated when action in [:new, :create]
   plug :require_authenticated when action in [:edit, :update, :delete]
@@ -82,16 +82,16 @@ defmodule Pow.Phoenix.RegistrationController do
   def respond_delete({:error, _changeset, conn}) do
     conn
     |> put_flash(:error, messages(conn).user_could_not_be_deleted(conn))
-    |> redirect(to: Controller.router_path(conn, __MODULE__, :edit))
+    |> redirect(to: routes(conn).router_path(conn, __MODULE__, :edit))
   end
 
   defp assign_create_path(conn, _opts) do
-    path = Controller.router_path(conn, __MODULE__, :create)
+    path = routes(conn).router_path(conn, __MODULE__, :create)
     Conn.assign(conn, :action, path)
   end
 
   defp assign_update_path(conn, _opts) do
-    path = Controller.router_path(conn, __MODULE__, :update)
+    path = routes(conn).router_path(conn, __MODULE__, :update)
     Conn.assign(conn, :action, path)
   end
 end

--- a/lib/pow/phoenix/controllers/registration_controller.ex
+++ b/lib/pow/phoenix/controllers/registration_controller.ex
@@ -82,16 +82,16 @@ defmodule Pow.Phoenix.RegistrationController do
   def respond_delete({:error, _changeset, conn}) do
     conn
     |> put_flash(:error, messages(conn).user_could_not_be_deleted(conn))
-    |> redirect(to: routes(conn).router_path(conn, __MODULE__, :edit))
+    |> redirect(to: routes(conn).path_for(conn, __MODULE__, :edit))
   end
 
   defp assign_create_path(conn, _opts) do
-    path = routes(conn).router_path(conn, __MODULE__, :create)
+    path = routes(conn).path_for(conn, __MODULE__, :create)
     Conn.assign(conn, :action, path)
   end
 
   defp assign_update_path(conn, _opts) do
-    path = routes(conn).router_path(conn, __MODULE__, :update)
+    path = routes(conn).path_for(conn, __MODULE__, :update)
     Conn.assign(conn, :action, path)
   end
 end

--- a/lib/pow/phoenix/controllers/session_controller.ex
+++ b/lib/pow/phoenix/controllers/session_controller.ex
@@ -8,7 +8,7 @@ defmodule Pow.Phoenix.SessionController do
   use Pow.Phoenix.Controller
 
   alias Plug.Conn
-  alias Pow.{Phoenix.Controller, Plug}
+  alias Pow.Plug
 
   plug :require_not_authenticated when action in [:new, :create]
   plug :require_authenticated when action in [:delete]
@@ -74,6 +74,6 @@ defmodule Pow.Phoenix.SessionController do
     create_path(conn, request_path: request_path)
   end
   defp create_path(conn, query_params \\ []) do
-    Controller.router_path(conn, __MODULE__, :create, [], query_params)
+    routes(conn).router_path(conn, __MODULE__, :create, [], query_params)
   end
 end

--- a/lib/pow/phoenix/controllers/session_controller.ex
+++ b/lib/pow/phoenix/controllers/session_controller.ex
@@ -74,6 +74,6 @@ defmodule Pow.Phoenix.SessionController do
     create_path(conn, request_path: request_path)
   end
   defp create_path(conn, query_params \\ []) do
-    routes(conn).router_path(conn, __MODULE__, :create, [], query_params)
+    routes(conn).path_for(conn, __MODULE__, :create, [], query_params)
   end
 end

--- a/lib/pow/phoenix/router.ex
+++ b/lib/pow/phoenix/router.ex
@@ -61,12 +61,12 @@ defmodule Pow.Phoenix.Router do
 
     @spec pow_session_path(Conn.t(), :new) :: binary()
     def pow_session_path(conn, :new) do
-      SessionController.routes(conn).router_path(conn, SessionController, :new)
+      SessionController.routes(conn).session_path(conn, :new)
     end
 
     @spec pow_registration_path(Conn.t(), :new) :: binary()
     def pow_registration_path(conn, :new) do
-      RegistrationController.routes(conn).router_path(conn, RegistrationController, :new)
+      RegistrationController.routes(conn).registration_path(conn, :new)
     end
   end
 end

--- a/lib/pow/phoenix/router.ex
+++ b/lib/pow/phoenix/router.ex
@@ -57,16 +57,16 @@ defmodule Pow.Phoenix.Router do
     @moduledoc false
 
     alias Plug.Conn
-    alias Pow.Phoenix.{Controller, RegistrationController, SessionController}
+    alias Pow.Phoenix.{RegistrationController, SessionController}
 
     @spec pow_session_path(Conn.t(), :new) :: binary()
     def pow_session_path(conn, :new) do
-      Controller.router_path(conn, SessionController, :new)
+      SessionController.routes(conn).router_path(conn, SessionController, :new)
     end
 
     @spec pow_registration_path(Conn.t(), :new) :: binary()
     def pow_registration_path(conn, :new) do
-      Controller.router_path(conn, RegistrationController, :new)
+      RegistrationController.routes(conn).router_path(conn, RegistrationController, :new)
     end
   end
 end

--- a/lib/pow/phoenix/routes.ex
+++ b/lib/pow/phoenix/routes.ex
@@ -12,6 +12,19 @@ defmodule Pow.Phoenix.Routes do
       end
 
     Update configuration with `routes_backend: MyAppWeb.Pow.Routes`.
+
+    You can also customize path generation:
+
+      defmodule MyAppWeb.Pow.Routes do
+        use Pow.Phoenix.Routes
+        alias MyAppWeb.Router.Helpers, as: Routes
+
+        def url_for(conn, verb, vars \\ [], query_params \\ [])
+        def url_for(conn, PowEmailConfirmation.Phoenix.ConfirmationController, :show, [token], _query_params),
+          do: Routes.custom_confirmation_url(conn, :new, token)
+        def url_for(conn, plug, verb, vars, query_params),
+          do: Pow.Phoenix.Routes.url_for(conn, plug, verb, vars, query_params)
+      end
   """
   alias Plug.Conn
   alias Pow.Phoenix.{Controller, RegistrationController, SessionController}
@@ -23,6 +36,10 @@ defmodule Pow.Phoenix.Routes do
   @callback after_registration_path(Conn.t()) :: binary()
   @callback after_user_updated_path(Conn.t()) :: binary()
   @callback after_user_deleted_path(Conn.t()) :: binary()
+  @callback session_path(Conn.t(), atom(), list()) :: binary()
+  @callback registration_path(Conn.t(), atom()) :: binary()
+  @callback path_for(Conn.t(), atom(), atom(), list(), Keyword.t()) :: binary()
+  @callback url_for(Conn.t(), atom(), atom(), list(), Keyword.t()) :: binary()
 
   defmacro __using__(_opts) do
     quote do
@@ -49,11 +66,17 @@ defmodule Pow.Phoenix.Routes do
       def after_user_deleted_path(conn),
         do: unquote(__MODULE__).after_user_deleted_path(conn)
 
-      def router_path(conn, plug, verb, vars \\ [], query_params \\ []),
-        do: unquote(__MODULE__).router_path(conn, plug, verb, vars, query_params)
+      def session_path(conn, verb, query_params \\ []),
+        do: unquote(__MODULE__).session_path(conn, verb, query_params)
 
-      def router_url(conn, plug, verb, vars \\ [], query_params \\ []),
-        do: unquote(__MODULE__).router_url(conn, plug, verb, vars, query_params)
+      def registration_path(conn, verb),
+        do: unquote(__MODULE__).registration_path(conn, verb)
+
+      def path_for(conn, plug, verb, vars \\ [], query_params \\ []),
+        do: unquote(__MODULE__).path_for(conn, plug, verb, vars, query_params)
+
+      def url_for(conn, plug, verb, vars \\ [], query_params \\ []),
+        do: unquote(__MODULE__).url_for(conn, plug, verb, vars, query_params)
 
       defoverridable unquote(__MODULE__)
     end
@@ -69,7 +92,7 @@ defmodule Pow.Phoenix.Routes do
   See `Pow.Phoenix.SessionController` for more on how this value is handled.
   """
   def user_not_authenticated_path(conn) do
-    router_path(conn, SessionController, :new, [], request_path: Phoenix.Controller.current_path(conn))
+    session_path(conn, :new, request_path: Phoenix.Controller.current_path(conn))
   end
 
   @doc """
@@ -82,9 +105,7 @@ defmodule Pow.Phoenix.Routes do
   @doc """
   Path to redirect user to when user has signed out.
   """
-  def after_sign_out_path(conn) do
-    router_path(conn, SessionController, :new)
-  end
+  def after_sign_out_path(conn), do: session_path(conn, :new)
 
   @doc """
   Path to redirect user to when user has signed in.
@@ -107,9 +128,7 @@ defmodule Pow.Phoenix.Routes do
   @doc """
   Path to redirect user to when user has updated their account.
   """
-  def after_user_updated_path(conn) do
-    router_path(conn, RegistrationController, :edit)
-  end
+  def after_user_updated_path(conn), do: registration_path(conn, :edit)
 
   @doc """
   Path to redirect user to when user has deleted their account.
@@ -118,19 +137,25 @@ defmodule Pow.Phoenix.Routes do
   """
   def after_user_deleted_path(conn), do: routes(conn).after_sign_out_path(conn)
 
+  @doc false
+  def session_path(conn, verb, query_params \\ []), do: path_for(conn, SessionController, verb, [], query_params)
+
+  @doc false
+  def registration_path(conn, verb), do: path_for(conn, RegistrationController, verb)
+
   @doc """
   Generates a path route.
   """
-  @spec router_path(Conn.t(), atom(), atom(), list(), Keyword.t()) :: binary()
-  def router_path(conn, plug, verb, vars \\ [], query_params \\ []) do
+  @spec path_for(Conn.t(), atom(), atom(), list(), Keyword.t()) :: binary()
+  def path_for(conn, plug, verb, vars \\ [], query_params \\ []) do
     gen_route(:path, conn, plug, verb, vars, query_params)
   end
 
   @doc """
   Generates a url route.
   """
-  @spec router_url(Conn.t(), atom(), atom(), list(), Keyword.t()) :: binary()
-  def router_url(conn, plug, verb, vars \\ [], query_params \\ []) do
+  @spec url_for(Conn.t(), atom(), atom(), list(), Keyword.t()) :: binary()
+  def url_for(conn, plug, verb, vars \\ [], query_params \\ []) do
     gen_route(:url, conn, plug, verb, vars, query_params)
   end
 


### PR DESCRIPTION
This will make it easier to manage #24 and #53

It's possible to do the following with this:

```elixir
defmodule MyAppWeb.Pow.Routes do
  use Pow.Phoenix.Routes
  alias MyAppWeb.Router.Helpers, as: Routes

  def session_path(conn, verb, query_params \\ []), do: Routes.custom_session_path(conn, verb, query_params)
end
```

```elixir
defmodule MyAppWeb.Pow.Routes do
  use Pow.Phoenix.Routes
  alias MyAppWeb.Router.Helpers, as: Routes

  def url_for(conn, verb, vars \\ [], query_params \\ [])
  def url_for(conn, PowEmailConfirmation.Phoenix.ConfirmationController, :show, [token], _query_params),
    do: Routes.custom_confirmation_url(conn, :new, token)
  def url_for(conn, plug, verb, vars, query_params),
    do: Pow.Phoenix.Routes.url_for(conn, plug, verb, vars, query_params)
end
```

This way, if custom controllers or routes are used, they can be overridden fairly easily using the `Pow.Phoenix.Routes` module.