### PR TITLE
Add user and conn assigns to mail

### DIFF
--- a/lib/pow/phoenix/mailer/mail.ex
+++ b/lib/pow/phoenix/mailer/mail.ex
@@ -23,24 +23,14 @@ defmodule Pow.Phoenix.Mailer.Mail do
 
     view_module = Pow.Phoenix.ViewHelpers.build_view_module(view_module, web_module)
 
-    subject = subject(conn, view_module, template)
-    text    = render(conn, view_module, "#{template}.text", view_assigns)
+    subject = view_module.subject(template, view_assigns)
+    text    = view_module.render("#{template}.text", view_assigns)
     html    =
-      conn
-      |> render(view_module, "#{template}.html", view_assigns)
+      "#{template}.html"
+      |> view_module.render(view_assigns)
       |> Phoenix.Template.HTML.encode_to_iodata!()
       |> IO.iodata_to_binary()
 
     struct(__MODULE__, user: user, subject: subject, text: text, html: html, assigns: assigns)
-  end
-
-  @spec subject(Conn.t(), module(), atom()) :: binary()
-  defp subject(conn, module, mail) do
-    module.subject(mail, conn: conn)
-  end
-
-  @spec render(Conn.t(), module(), binary(), Keyword.t()) :: binary()
-  defp render(_conn, module, mail, assigns) do
-    module.render(mail, assigns)
   end
 end

--- a/lib/pow/phoenix/mailer/mail.ex
+++ b/lib/pow/phoenix/mailer/mail.ex
@@ -17,16 +17,17 @@ defmodule Pow.Phoenix.Mailer.Mail do
   """
   @spec new(Conn.t(), map(), {module(), atom()}, Keyword.t()) :: t()
   def new(conn, user, {view_module, template}, assigns) do
-    config     = Plug.fetch_config(conn)
-    web_module = Config.get(config, :web_mailer_module)
+    config       = Plug.fetch_config(conn)
+    web_module   = Config.get(config, :web_mailer_module)
+    view_assigns = Keyword.merge([conn: conn, user: user], assigns)
 
     view_module = Pow.Phoenix.ViewHelpers.build_view_module(view_module, web_module)
 
     subject = subject(conn, view_module, template)
-    text    = render(conn, view_module, "#{template}.text", assigns)
+    text    = render(conn, view_module, "#{template}.text", view_assigns)
     html    =
       conn
-      |> render(view_module, "#{template}.html", assigns)
+      |> render(view_module, "#{template}.html", view_assigns)
       |> Phoenix.Template.HTML.encode_to_iodata!()
       |> IO.iodata_to_binary()
 

--- a/lib/pow/phoenix/mailer/view.ex
+++ b/lib/pow/phoenix/mailer/view.ex
@@ -7,9 +7,7 @@ defmodule Pow.Phoenix.Mailer.View do
     quote do
       @template_module Pow.Phoenix.View.__template_module__(__MODULE__)
 
-      def render(mail, assigns) do
-        @template_module.render(mail, assigns)
-      end
+      def render(mail, assigns), do: @template_module.render(mail, assigns)
 
       def subject(mail, _assigns), do: @template_module.subject(mail)
     end

--- a/test/mix/tasks/extension/phoenix/pow.extension.phoenix.mailer.gen.templates_test.exs
+++ b/test/mix/tasks/extension/phoenix/pow.extension.phoenix.mailer.gen.templates_test.exs
@@ -48,7 +48,14 @@ defmodule Mix.Tasks.Pow.Extension.Phoenix.Mailer.Gen.TemplatesTest do
 
         assert view_content =~ "defmodule PowWeb.#{inspect(module)}.#{Macro.camelize(base_name)}View do"
         assert view_content =~ "use PowWeb, :mailer_view"
-        assert view_content =~ "def subject(:"
+
+        template =
+          expected_templates
+          |> Map.get(base_name)
+          |> List.first()
+          |> String.split(".html.eex")
+
+        assert view_content =~ "def subject(:#{template}, _assigns), do:"
       end
 
       for _ <- 1..6, do: assert_received({:mix_shell, :info, [_msg]})

--- a/test/pow/phoenix/mailer/mail_test.exs
+++ b/test/pow/phoenix/mailer/mail_test.exs
@@ -6,7 +6,6 @@ defmodule Pow.Phoenix.MailerTemplate do
   "Test subject",
   """
   <%= @value %> text
-  <%= inspect @user %>
   """,
   """
   <%= content_tag(:h3, "\#{@value} HTML") %>
@@ -33,7 +32,6 @@ defmodule Pow.Phoenix.Mailer.MailTest do
     assert mail.subject == "Test subject"
     assert mail.html =~ "<h3>test HTML</h3>"
     assert mail.text =~ "test text\n"
-    assert mail.text =~ "\n:user\n"
     assert mail.assigns[:value] == "test"
   end
 

--- a/test/pow/phoenix/mailer/mail_test.exs
+++ b/test/pow/phoenix/mailer/mail_test.exs
@@ -42,8 +42,8 @@ defmodule Pow.Phoenix.Mailer.MailTest do
     assert mail = Mail.new(conn, :user, {MailerView, :mail_test}, value: "test")
 
     assert mail.user == :user
-    assert mail.subject == ":web_mailer_module subject"
-    assert mail.html == "<p>:web_mailer_module html mail</p>"
-    assert mail.text == ":web_mailer_module text mail"
+    assert mail.subject == ":web_mailer_module subject :user"
+    assert mail.html == "<p>:web_mailer_module html mail :user</p>"
+    assert mail.text == ":web_mailer_module text mail :user"
   end
 end

--- a/test/pow/phoenix/mailer/mail_test.exs
+++ b/test/pow/phoenix/mailer/mail_test.exs
@@ -6,6 +6,7 @@ defmodule Pow.Phoenix.MailerTemplate do
   "Test subject",
   """
   <%= @value %> text
+  <%= inspect @user %>
   """,
   """
   <%= content_tag(:h3, "\#{@value} HTML") %>
@@ -32,6 +33,7 @@ defmodule Pow.Phoenix.Mailer.MailTest do
     assert mail.subject == "Test subject"
     assert mail.html =~ "<h3>test HTML</h3>"
     assert mail.text =~ "test text\n"
+    assert mail.text =~ "\n:user\n"
     assert mail.assigns[:value] == "test"
   end
 

--- a/test/support/phoenix/views.ex
+++ b/test/support/phoenix/views.ex
@@ -12,7 +12,7 @@ defmodule Pow.Test.Phoenix.Pow.MailerView do
   @moduledoc false
   use Pow.Test.Phoenix.Web, :mailer_view
 
-  def subject(:mail_test, _assigns), do: ":web_mailer_module subject"
+  def subject(:mail_test, assigns), do: ":web_mailer_module subject #{inspect assigns[:user]}"
 end
 
 defmodule Pow.Test.Phoenix.ErrorView do

--- a/test/support/phoenix/web_module/templates/mailer/mail_test.html.eex
+++ b/test/support/phoenix/web_module/templates/mailer/mail_test.html.eex
@@ -1,1 +1,1 @@
-<%= content_tag(:p, ":web_mailer_module html mail") %>
+<%= content_tag(:p, ":web_mailer_module html mail #{inspect @user}") %>

--- a/test/support/phoenix/web_module/templates/mailer/mail_test.text.eex
+++ b/test/support/phoenix/web_module/templates/mailer/mail_test.text.eex
@@ -1,1 +1,1 @@
-<%= ":web_mailer_module text mail" %>
+<%= ":web_mailer_module text mail #{inspect @user}" %>


### PR DESCRIPTION
Resolves #69 

Subject has also been refactored to have access to same view assigns as the templates.