### PR TITLE
Granular default routes

### DIFF
--- a/guides/DISABLE_REGISTRATION.md
+++ b/guides/DISABLE_REGISTRATION.md
@@ -1,0 +1,15 @@
+# Disable registration
+
+You may have an app in which users are not permitted to sign up. Pow makes it easy to disable registration by removing the registration routes.
+
+First you should follow the [Modify templates](../README.md#modify-templates) section in README.
+
+## Templates
+
+Delete the `templates/pow/registration` folder and the `views/pow/registration_view.ex` file. Open up `templates/pow/session/new.html.eex` and remove the `Routes.pow_registration_path` link.
+
+## Routes
+
+Replace `pow_routes()` with `pow_session_routes()` in your router module.
+
+That's it!

--- a/lib/pow/phoenix/router.ex
+++ b/lib/pow/phoenix/router.ex
@@ -29,7 +29,7 @@ defmodule Pow.Phoenix.Router do
   """
   defmacro __using__(_opts \\ []) do
     quote do
-      import unquote(__MODULE__)
+      import unquote(__MODULE__), only: [pow_routes: 0, pow_scope: 1, pow_session_routes: 0, pow_registration_routes: 0]
     end
   end
 

--- a/lib/pow/phoenix/router.ex
+++ b/lib/pow/phoenix/router.ex
@@ -45,11 +45,36 @@ defmodule Pow.Phoenix.Router do
       end
   """
   defmacro pow_routes do
-    quote location: :keep do
+    quote do
+      pow_session_routes()
+      pow_registration_routes()
+    end
+  end
+
+  @doc false
+  defmacro pow_scope(do: context) do
+    quote do
       unquote(__MODULE__).validate_scope!(@phoenix_router_scopes)
 
       scope "/", Pow.Phoenix, as: "pow" do
+        unquote(context)
+      end
+    end
+  end
+
+  @doc false
+  defmacro pow_session_routes do
+    quote location: :keep do
+      pow_scope do
         resources "/session", SessionController, singleton: true, only: [:new, :create, :delete]
+      end
+    end
+  end
+
+  @doc false
+  defmacro pow_registration_routes do
+    quote location: :keep do
+      pow_scope do
         resources "/registration", RegistrationController, singleton: true, only: [:new, :create, :edit, :update, :delete]
       end
     end

--- a/mix.exs
+++ b/mix.exs
@@ -92,6 +92,10 @@ defmodule Pow.MixProject do
           filename: "CustomControllers",
           title: "Custom controllers"
         ],
+        "guides/DISABLE_REGISTRATION.md": [
+          filename: "DisableRegistration",
+          title: "Disable registration"
+        ],
         "lib/extensions/email_confirmation/README.md": [
           filename: "PowEmailConfirmation",
           title: "PowEmailConfirmation"


### PR DESCRIPTION
This makes it possible to call `pow_registration_routes/0` and `pow_session_routes/0` for the individual routes definitions. Also `pow_scope/1` can be used.

Resolves #67 