### PR TITLE
PowInvitation extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Added `PowInvitation` extension
 * Added support in `Pow.Ecto.Schema` for Ecto associations fields
+* Added support for adding custom methods with `Pow.Extension.Ecto.Schema` through `__using__/1` macro in extension ecto schema module
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 
+* Added `PowInvitation` extension
 * Added support in `Pow.Ecto.Schema` for Ecto associations fields
 
 ### Bug fixes

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Pow is made so it's easy to extend the functionality with your own complimentary
 * [PowResetPassword](lib/extensions/reset_password/README.md)
 * [PowEmailConfirmation](lib/extensions/email_confirmation/README.md)
 * [PowPersistentSession](lib/extensions/persistent_session/README.md)
+* [PowInvitation](lib/extensions/invitation/README.md)
 
 ### Add extensions support
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -15,7 +15,7 @@ config :pow, Pow.Ecto.Schema.Password, iterations: 1
 
 config :phoenix, :json_library, Jason
 
-extension_test_modules = [PowEmailConfirmation, PowPersistentSession, PowResetPassword]
+extension_test_modules = [PowEmailConfirmation, PowInvitation, PowPersistentSession, PowResetPassword]
 
 for extension <- extension_test_modules do
   endpoint_module = Module.concat([extension, TestWeb.Phoenix.Endpoint])

--- a/config/test.exs
+++ b/config/test.exs
@@ -15,7 +15,7 @@ config :pow, Pow.Ecto.Schema.Password, iterations: 1
 
 config :phoenix, :json_library, Jason
 
-extension_test_modules = [PowEmailConfirmation, PowInvitation, PowPersistentSession, PowResetPassword]
+extension_test_modules = [PowEmailConfirmation, PowInvitation, PowEmailConfirmation.PowInvitation, PowPersistentSession, PowResetPassword]
 
 for extension <- extension_test_modules do
   endpoint_module = Module.concat([extension, TestWeb.Phoenix.Endpoint])

--- a/lib/extensions/email_confirmation/README.md
+++ b/lib/extensions/email_confirmation/README.md
@@ -29,3 +29,7 @@ To prevent the persistent session from being created when the email hasn't been 
 If you want your user to be automatically confirmed in test and seed, you just have to call: `PowEmailConfirmation.Ecto.Context.confirm_email(user, otp_app: :my_app)`
 
 You can also update or insert the row directly and set `email_confirmed_at: DateTime.utc_now()`.
+
+## Note on PowInvitation
+
+When a user is invited with [PowInvitation](../invitation/README.md), the email will only be required confirmed if the invited user decides to change their email when accepting the invitation.

--- a/lib/extensions/invitation/README.md
+++ b/lib/extensions/invitation/README.md
@@ -1,0 +1,82 @@
+# PowInvitation
+
+This extension will set up a basic invitation system where users can invite other users to join. If `:email` field exists on the user struct an e-mail is sent out with an invitation link. Otherwise a page with the invitation link is shown.
+
+Invited users are persisted in the database without a password. Only the user id will be validated when the user is invited, but `changeset/2` on your user schema will be used for when the user accepts the invitation.
+
+## Installation
+
+Follow the instructions for extensions in [README.md](../../../README.md), and set `PowInvitation` in the `:extensions` list.
+
+## Configuration
+
+There are numerous ways you can modify the invitation flow. Here's a few common setups to get your started.
+
+### Parent organization or team
+
+If your users belongs to a parent organization or team, you can set up the `invite_changeset/3` to carry over the id for invitations:
+
+```elixir
+defmodule MyApp.Users.User do
+  # ...
+
+  def invite_changeset(user_or_changeset, invited_by, attrs) do
+    user_or_changeset
+    |> pow_invite_changeset(attrs)
+    |> changeset_organization(invited_by, attrs)
+  end
+
+  defp changeset_organization(changeset, invited_by) do
+    Ecto.Changeset.change(changeset, organization_id: invited_by.organization_id)
+  end
+end
+```
+
+### Limit invitation based on role
+
+If you have different roles (e.g. [admin and user](../../../guides/USER_ROLES.md)), you can limit the type of user who can invite others by setting up a plug in your `router.ex`:
+
+```elixir
+defmodule MyAppWeb.Router do
+  use MyAppWeb, :router
+  # ...
+
+  pipeline :admin_role do
+    plug MyAppWeb.EnsureRolePlug, :admin
+  end
+
+  scope "/", MyAppWeb do
+    pipe_through [:browser, :authenticated, :admin_role]
+
+    resource "/invitations", PowInvitation.Phoenix.InvitationController, only: [:new, :create, :show]
+  end
+
+  # ... you would want `pow_routes/0` to be after
+end
+```
+
+### Limit registration
+
+If you wish to restrict signup to only invites, you can modify `router.ex` to exclude registration by using `pow_session_routes/0` in place of `pow_routes/0`:
+
+```elixir
+defmodule MyAppWeb.Router do
+  use MyAppWeb, :router
+  # ...
+
+  scope "/" do
+    pipe_through :browser
+
+    pow_session_routes()
+    pow_extension_routes()
+  end
+
+  # ...
+end
+```
+
+You would want to use custom template for the session controller, since by default it'll still have the link to registration.
+
+### Expire invited users
+
+Invited users will have a token set in the `:invitation_token` field and `:invitation_accepted_at` field set to nil. If you want to expire the invitation link you can run a background task to delete these users a certain time after `:inserted_at`.

--- a/lib/extensions/invitation/README.md
+++ b/lib/extensions/invitation/README.md
@@ -80,3 +80,7 @@ You would want to use custom template for the session controller, since by defau
 ### Expire invited users
 
 Invited users will have a token set in the `:invitation_token` field and `:invitation_accepted_at` field set to nil. If you want to expire the invitation link you can run a background task to delete these users a certain time after `:inserted_at`.
+
+## Note on PowEmailConfirmation
+
+[PowEmailConfirmation](../email_confirmation/README.md) will only require email confirmation if the invited user changes their email when accepting their invitation.

--- a/lib/extensions/invitation/ecto/context.ex
+++ b/lib/extensions/invitation/ecto/context.ex
@@ -11,10 +11,11 @@ defmodule PowInvitation.Ecto.Context do
   """
   @spec create(map(), map(), Config.t()) :: {:ok, map()} | {:error, Changeset.t()}
   def create(inviter_user, params, config) do
-    config
-    |> Context.user_schema_mod()
+    user_mod = Context.user_schema_mod(config)
+
+    user_mod
     |> struct()
-    |> Schema.invite_changeset(inviter_user, params)
+    |> user_mod.invite_changeset(inviter_user, params)
     |> Context.do_insert(config)
   end
 

--- a/lib/extensions/invitation/ecto/context.ex
+++ b/lib/extensions/invitation/ecto/context.ex
@@ -1,0 +1,45 @@
+defmodule PowInvitation.Ecto.Context do
+  @moduledoc false
+  use Pow.Extension.Ecto.Context.Base
+
+  alias Ecto.Changeset
+  alias Pow.Ecto.Context
+  alias PowInvitation.Ecto.Schema
+
+  @doc """
+  Creates an invited user
+  """
+  @spec create(map(), map(), Config.t()) :: {:ok, map()} | {:error, Changeset.t()}
+  def create(inviter_user, params, config) do
+    config
+    |> Context.user_schema_mod()
+    |> struct()
+    |> Schema.invite_changeset(inviter_user, params)
+    |> Context.do_insert(config)
+  end
+
+  @doc """
+  Updates an invited user and accepts invitation.
+  """
+  @spec update(map(), map(), Config.t()) :: {:ok, map()} | {:error, Changeset.t()}
+  def update(user, params, config) do
+    user
+    |> Schema.accept_invitation_changeset(params)
+    |> Context.do_update(config)
+  end
+
+  @doc """
+  Finds an invited user by the `invitation_token` column.
+
+  Ignores users with `:invitation_accepted_at` set.
+  """
+  @spec get_by_invitation_token(binary(), Config.t()) :: map() | nil
+  def get_by_invitation_token(token, config) do
+    [invitation_token: token]
+    |> Context.get_by(config)
+    |> case do
+      %{invitation_accepted_at: nil} = user -> user
+      _ -> nil
+    end
+  end
+end

--- a/lib/extensions/invitation/ecto/schema.ex
+++ b/lib/extensions/invitation/ecto/schema.ex
@@ -1,0 +1,66 @@
+defmodule PowInvitation.Ecto.Schema do
+  @moduledoc false
+  use Pow.Extension.Ecto.Schema.Base
+  alias Ecto.Changeset
+  alias Pow.UUID
+
+  @impl true
+  def attrs(_config) do
+    [
+      {:invitation_token, :string},
+      {:invitation_accepted_at, :utc_datetime}
+    ]
+  end
+
+  @impl true
+  def assocs(_config) do
+    [
+      {:belongs_to, :invited_by, :users},
+      {:has_many, :invited_users, :users, foreign_key: :invited_by_id}
+    ]
+  end
+
+  @impl true
+  def indexes(_config) do
+    [{:invitation_token, true}]
+  end
+
+  @spec invite_changeset(Ecto.Schema.t() | Changeset.t(), Ecto.Schema.t(), map()) :: Changeset.t()
+  def invite_changeset(%Changeset{data: %user_mod{}} = changeset, invited_by, attrs) do
+    changeset
+    |> user_mod.pow_user_id_field_changeset(attrs)
+    |> invitation_token_changeset()
+    |> invited_by_changeset(invited_by)
+  end
+  def invite_changeset(user, invited_by, attrs) do
+    user
+    |> Changeset.change()
+    |> invite_changeset(invited_by, attrs)
+  end
+
+  defp invitation_token_changeset(changeset) do
+    changeset
+    |> Changeset.put_change(:invitation_token, UUID.generate())
+    |> Changeset.unique_constraint(:invitation_token)
+  end
+
+  defp invited_by_changeset(%Changeset{data: data} = changeset, invited_by) do
+    data = Ecto.build_assoc(invited_by, :invited_users, data)
+
+    Changeset.assoc_constraint(%{changeset | data: data}, :invited_by)
+  end
+
+  @spec accept_invitation_changeset(Ecto.Schema.t() | Changeset.t(), map()) :: Changeset.t()
+  def accept_invitation_changeset(%Changeset{data: %user_mod{}} = changeset, attrs) do
+    accepted_at = Pow.Ecto.Schema.__timestamp_for__(user_mod, :invitation_accepted_at)
+
+    changeset
+    |> user_mod.changeset(attrs)
+    |> Changeset.change(invitation_accepted_at: accepted_at)
+  end
+  def accept_invitation_changeset(user, attrs) do
+    user
+    |> Changeset.change()
+    |> accept_invitation_changeset(attrs)
+  end
+end

--- a/lib/extensions/invitation/ecto/schema.ex
+++ b/lib/extensions/invitation/ecto/schema.ex
@@ -25,10 +25,21 @@ defmodule PowInvitation.Ecto.Schema do
     [{:invitation_token, true}]
   end
 
+  @doc false
+  defmacro __using__(_config) do
+    quote do
+      def invite_changeset(changeset, invited_by, attrs), do: pow_invite_changeset(changeset, invited_by, attrs)
+
+      defdelegate pow_invite_changeset(changeset, invited_by, attrs), to: unquote(__MODULE__), as: :invite_changeset
+
+      defoverridable invite_changeset: 3
+    end
+  end
+
   @spec invite_changeset(Ecto.Schema.t() | Changeset.t(), Ecto.Schema.t(), map()) :: Changeset.t()
-  def invite_changeset(%Changeset{data: %user_mod{}} = changeset, invited_by, attrs) do
+  def invite_changeset(%Changeset{data: user} = changeset, invited_by, attrs) do
     changeset
-    |> user_mod.pow_user_id_field_changeset(attrs)
+    |> user.__struct__.pow_user_id_field_changeset(attrs)
     |> invitation_token_changeset()
     |> invited_by_changeset(invited_by)
   end

--- a/lib/extensions/invitation/phoenix/controllers/invitation_controller.ex
+++ b/lib/extensions/invitation/phoenix/controllers/invitation_controller.ex
@@ -1,0 +1,122 @@
+defmodule PowInvitation.Phoenix.InvitationController do
+  @moduledoc false
+  use Pow.Extension.Phoenix.Controller.Base
+
+  alias Plug.Conn
+  alias PowInvitation.{Phoenix.Mailer, Plug}
+  alias Pow.Phoenix.{RegistrationController, SessionController}
+
+  plug :require_authenticated when action in [:new, :create, :show]
+  plug :require_not_authenticated when action in [:edit, :update]
+  plug :load_user_from_invitation_token when action in [:show, :edit, :update]
+  plug :assign_create_path when action in [:new, :create]
+  plug :assign_update_path when action in [:edit, :update]
+
+  @spec process_new(Conn.t(), map()) :: {:ok, map(), Conn.t()}
+  def process_new(conn, _params) do
+    {:ok, Plug.change_user(conn), conn}
+  end
+
+  @spec respond_new({:ok, map(), Conn.t()}) :: Conn.t()
+  def respond_new({:ok, changeset, conn}) do
+    conn
+    |> assign(:changeset, changeset)
+    |> render("new.html")
+  end
+
+  @spec process_create(Conn.t(), map()) :: {:ok | :error, map(), Conn.t()}
+  def process_create(conn, %{"user" => user_params}) do
+    Plug.create_user(conn, user_params)
+  end
+
+  @spec respond_create({:ok | :error, map(), Conn.t()}) :: Conn.t()
+  def respond_create({:ok, %{email: email} = user, conn}) when is_binary(email) do
+    deliver_email(conn, user)
+
+    conn
+    |> put_flash(:info, messages(conn).invitation_email_sent(conn))
+    |> redirect(to: routes(conn).path_for(conn, __MODULE__, :new))
+  end
+  def respond_create({:ok, user, conn}) do
+    redirect(conn, to: routes(conn).path_for(conn, __MODULE__, :show, [user.invitation_token]))
+  end
+  def respond_create({:error, changeset, conn}) do
+    conn
+    |> assign(:changeset, changeset)
+    |> render("new.html")
+  end
+
+  defp deliver_email(conn, user) do
+    url        = invitation_url(conn, user)
+    invited_by = Pow.Plug.current_user(conn)
+    email      = Mailer.invitation(conn, user, invited_by, url)
+
+    Pow.Phoenix.Mailer.deliver(conn, email)
+  end
+
+  defp invitation_url(conn, user) do
+    routes(conn).url_for(conn, __MODULE__, :edit, [user.invitation_token])
+  end
+
+  @spec process_show(Conn.t(), map()) :: {:ok, Conn.t()}
+  def process_show(conn, _params), do: {:ok, conn}
+
+  @spec respond_show({:ok, Conn.t()}) :: Conn.t()
+  def respond_show({:ok, %{assigns: %{invited_user: user}} = conn}) do
+    conn
+    |> assign(:url, invitation_url(conn, user))
+    |> render("show.html")
+  end
+
+  @spec process_edit(Conn.t(), map()) :: {:ok, map(), Conn.t()}
+  def process_edit(conn, _params) do
+    {:ok, Plug.change_user(conn), conn}
+  end
+
+  @spec respond_edit({:ok, map(), Conn.t()}) :: Conn.t()
+  def respond_edit({:ok, changeset, conn}) do
+    conn
+    |> assign(:changeset, changeset)
+    |> render("edit.html")
+  end
+
+  @spec process_update(Conn.t(), map()) :: {:ok | :error, map(), Conn.t()}
+  def process_update(conn, %{"user" => user_params}) do
+    Plug.update_user(conn, user_params)
+  end
+
+  @spec respond_update({:ok, map(), Conn.t()}) :: Conn.t()
+  def respond_update({:ok, _user, conn}) do
+    conn
+    |> put_flash(:info, RegistrationController.messages(conn).user_has_been_created(conn))
+    |> redirect(to: routes(conn).after_registration_path(conn))
+  end
+  def respond_update({:error, changeset, conn}) do
+    conn
+    |> assign(:changeset, changeset)
+    |> render("edit.html")
+  end
+
+  defp load_user_from_invitation_token(%{params: %{"id" => token}} = conn, _opts) do
+    case Plug.invited_user_from_token(conn, token) do
+      nil  ->
+        conn
+        |> put_flash(:error, messages(conn).invalid_invitation(conn))
+        |> redirect(to: routes(conn).path_for(conn, SessionController, :new))
+        |> halt()
+
+      user ->
+        Plug.assign_invited_user(conn, user)
+    end
+  end
+
+  defp assign_create_path(conn, _opts) do
+    path = routes(conn).path_for(conn, __MODULE__, :create)
+    Conn.assign(conn, :action, path)
+  end
+
+  defp assign_update_path(%{params: %{"id" => token}} = conn, _opts) do
+    path = routes(conn).path_for(conn, __MODULE__, :update, [token])
+    Conn.assign(conn, :action, path)
+  end
+end

--- a/lib/extensions/invitation/phoenix/mailers/mailer.ex
+++ b/lib/extensions/invitation/phoenix/mailers/mailer.ex
@@ -1,0 +1,13 @@
+defmodule PowInvitation.Phoenix.Mailer do
+  @moduledoc false
+  alias Plug.Conn
+  alias Pow.Phoenix.Mailer.Mail
+  alias PowInvitation.Phoenix.MailerView
+
+  @spec invitation(Conn.t(), map(), map(), binary()) :: Mail.t()
+  def invitation(conn, user, invited_by, url) do
+    invited_by_user_id = Map.get(invited_by, invited_by.__struct__.pow_user_id_field())
+
+    Mail.new(conn, user, {MailerView, :invitation}, invited_by: invited_by, invited_by_user_id: invited_by_user_id, url: url)
+  end
+end

--- a/lib/extensions/invitation/phoenix/mailers/mailer_template.ex
+++ b/lib/extensions/invitation/phoenix/mailers/mailer_template.ex
@@ -1,0 +1,19 @@
+defmodule PowInvitation.Phoenix.MailerTemplate do
+  @moduledoc false
+  use Pow.Phoenix.Mailer.Template
+
+  template :invitation,
+  "You've been invited",
+  """
+  Hi,
+
+  You've been invited by <%= @invited_by_user_id %>. Please use the following link to accept your invitation:
+
+  <%= @url %>
+  """,
+  """
+  <%= content_tag(:h3, "Hi,") %>
+  <%= content_tag(:p, "You've been invited by \#{@invited_by_user_id}. Please use the following link to accept your invitation:") %>
+  <%= content_tag(:p, link(@url, to: @url)) %>
+  """
+end

--- a/lib/extensions/invitation/phoenix/mailers/mailer_view.ex
+++ b/lib/extensions/invitation/phoenix/mailers/mailer_view.ex
@@ -1,0 +1,4 @@
+defmodule PowInvitation.Phoenix.MailerView do
+  @moduledoc false
+  use Pow.Phoenix.Mailer.View
+end

--- a/lib/extensions/invitation/phoenix/messages.ex
+++ b/lib/extensions/invitation/phoenix/messages.ex
@@ -1,0 +1,6 @@
+defmodule PowInvitation.Phoenix.Messages do
+  @moduledoc false
+
+  def invalid_invitation(_conn), do: "The invitation doesn't exist."
+  def invitation_email_sent(_conn), do: "An e-mail with invitation link has been sent."
+end

--- a/lib/extensions/invitation/phoenix/router.ex
+++ b/lib/extensions/invitation/phoenix/router.ex
@@ -1,0 +1,10 @@
+defmodule PowInvitation.Phoenix.Router do
+  @moduledoc false
+  use Pow.Extension.Phoenix.Router.Base
+
+  defmacro routes(_config) do
+    quote location: :keep do
+      resources "/invitations", InvitationController, only: [:new, :create, :show, :edit, :update]
+    end
+  end
+end

--- a/lib/extensions/invitation/phoenix/templates/invitation_templates.ex
+++ b/lib/extensions/invitation/phoenix/templates/invitation_templates.ex
@@ -1,0 +1,33 @@
+defmodule PowInvitation.Phoenix.InvitationTemplate do
+  @moduledoc false
+  use Pow.Phoenix.Template
+
+  template :new, :html,
+  """
+  <h1>Invite</h1>
+
+  <%= Pow.Phoenix.HTML.FormTemplate.render([
+    {:text, {:changeset, :pow_user_id_field}}
+  ]) %>
+  """
+
+  template :edit, :html,
+  """
+  <h1>Register</h1>
+
+  <%= Pow.Phoenix.HTML.FormTemplate.render([
+    {:text, {:changeset, :pow_user_id_field}},
+    {:password, :password},
+    {:password, :confirm_password}
+  ]) %>
+
+  <span><%%= link "Sign in", to: Routes.<%= Pow.Phoenix.Controller.route_helper(Pow.Phoenix.SessionController) %>_path(@conn, :new) %></span>
+  """
+
+  template :show, :html,
+  """
+  <h1>Invitation</h1>
+
+  <blockquote><%%= @url %></blockquote>
+  """
+end

--- a/lib/extensions/invitation/phoenix/views/invitation_view.ex
+++ b/lib/extensions/invitation/phoenix/views/invitation_view.ex
@@ -1,0 +1,4 @@
+defmodule PowInvitation.Phoenix.InvitationView do
+  @moduledoc false
+  use Pow.Phoenix.View
+end

--- a/lib/extensions/invitation/plug.ex
+++ b/lib/extensions/invitation/plug.ex
@@ -1,0 +1,80 @@
+defmodule PowInvitation.Plug do
+  @moduledoc """
+  Plug helper methods.
+  """
+  alias Plug.Conn
+  alias Pow.Plug
+  alias PowInvitation.Ecto.{Context, Schema}
+
+  @doc """
+  Creates a new invited user by the current user in the connection.
+  """
+  @spec create_user(Conn.t(), map()) :: {:ok, map(), Conn.t()} | {:error, map(), Conn.t()}
+  def create_user(conn, params) do
+    config = Plug.fetch_config(conn)
+
+    conn
+    |> Plug.current_user()
+    |> Context.create(params, config)
+    |> case do
+      {:ok, user}         -> {:ok, user, conn}
+      {:error, changeset} -> {:error, changeset, conn}
+    end
+  end
+
+  @doc """
+  Creates a changeset from the user fetched in the connection.
+  """
+  @spec change_user(Conn.t(), map()) :: map()
+  def change_user(conn, params \\ %{}) do
+    conn
+    |> invited_user()
+    |> Kernel.||(user_struct(conn))
+    |> Schema.accept_invitation_changeset(params)
+  end
+
+  defp user_struct(conn) do
+    conn
+    |> Plug.fetch_config()
+    |> Context.user_schema_mod()
+    |> struct()
+  end
+
+  @doc """
+  Updates current user in the connection with the params.
+
+  If successful the session will be regenerated.
+  """
+  @spec update_user(Conn.t(), map()) :: {:ok, map(), Conn.t()} | {:error, map(), Conn.t()}
+  def update_user(conn, params) do
+    config = Plug.fetch_config(conn)
+
+    conn
+    |> invited_user()
+    |> Context.update(params, config)
+    |> case do
+      {:ok, user}         -> {:ok, user, Plug.get_mod(config).do_create(conn, user, config)}
+      {:error, changeset} -> {:error, changeset, conn}
+    end
+  end
+
+  defp invited_user(conn), do: conn.assigns[:invited_user]
+
+  @doc """
+  Fetches invited user by the invitation token.
+  """
+  @spec invited_user_from_token(Conn.t(), binary()) :: map() | nil
+  def invited_user_from_token(conn, token) do
+    config = Plug.fetch_config(conn)
+
+    Context.get_by_invitation_token(token, config)
+  end
+
+  @doc """
+  Assigns a `:invited_user` key with the user in the connection.
+  """
+  @spec assign_invited_user(Conn.t(), map()) :: Conn.t()
+  def assign_invited_user(conn, user) do
+    Conn.assign(conn, :invited_user, user)
+  end
+end

--- a/lib/pow/extension/ecto/schema.ex
+++ b/lib/pow/extension/ecto/schema.ex
@@ -43,11 +43,25 @@ defmodule Pow.Extension.Ecto.Schema do
     quote do
       @pow_extension_config Config.merge(@pow_config, unquote(config))
 
+      Module.eval_quoted(__MODULE__, unquote(__MODULE__).__use_extensions__(@pow_extension_config))
+
       unquote(__MODULE__).__register_extension_fields__()
       unquote(__MODULE__).__register_extension_assocs__()
       unquote(__MODULE__).__pow_extension_methods__()
       unquote(__MODULE__).__register_after_compile_validation__()
     end
+  end
+
+  @doc false
+  def __use_extensions__(config) do
+    config
+    |> schema_modules()
+    |> Enum.filter(&Kernel.macro_exported?(&1, :__using__, 1))
+    |> Enum.map(fn module ->
+      quote do
+        use unquote(module), unquote(config)
+      end
+    end)
   end
 
   @doc false

--- a/mix.exs
+++ b/mix.exs
@@ -104,6 +104,10 @@ defmodule Pow.MixProject do
           filename: "PowEmailConfirmation",
           title: "PowEmailConfirmation"
         ],
+        "lib/extensions/invitation/README.md": [
+          filename: "PowInvitation",
+          title: "PowInvitation"
+        ],
         "lib/extensions/persistent_session/README.md": [
           filename: "PowPersistentSession",
           title: "PowPersistentSession"

--- a/test/extensions/invitation/ecto/context_test.exs
+++ b/test/extensions/invitation/ecto/context_test.exs
@@ -1,0 +1,19 @@
+defmodule PowInvitation.Ecto.ContextTest do
+  use Pow.Test.Ecto.TestCase
+  doctest PowInvitation.Ecto.Context
+
+  alias PowInvitation.Ecto.Context
+  alias PowInvitation.Test.{RepoMock, Users.User}
+
+  @config [repo: RepoMock, user: User]
+
+  describe "get_by_invitation_token/2" do
+    test "gets when :invitation_accepted_at is nil" do
+      assert Context.get_by_invitation_token("valid", @config)
+    end
+
+    test "nil when :invitation_accepted_at is not nil" do
+      refute Context.get_by_invitation_token("valid_but_accepted", @config)
+    end
+  end
+end

--- a/test/extensions/invitation/ecto/schema_test.exs
+++ b/test/extensions/invitation/ecto/schema_test.exs
@@ -1,0 +1,60 @@
+defmodule PowInvitation.Ecto.SchemaTest do
+  use ExUnit.Case
+  doctest PowInvitation.Ecto.Schema
+
+  alias PowInvitation.Ecto.Schema
+  alias PowInvitation.Test.Users.User
+
+  test "user_schema/1" do
+    user = %User{}
+
+    assert Map.has_key?(user, :invitation_token)
+    assert Map.has_key?(user, :invitation_accepted_at)
+    assert Map.has_key?(user, :invited_by)
+    assert Map.has_key?(user, :invited_users)
+  end
+
+  describe "invite_changeset/3" do
+    @valid_params %{email: "test@example.com"}
+    @invited_by %User{id: 1}
+    @invalid_params %{email: "foo"}
+
+    test "with valid params" do
+      changeset = Schema.invite_changeset(%User{}, @invited_by, @valid_params)
+
+      assert changeset.valid?
+      assert changeset.changes.email == "test@example.com"
+      assert changeset.changes.invitation_token
+      assert changeset.data.invited_by_id == @invited_by.id
+    end
+
+    test "with invalid params" do
+      changeset = Schema.invite_changeset(%User{}, @invited_by, @invalid_params)
+
+      refute changeset.valid?
+      assert changeset.errors[:email]
+    end
+  end
+
+  describe "accept_invitation_changeset/2" do
+    @password "password12"
+    @valid_params %{email: "test@example.com", password: @password, confirm_password: @password}
+    @invalid_params %{email: "foo"}
+
+    test "with valid params" do
+      changeset = Schema.accept_invitation_changeset(%User{}, @valid_params)
+
+      assert changeset.valid?
+      assert changeset.changes.email == "test@example.com"
+      assert changeset.changes.invitation_accepted_at
+    end
+
+    test "with invalid params" do
+      changeset = Schema.accept_invitation_changeset(%User{}, @invalid_params)
+
+      refute changeset.valid?
+      assert changeset.errors[:email]
+      assert changeset.errors[:password]
+    end
+  end
+end

--- a/test/extensions/invitation/ecto/schema_test.exs
+++ b/test/extensions/invitation/ecto/schema_test.exs
@@ -4,6 +4,7 @@ defmodule PowInvitation.Ecto.SchemaTest do
 
   alias PowInvitation.Ecto.Schema
   alias PowInvitation.Test.Users.User
+  alias PowInvitation.PowEmailConfirmation.Test.Users.User, as: UserEmailConfirmation
 
   test "user_schema/1" do
     user = %User{}
@@ -55,6 +56,22 @@ defmodule PowInvitation.Ecto.SchemaTest do
       refute changeset.valid?
       assert changeset.errors[:email]
       assert changeset.errors[:password]
+    end
+
+    test "with PowEmailConfirmation extension" do
+      user = Ecto.put_meta(%UserEmailConfirmation{email: "test@example.com"}, state: :loaded)
+
+      changeset = Schema.accept_invitation_changeset(user, @valid_params)
+
+      assert changeset.valid?
+      refute changeset.changes[:email_confirmation_token]
+      refute changeset.changes[:unconfirmed_email]
+
+      changeset = Schema.accept_invitation_changeset(user, %{@valid_params | email: "new@example.com"})
+
+      assert changeset.valid?
+      assert changeset.changes[:email_confirmation_token]
+      assert changeset.changes[:unconfirmed_email] == "new@example.com"
     end
   end
 end

--- a/test/extensions/invitation/phoenix/controllers/invitation_controller_test.exs
+++ b/test/extensions/invitation/phoenix/controllers/invitation_controller_test.exs
@@ -1,0 +1,172 @@
+defmodule PowInvitation.Phoenix.InvitationControllerTest do
+  use PowInvitation.TestWeb.Phoenix.ConnCase
+
+  alias PowInvitation.Test.Users.User
+
+  @user %User{id: 1, email: "test@example.com"}
+  @url_regex ~r/http:\/\/localhost\/invitations\/[a-z0-9\-]*\/edit/
+
+  describe "new/2" do
+    test "not signed in", %{conn: conn} do
+      conn = get(conn, Routes.pow_invitation_invitation_path(conn, :new))
+
+      assert_not_authenticated_redirect(conn)
+    end
+
+    test "shows", %{conn: conn} do
+      conn =
+        conn
+        |> Pow.Plug.assign_current_user(@user, [])
+        |> get(Routes.pow_invitation_invitation_path(conn, :new))
+
+      assert html = html_response(conn, 200)
+      assert html =~ "<label for=\"user_email\">Email</label>"
+      assert html =~ "<input id=\"user_email\" name=\"user[email]\" type=\"text\">"
+    end
+  end
+
+  describe "create/2" do
+    @valid_params %{"user" => %{"email" => "test@example.com"}}
+    @invalid_params %{"user" => %{"email" => "invalid"}}
+    @valid_params_no_email %{"user" => %{"email" => :no_email}}
+
+    test "not signed in", %{conn: conn} do
+      conn = post(conn, Routes.pow_invitation_invitation_path(conn, :create, @valid_params))
+
+      assert_not_authenticated_redirect(conn)
+    end
+
+    test "with valid params", %{conn: conn} do
+      conn =
+        conn
+        |> Pow.Plug.assign_current_user(@user, [])
+        |> post(Routes.pow_invitation_invitation_path(conn, :create, @valid_params))
+
+      assert_received {:mail_mock, mail}
+
+      assert mail.subject == "You've been invited"
+      assert mail.text =~ "You've been invited by #{@user.email}."
+      assert mail.text =~ @url_regex
+      assert mail.html =~ "<p>You&#39;ve been invited by #{@user.email}."
+      assert mail.html =~ @url_regex
+
+      assert redirected_to(conn) == Routes.pow_invitation_invitation_path(conn, :new)
+      assert get_flash(conn, :info) == "An e-mail with invitation link has been sent."
+    end
+
+    test "with invalid params", %{conn: conn} do
+      conn =
+        conn
+        |> Pow.Plug.assign_current_user(@user, [])
+        |> post(Routes.pow_invitation_invitation_path(conn, :create, @invalid_params))
+
+      assert html = html_response(conn, 200)
+      assert html =~ "<label for=\"user_email\">Email</label>"
+      assert html =~ "<input id=\"user_email\" name=\"user[email]\" type=\"text\" value=\"invalid\">"
+      assert html =~ "<span class=\"help-block\">has invalid format</span>"
+    end
+
+    test "user with no email", %{conn: conn} do
+      conn =
+        conn
+        |> Pow.Plug.assign_current_user(@user, [])
+        |> post(Routes.pow_invitation_invitation_path(conn, :create, @valid_params_no_email))
+
+      refute_received {:mail_mock, _mail}
+
+      assert redirected_to(conn) == Routes.pow_invitation_invitation_path(conn, :show, "valid")
+    end
+  end
+
+  describe "show/2" do
+    test "not signed in", %{conn: conn} do
+      conn = get(conn, Routes.pow_invitation_invitation_path(conn, :show, "valid"))
+
+      assert_not_authenticated_redirect(conn)
+    end
+
+    test "shows", %{conn: conn} do
+      conn =
+        conn
+        |> Pow.Plug.assign_current_user(@user, [])
+        |> get(Routes.pow_invitation_invitation_path(conn, :show, "valid"))
+
+      assert html = html_response(conn, 200)
+      assert html =~ @url_regex
+    end
+  end
+
+  describe "edit/2" do
+    test "already signed in", %{conn: conn} do
+      conn =
+        conn
+        |> Pow.Plug.assign_current_user(@user, [])
+        |> get(Routes.pow_invitation_invitation_path(conn, :edit, "valid"))
+
+      assert_authenticated_redirect(conn)
+    end
+
+    test "invalid invitation token", %{conn: conn} do
+      conn = get conn, Routes.pow_invitation_invitation_path(conn, :edit, "invalid")
+
+      assert redirected_to(conn) == Routes.pow_session_path(conn, :new)
+      assert get_flash(conn, :error) == "The invitation doesn't exist."
+    end
+
+    test "shows", %{conn: conn} do
+      conn = get conn, Routes.pow_invitation_invitation_path(conn, :edit, "valid")
+
+      assert html = html_response(conn, 200)
+      assert html =~ "<label for=\"user_email\">Email</label>"
+      assert html =~ "<input id=\"user_email\" name=\"user[email]\" type=\"text\" value=\"test@example.com\">"
+      assert html =~ "<label for=\"user_password\">Password</label>"
+      assert html =~ "<input id=\"user_password\" name=\"user[password]\" type=\"password\">"
+      assert html =~ "<label for=\"user_confirm_password\">Confirm password</label>"
+      assert html =~ "<input id=\"user_confirm_password\" name=\"user[confirm_password]\" type=\"password\">"
+      assert html =~ "<button type=\"submit\">Submit</button>"
+    end
+  end
+
+  describe "update/2" do
+    @password "password1234"
+    @valid_params %{"user" => %{"email" => "test@example.com", "password" => @password, "confirm_password" => @password}}
+    @invalid_params %{"user" => %{"email" => "invalid", "password" => @password, "confirm_password" => "invalid"}}
+
+    test "already signed in", %{conn: conn} do
+      conn =
+        conn
+        |> Pow.Plug.assign_current_user(@user, [])
+        |> put(Routes.pow_invitation_invitation_path(conn, :update, "valid", @valid_params))
+
+      assert_authenticated_redirect(conn)
+    end
+
+    test "invalid invitation", %{conn: conn} do
+      conn = put conn, Routes.pow_invitation_invitation_path(conn, :update, "invalid", @valid_params)
+
+      assert redirected_to(conn) == Routes.pow_session_path(conn, :new)
+      assert get_flash(conn, :error) == "The invitation doesn't exist."
+    end
+
+    test "with valid params", %{conn: conn} do
+      conn = put conn, Routes.pow_invitation_invitation_path(conn, :update, "valid", @valid_params)
+
+      assert redirected_to(conn) == "/"
+      assert get_flash(conn, :info) == "user_created"
+      assert conn.private[:plug_session]["auth"]
+    end
+
+    test "with invalid params", %{conn: conn} do
+      conn = put conn, Routes.pow_invitation_invitation_path(conn, :update, "valid", @invalid_params)
+
+      assert html = html_response(conn, 200)
+      assert html =~ "<label for=\"user_email\">Email</label>"
+      assert html =~ "<input id=\"user_email\" name=\"user[email]\" type=\"text\" value=\"invalid\">"
+      assert html =~ "<span class=\"help-block\">has invalid format</span>"
+      assert html =~ "<label for=\"user_password\">Password</label>"
+      assert html =~ "<input id=\"user_password\" name=\"user[password]\" type=\"password\">"
+      assert html =~ "<span class=\"help-block\">not same as password</span>"
+      refute conn.private[:plug_session]["auth"]
+    end
+  end
+end

--- a/test/pow/extension/ecto/schema_test.exs
+++ b/test/pow/extension/ecto/schema_test.exs
@@ -28,6 +28,12 @@ defmodule Pow.Test.Extension.Ecto.Schema.Ecto.Schema do
       _       -> changeset
     end
   end
+
+  defmacro __using__(_config) do
+    quote do
+      def custom_method(), do: true
+    end
+  end
 end
 
 defmodule Pow.Test.Extension.Ecto.Schema.User do
@@ -100,6 +106,11 @@ defmodule Pow.Extension.Ecto.SchemaTest do
     changeset = User.changeset(%User{}, Map.put(@valid_params, "custom", "error"))
     refute changeset.valid?
     assert changeset.errors[:custom] == {"custom error", []}
+  end
+
+  test "has custom method definitions" do
+    assert Kernel.function_exported?(User, :custom_method, 0)
+    assert User.custom_method()
   end
 
   test "validates attributes" do

--- a/test/support/extensions/email_confirmation/pow.ex
+++ b/test/support/extensions/email_confirmation/pow.ex
@@ -2,4 +2,15 @@ defmodule PowEmailConfirmation.Test do
   @moduledoc false
   use Pow.Test.ExtensionMocks,
     extensions: [PowEmailConfirmation]
+
+  extensions = [PowEmailConfirmation, PowInvitation]
+  context    = PowEmailConfirmation.PowInvitation.Test
+  config =
+    @config
+    |> Keyword.put(:extensions, extensions)
+    |> Keyword.put(:user, Module.concat([context, Users.User]))
+    |> Keyword.put(:repo, __MODULE__.RepoMock.Invitation)
+
+  Pow.Test.ExtensionMocks.__user_schema__(context, extensions)
+  Pow.Test.ExtensionMocks.__phoenix_endpoint__(String.to_atom("#{context}Web"), config, [])
 end

--- a/test/support/extensions/email_confirmation/repo_mock.ex
+++ b/test/support/extensions/email_confirmation/repo_mock.ex
@@ -53,4 +53,15 @@ defmodule PowEmailConfirmation.Test.RepoMock do
   end
 
   def get!(User, 1), do: Process.get({:user, 1})
+
+  defmodule Invitation do
+    alias PowEmailConfirmation.Test.RepoMock
+    alias PowEmailConfirmation.PowInvitation.Test.Users.User
+
+    def get_by(User, invitation_token: "token"), do: Ecto.put_meta(%User{id: 1, email: "test@example.com"}, state: :loaded)
+
+    def update(changeset), do: RepoMock.update(changeset)
+
+    def get!(User, 1), do: Process.get({:user, 1})
+  end
 end

--- a/test/support/extensions/invitation/pow.ex
+++ b/test/support/extensions/invitation/pow.ex
@@ -1,0 +1,5 @@
+defmodule PowInvitation.Test do
+  @moduledoc false
+  use Pow.Test.ExtensionMocks,
+    extensions: [PowInvitation]
+end

--- a/test/support/extensions/invitation/pow.ex
+++ b/test/support/extensions/invitation/pow.ex
@@ -2,4 +2,6 @@ defmodule PowInvitation.Test do
   @moduledoc false
   use Pow.Test.ExtensionMocks,
     extensions: [PowInvitation]
+
+  Pow.Test.ExtensionMocks.__user_schema__(PowInvitation.PowEmailConfirmation.Test, [PowInvitation, PowEmailConfirmation])
 end

--- a/test/support/extensions/invitation/repo_mock.ex
+++ b/test/support/extensions/invitation/repo_mock.ex
@@ -1,0 +1,33 @@
+defmodule PowInvitation.Test.RepoMock do
+  @moduledoc false
+
+  alias PowInvitation.Test.Users.User
+
+  @user %User{id: 1, email: "test@example.com"}
+
+  def insert(%{valid?: true} = changeset) do
+    user = %{Ecto.Changeset.apply_changes(changeset) | id: 1}
+
+    # We store the user in the process because the user is force reloaded with `get!/2`
+    Process.put({:user, 1}, user)
+
+    {:ok, user}
+  end
+  def insert(%{changes: %{email: "no_email"}} = changeset) do
+    changeset
+    |> Map.put(:valid?, true)
+    |> Ecto.Changeset.put_change(:email, nil)
+    |> Ecto.Changeset.put_change(:invitation_token, "valid")
+    |> insert()
+  end
+  def insert(%{valid?: false} = changeset), do: {:error, %{changeset | action: :insert}}
+
+  def get!(User, 1), do: Process.get({:user, 1})
+
+  def get_by(User, [invitation_token: "valid"]), do: %{@user | invitation_token: "valid"}
+  def get_by(User, [invitation_token: "valid_but_accepted"]), do: %{@user | invitation_accepted_at: :now}
+  def get_by(User, [invitation_token: "invalid"]), do: nil
+
+  def update(%{valid?: true} = changeset), do: {:ok, Ecto.Changeset.apply_changes(changeset)}
+  def update(%{valid?: false} = changeset), do: {:error, %{changeset | action: :update}}
+end

--- a/test/support/extensions/mocks.ex
+++ b/test/support/extensions/mocks.ex
@@ -182,7 +182,8 @@ defmodule Pow.Test.ExtensionMocks do
       use Pow.Extension.Phoenix.Messages,
         extensions: unquote(extensions)
 
-        def signed_in(_conn), do: "signed_in"
+      def signed_in(_conn), do: "signed_in"
+      def user_has_been_created(_conn), do: "user_created"
     end
 
     Module.create(module, quoted, Macro.Env.location(__ENV__))


### PR DESCRIPTION
Resolves #99

The most common use case is teams/organizations where an admin user wish to invite other users. By default this extension will be built to allow a single user to invite any other user by assigning a user id. When invited, a user will be created with only user id, inviter user and invitation token set. The invitation token will be used to link to the sign up page, where a user can update their username and password to activate the account.

If a developer wish to associate the new user to the same team, they would only be required to pull the team id from the inviter user in a custom `invite_changeset/3` method. Likewise roles can be managed this way (and customizing the template too).

Developers would also be able to restrict the number of users that can be invited this way. They would need to customize the template, and add a custom validation in the `invite_changeset/3` method.

PowAssent probably also needs to be updated to handle invited users.

This is working right now. To test it, set it up like all other extensions, log in and then go to `http://localhost:4000/invitations/new`.