### PR TITLE
Deprecate `:messages_backend_fallback` for extension controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.0.3 (TBA)
 
 * Deprecated `Pow.Extension.Config.underscore_extension/1`
+* Deprecated `:messages_backend_fallback` setting for extension controllers
 * Removed deprecated macro `router_helpers/1` in `Pow.Phoenix.Controller`
 * Fixed bug in `Pow.Extension.Phoenix.Router.Base` and `Pow.Extension.Phoenix.Messages` where the full extension name wasn't used to namespace methods
 

--- a/lib/extensions/email_confirmation/phoenix/controllers/confirmation_controller.ex
+++ b/lib/extensions/email_confirmation/phoenix/controllers/confirmation_controller.ex
@@ -1,7 +1,6 @@
 defmodule PowEmailConfirmation.Phoenix.ConfirmationController do
   @moduledoc false
-  use Pow.Extension.Phoenix.Controller.Base,
-    messages_backend_fallback: PowEmailConfirmation.Phoenix.Messages
+  use Pow.Extension.Phoenix.Controller.Base
 
   alias Plug.Conn
   alias PowEmailConfirmation.Plug

--- a/lib/extensions/email_confirmation/phoenix/controllers/controller_callbacks.ex
+++ b/lib/extensions/email_confirmation/phoenix/controllers/controller_callbacks.ex
@@ -23,7 +23,7 @@ defmodule PowEmailConfirmation.Phoenix.ControllerCallbacks do
   def before_respond(Pow.Phoenix.RegistrationController, :update, {:ok, user, conn}, _config) do
     case should_send_email?(user, conn.private[:pow_user_before_update]) do
       true  ->
-        error = ConfirmationController.messages(conn).email_confirmation_required_for_update(conn)
+        error = messages(conn).email_confirmation_required_for_update(conn)
         conn  = Phoenix.Controller.put_flash(conn, :error, error)
 
         send_confirmation_email(user, conn)
@@ -42,8 +42,8 @@ defmodule PowEmailConfirmation.Phoenix.ControllerCallbacks do
     send_confirmation_email(user, conn)
 
     {:ok, conn} = Plug.clear_authenticated_user(conn)
-    error       = ConfirmationController.messages(conn).email_confirmation_required(conn)
-    path        = ConfirmationController.routes(conn).session_path(conn, :new)
+    error       = messages(conn).email_confirmation_required(conn)
+    path        = routes(conn).session_path(conn, :new)
     conn        =
       conn
       |> Phoenix.Controller.put_flash(:error, error)
@@ -56,7 +56,7 @@ defmodule PowEmailConfirmation.Phoenix.ControllerCallbacks do
   @spec send_confirmation_email(map(), Conn.t()) :: any()
   def send_confirmation_email(user, conn) do
     token = user.email_confirmation_token
-    url   = ConfirmationController.routes(conn).url_for(conn, ConfirmationController, :show, [token])
+    url   = routes(conn).url_for(conn, ConfirmationController, :show, [token])
     email = Mailer.email_confirmation(conn, user, url)
 
     Pow.Phoenix.Mailer.deliver(conn, email)

--- a/lib/extensions/reset_password/phoenix/controllers/reset_password_controller.ex
+++ b/lib/extensions/reset_password/phoenix/controllers/reset_password_controller.ex
@@ -1,7 +1,6 @@
 defmodule PowResetPassword.Phoenix.ResetPasswordController do
   @moduledoc false
-  use Pow.Extension.Phoenix.Controller.Base,
-    messages_backend_fallback: PowResetPassword.Phoenix.Messages
+  use Pow.Extension.Phoenix.Controller.Base
 
   alias Plug.Conn
   alias PowResetPassword.{Phoenix.Mailer, Plug}

--- a/lib/pow/extension/phoenix/controllers/controller/base.ex
+++ b/lib/pow/extension/phoenix/controllers/controller/base.ex
@@ -5,27 +5,66 @@ defmodule Pow.Extension.Phoenix.Controller.Base do
   ## Usage
 
       defmodule MyPowExtension.Phoenix.CustomController do
-        use Pow.Extension.Phoenix.Controller.Base,
-          messages_backend_fallback: MyPowExtension.Phoenix.Messages
+        use Pow.Extension.Phoenix.Controller.Base
 
         # ...
       end
   """
-  alias Pow.{Config, Phoenix.Controller}
+  alias Pow.{Config, Phoenix.Controller, Phoenix.Routes}
 
   @doc false
   defmacro __using__(config) do
     quote do
       use Controller, unquote(config)
 
-      @messages_fallback Config.get(unquote(config), :messages_backend_fallback)
+      unquote(__MODULE__).__define_helper_methods__(unquote(config))
+    end
+  end
 
-      def messages(conn) do
-        case Controller.messages(conn, @messages_fallback) do
-          @messages_fallback -> @messages_fallback
-          messages -> Module.concat([messages, @messages_fallback])
-        end
-      end
+  @doc false
+  defmacro __define_helper_methods__(config) do
+    quote do
+      @messages_fallback unquote(__MODULE__).__messages_fallback__(unquote(config), __MODULE__, __ENV__)
+
+      @doc false
+      def messages(conn), do: unquote(__MODULE__).__messages_module__(conn, @messages_fallback)
+
+      @doc false
+      def routes(conn), do: Controller.routes(conn, Routes)
+    end
+  end
+
+  @doc false
+  def __messages_module__(conn, fallback) do
+    case Controller.messages(conn, fallback) do
+      ^fallback -> fallback
+      messages  -> Module.concat([messages, fallback])
+    end
+  end
+
+  @doc false
+  def __messages_fallback__(module) do
+    [_controller | base] =
+      module
+      |> Module.split()
+      |> Enum.reverse()
+
+    [Messages]
+    |> Enum.concat(base)
+    |> Enum.reverse()
+    |> Module.concat()
+  end
+
+  # TODO: Remove config fallback by 1.1.0
+  def __messages_fallback__(config, module, env) do
+    case Config.get(config, :messages_backend_fallback) do
+      nil    ->
+        __messages_fallback__(module)
+
+      module ->
+        IO.warn("Passing `:messages_backend_fallback` is deprecated", Macro.Env.stacktrace(env))
+
+        module
     end
   end
 end

--- a/lib/pow/extension/phoenix/controllers/controller_callbacks/base.ex
+++ b/lib/pow/extension/phoenix/controllers/controller_callbacks/base.ex
@@ -12,11 +12,15 @@ defmodule Pow.Extension.Phoenix.ControllerCallbacks.Base do
         end
       end
   """
-  alias Pow.Config
+  alias Pow.{Config, Extension.Phoenix.Controller.Base}
 
   @doc false
-  defmacro __using__(_opts) do
+  defmacro __using__(config) do
     quote do
+      import Base, only: [__define_helper_methods__: 1]
+
+      __define_helper_methods__(unquote(config))
+
       @before_compile unquote(__MODULE__)
     end
   end


### PR DESCRIPTION
There isn't a good reason for having that configuration, since the extension phoenix messages module is always expected to be set up the same way.

This also includes some refactoring of controller callback, and making them have access to the same `messages/1` and `routes/1` module like controllers.