### PR TITLE
Email confirmation redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Added support in `Pow.Ecto.Schema` for Ecto associations fields
 * Added support for adding custom methods with `Pow.Extension.Ecto.Schema` through `__using__/1` macro in extension ecto schema module
 * Help information raised with invalid schema arguments for `pow.install`, `pow.ecto.install`, `pow.ecto.gen.migration`, and `pow.ecto.gen.schema` mix tasks
+* `PowEmailConfirmation` now redirects unconfirmed users to `after_registration_path/1` or `after_sign_in_path/1` rather than `pow_session_path(conn, :new)`
 
 ### Bug fixes
 

--- a/lib/extensions/email_confirmation/README.md
+++ b/lib/extensions/email_confirmation/README.md
@@ -2,7 +2,9 @@
 
 This extension will send an e-mail confirmation link when the user registers, and when the user changes their e-mail. It requires that the user schema has an `:email` field.
 
-Users won't be signed in when they register, and can't sign in until the e-mail has been confirmed. The confirmation e-mail will be sent every time the sign in fails. When users are already registered, the e-mail won't be changed for a user until the user has clicked the e-mail confirmation link.
+Users won't be signed in when they register, and can't sign in until the e-mail has been confirmed. The confirmation e-mail will be sent every time the sign in fails. The user will be redirected to `after_registration_path/1` and `after_sign_in_path/1` accordingly.
+
+When users are already registered, the e-mail won't be changed for a user until the user has clicked the e-mail confirmation link.
 
 ## Installation
 

--- a/test/extensions/email_confirmation/phoenix/controllers/controller_callbacks_test.exs
+++ b/test/extensions/email_confirmation/phoenix/controllers/controller_callbacks_test.exs
@@ -13,7 +13,7 @@ defmodule PowEmailConfirmation.Phoenix.ControllerCallbacksTest do
       conn = post conn, Routes.pow_session_path(conn, :create, %{"user" => @valid_params})
 
       assert get_flash(conn, :error) == "You'll need to confirm your e-mail before you can sign in. An e-mail confirmation link has been sent to you."
-      assert redirected_to(conn) == Routes.pow_session_path(conn, :new)
+      assert redirected_to(conn) == "/"
 
       refute Plug.current_user(conn)
 
@@ -38,7 +38,7 @@ defmodule PowEmailConfirmation.Phoenix.ControllerCallbacksTest do
       conn = post conn, Routes.pow_registration_path(conn, :create, @valid_params)
 
       assert get_flash(conn, :error) == "You'll need to confirm your e-mail before you can sign in. An e-mail confirmation link has been sent to you."
-      assert redirected_to(conn) == Routes.pow_session_path(conn, :new)
+      assert redirected_to(conn) == "/"
 
       refute Plug.current_user(conn)
 


### PR DESCRIPTION
Resolves #117 

Use `after_registration_path/1` and `after_sign_in_path/1`