### PR TITLE
Use provided schema name in printed instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v1.0.3 (TBA)
 
+* Correct shell instructions for `mix pow.install` task with custom schema
 * Deprecated `Pow.Extension.Config.underscore_extension/1`
 * Deprecated `:messages_backend_fallback` setting for extension controllers
 * Removed deprecated macro `router_helpers/1` in `Pow.Phoenix.Controller`

--- a/lib/mix/pow.ex
+++ b/lib/mix/pow.ex
@@ -94,6 +94,14 @@ defmodule Mix.Pow do
     do: config
 
   @doc """
+  Parses arguments into schema name and schema plural.
+  """
+  @spec schema_options_from_args([binary()]) :: map()
+  def schema_options_from_args(_opts \\ [])
+  def schema_options_from_args([schema_name, schema_plural | _rest]), do: %{schema_name: schema_name, schema_plural: schema_plural}
+  def schema_options_from_args(_any), do: %{schema_name: "Users.User", schema_plural: "users"}
+
+  @doc """
   Fetches context app for the project.
   """
   @spec context_app :: atom() | no_return

--- a/lib/mix/tasks/ecto/pow.ecto.gen.migration.ex
+++ b/lib/mix/tasks/ecto/pow.ecto.gen.migration.ex
@@ -29,13 +29,9 @@ defmodule Mix.Tasks.Pow.Ecto.Gen.Migration do
   end
 
   defp parse({config, parsed, _invalid}) do
-    case parsed do
-      [_schema_name, schema_plural | _rest] ->
-        Map.merge(config, %{schema_plural: schema_plural})
-
-      _ ->
-        config
-    end
+    parsed
+    |> Pow.schema_options_from_args()
+    |> Map.merge(config)
   end
 
   defp create_migrations_files(config, args) do
@@ -46,9 +42,8 @@ defmodule Mix.Tasks.Pow.Ecto.Gen.Migration do
     |> Enum.each(&create_migration_files/1)
   end
 
-  defp create_migration_files(%{repo: repo, binary_id: binary_id} = config) do
+  defp create_migration_files(%{repo: repo, binary_id: binary_id, schema_plural: schema_plural}) do
     context_base  = Pow.context_base(Pow.context_app())
-    schema_plural = Map.get(config, :schema_plural, "users")
     schema        = SchemaMigration.new(context_base, schema_plural, repo: repo, binary_id: binary_id)
     content       = SchemaMigration.gen(schema)
 

--- a/lib/mix/tasks/ecto/pow.ecto.gen.schema.ex
+++ b/lib/mix/tasks/ecto/pow.ecto.gen.schema.ex
@@ -29,20 +29,14 @@ defmodule Mix.Tasks.Pow.Ecto.Gen.Schema do
   end
 
   defp parse({config, parsed, _invalid}) do
-    case parsed do
-      [schema_name, schema_plural | _rest] ->
-        Map.merge(config, %{schema_name: schema_name, schema_plural: schema_plural})
-
-      _ ->
-        config
-    end
+    parsed
+    |> Pow.schema_options_from_args()
+    |> Map.merge(config)
   end
 
-  defp create_schema_file(%{binary_id: binary_id} = config) do
+  defp create_schema_file(%{binary_id: binary_id, schema_name: schema_name, schema_plural: schema_plural} = config) do
     context_app   = Map.get(config, :context_app, Pow.context_app())
     context_base  = Pow.context_base(context_app)
-    schema_name   = Map.get(config, :schema_name, "Users.User")
-    schema_plural = Map.get(config, :schema_plural, "users")
     schema        = SchemaModule.new(context_base, schema_name, schema_plural, binary_id: binary_id)
     content       = SchemaModule.gen(schema)
     dir_name      = dir_name(schema_name)

--- a/lib/mix/tasks/phoenix/pow.phoenix.gen.templates.ex
+++ b/lib/mix/tasks/phoenix/pow.phoenix.gen.templates.ex
@@ -19,14 +19,15 @@ defmodule Mix.Tasks.Pow.Phoenix.Gen.Templates do
   @mix_task "pow.phoenix.gen.templates"
 
   @doc false
-  def run(args) do
+  def run(args), do: run(args, Pow.schema_options_from_args())
+  def run(args, schema_opts) do
     Pow.no_umbrella!(@mix_task)
     Pow.ensure_phoenix!(@mix_task, args)
 
     args
     |> Pow.parse_options(@switches, @default_opts)
     |> create_template_files()
-    |> print_shell_instructions()
+    |> print_shell_instructions(schema_opts)
   end
 
   @templates [
@@ -48,14 +49,14 @@ defmodule Mix.Tasks.Pow.Phoenix.Gen.Templates do
     %{context_base: context_base, web_module: web_module}
   end
 
-  defp print_shell_instructions(%{context_base: context_base, web_module: web_base}) do
+  defp print_shell_instructions(%{context_base: context_base, web_module: web_base}, %{schema_name: schema_name}) do
     Mix.shell.info("""
     Pow Phoenix templates and views has been generated.
 
     Please add `web_module: #{inspect(web_base)}` to your configuration.
 
     config :#{Macro.underscore(context_base)}, :pow,
-      user: #{inspect(context_base)}.Users.User,
+      user: #{inspect(context_base)}.#{schema_name},
       repo: #{inspect(context_base)}.Repo,
       web_module: #{inspect(web_base)}
     """)

--- a/lib/mix/tasks/phoenix/pow.phoenix.install.ex
+++ b/lib/mix/tasks/phoenix/pow.phoenix.install.ex
@@ -25,28 +25,21 @@ defmodule Mix.Tasks.Pow.Phoenix.Install do
   @mix_task "pow.phoenix.install"
 
   @doc false
-  def run(args) do
+  def run(args), do: run(args, Pow.schema_options_from_args())
+  def run(args, schema_opts) do
     Pow.no_umbrella!(@mix_task)
     Pow.ensure_phoenix!(@mix_task, args)
 
     args
     |> Pow.parse_options(@switches, @default_opts)
-    |> parse()
+    |> parse_structure()
     |> maybe_run_gen_templates(args)
     |> maybe_run_extensions_gen_templates(args)
-    |> print_shell_instructions()
+    |> print_shell_instructions(schema_opts)
   end
 
-  defp parse({config, parsed, _invalid}) do
-    parsed
-    |> case do
-      [schema_name | _rest] ->
-        Map.merge(config, %{schema_name: schema_name})
-
-      _ ->
-        config
-    end
-    |> Map.put(:structure, Phoenix.parse_structure(config))
+  defp parse_structure({config, _parsed, _invalid}) do
+    Map.put(config, :structure, Phoenix.parse_structure(config))
   end
 
   defp maybe_run_gen_templates(%{templates: true} = config, args) do
@@ -63,11 +56,10 @@ defmodule Mix.Tasks.Pow.Phoenix.Install do
   end
   defp maybe_run_extensions_gen_templates(config, _args), do: config
 
-  defp print_shell_instructions(%{structure: structure} = config) do
+  defp print_shell_instructions(%{structure: structure}, %{schema_name: schema_name}) do
     context_base = structure[:context_base]
     web_base     = structure[:web_module]
     web_prefix   = structure[:web_prefix]
-    schema_name  = Map.get(config, :schema_name, "Users.User")
 
     Mix.shell.info("""
     Pow has been installed in your phoenix app!

--- a/lib/mix/tasks/pow.install.ex
+++ b/lib/mix/tasks/pow.install.ex
@@ -6,6 +6,8 @@ defmodule Mix.Tasks.Pow.Install do
 
       mix pow.install -r MyApp.Repo
 
+      mix pow.install -r MyApp.Repo Accounts.Organization organizations
+
   ## Arguments
 
     * `--templates` generate templates and views
@@ -16,7 +18,7 @@ defmodule Mix.Tasks.Pow.Install do
   use Mix.Task
 
   alias Mix.Project
-  alias Mix.Tasks.Pow.{Ecto, Phoenix}
+  alias Mix.{Pow, Tasks.Pow.Ecto, Tasks.Pow.Phoenix}
 
   @doc false
   def run(args) do
@@ -34,7 +36,16 @@ defmodule Mix.Tasks.Pow.Install do
   end
 
   defp run_phoenix_install(args) do
-    Phoenix.Install.run(args)
+    Phoenix.Install.run(args, schema_opts(args))
+  end
+
+  defp schema_opts({_config, parsed, _invalid}) do
+    Pow.schema_options_from_args(parsed)
+  end
+  defp schema_opts(args) when is_list(args) do
+    args
+    |> Pow.parse_options([], [])
+    |> schema_opts()
   end
 
   defp no_umbrella! do

--- a/test/mix/tasks/phoenix/pow.phoenix.install_test.exs
+++ b/test/mix/tasks/phoenix/pow.phoenix.install_test.exs
@@ -43,12 +43,8 @@ defmodule Mix.Tasks.Pow.Phoenix.InstallTest do
     File.cd!(@tmp_path, fn ->
       Install.run(options)
 
-      assert_received {:mix_shell, :info, [msg]}
-      assert msg =~ "config :pow, :pow,"
+      assert_received {:mix_shell, :info, ["Pow has been installed in your phoenix app!" <> msg]}
       assert msg =~ "user: Pow.Accounts.User,"
-      assert msg =~ "plug Pow.Plug.Session, otp_app: :pow"
-      assert msg =~ "use Pow.Phoenix.Router"
-      assert msg =~ "pow_routes()"
     end)
   end
 

--- a/test/mix/tasks/phoenix/pow.phoenix.install_test.exs
+++ b/test/mix/tasks/phoenix/pow.phoenix.install_test.exs
@@ -37,6 +37,21 @@ defmodule Mix.Tasks.Pow.Phoenix.InstallTest do
     end)
   end
 
+  test "with schema name" do
+    options = @options ++ ~w(Accounts.User)
+
+    File.cd!(@tmp_path, fn ->
+      Install.run(options)
+
+      assert_received {:mix_shell, :info, [msg]}
+      assert msg =~ "config :pow, :pow,"
+      assert msg =~ "user: Pow.Accounts.User,"
+      assert msg =~ "plug Pow.Plug.Session, otp_app: :pow"
+      assert msg =~ "use Pow.Phoenix.Router"
+      assert msg =~ "pow_routes()"
+    end)
+  end
+
   test "with templates" do
     options = @options ++ ~w(--templates)
 

--- a/test/mix/tasks/phoenix/pow.phoenix.install_test.exs
+++ b/test/mix/tasks/phoenix/pow.phoenix.install_test.exs
@@ -37,17 +37,6 @@ defmodule Mix.Tasks.Pow.Phoenix.InstallTest do
     end)
   end
 
-  test "with schema name" do
-    options = @options ++ ~w(Accounts.User)
-
-    File.cd!(@tmp_path, fn ->
-      Install.run(options)
-
-      assert_received {:mix_shell, :info, ["Pow has been installed in your phoenix app!" <> msg]}
-      assert msg =~ "user: Pow.Accounts.User,"
-    end)
-  end
-
   test "with templates" do
     options = @options ++ ~w(--templates)
 

--- a/test/mix/tasks/pow.install_test.exs
+++ b/test/mix/tasks/pow.install_test.exs
@@ -22,6 +22,17 @@ defmodule Mix.Tasks.Pow.InstallTest do
     end)
   end
 
+  test "with schema name and table" do
+    options = ~w(Accounts.Organization users)
+
+    File.cd!(@tmp_path, fn ->
+      Install.run(options)
+
+      assert_received {:mix_shell, :info, ["Pow has been installed in your phoenix app!" <> msg]}
+      assert msg =~ "user: Pow.Accounts.Organization"
+    end)
+  end
+
   test "raises error in umbrella app" do
     File.cd!(@tmp_path, fn ->
       File.write!("mix.exs", """


### PR DESCRIPTION
I've noticed that printed instructions after running `mix pow.install` aren't correct if you provide schema name. 