### PR TITLE
Raise error with helper for invalid schema args

### DIFF
--- a/lib/mix/pow.ex
+++ b/lib/mix/pow.ex
@@ -98,8 +98,38 @@ defmodule Mix.Pow do
   """
   @spec schema_options_from_args([binary()]) :: map()
   def schema_options_from_args(_opts \\ [])
-  def schema_options_from_args([schema_name, schema_plural | _rest]), do: %{schema_name: schema_name, schema_plural: schema_plural}
+  def schema_options_from_args([schema, plural | _rest]), do: %{schema_name: schema, schema_plural: plural}
   def schema_options_from_args(_any), do: %{schema_name: "Users.User", schema_plural: "users"}
+
+  @doc false
+  @spec validate_schema_args!([binary()], binary()) :: map()
+  def validate_schema_args!([schema, plural | _rest] = args, task) do
+    cond do
+      not schema_valid?(schema) ->
+        raise_invalid_schema_args_error("Expected the schema argument, #{inspect schema}, to be a valid module name", task)
+      not plural_valid?(plural) ->
+        raise_invalid_schema_args_error("Expected the plural argument, #{inspect plural}, to be all lowercase using snake_case convention", task)
+      true ->
+        schema_options_from_args(args)
+    end
+  end
+  def validate_schema_args!([_schema | _rest], task) do
+    raise_invalid_schema_args_error("Invalid arguments", task)
+  end
+  def validate_schema_args!([], _task), do: schema_options_from_args()
+
+  defp schema_valid?(schema), do: schema =~ ~r/^[A-Z]\w*(\.[A-Z]\w*)*$/
+
+  defp plural_valid?(plural), do: plural =~ ~r/^[a-z\_]*$/
+
+  defp raise_invalid_schema_args_error(msg, task) do
+    Mix.raise("""
+    #{msg}
+
+    mix #{task} accepts both a module name and the plural of the resource:
+        mix #{task} Users.User users
+    """)
+  end
 
   @doc """
   Fetches context app for the project.

--- a/lib/mix/tasks/ecto/pow.ecto.gen.migration.ex
+++ b/lib/mix/tasks/ecto/pow.ecto.gen.migration.ex
@@ -38,7 +38,7 @@ defmodule Mix.Tasks.Pow.Ecto.Gen.Migration do
 
   defp parse({config, parsed, _invalid}) do
     parsed
-    |> Pow.schema_options_from_args()
+    |> Pow.validate_schema_args!(@mix_task)
     |> Map.merge(config)
   end
 

--- a/lib/mix/tasks/ecto/pow.ecto.gen.schema.ex
+++ b/lib/mix/tasks/ecto/pow.ecto.gen.schema.ex
@@ -38,7 +38,7 @@ defmodule Mix.Tasks.Pow.Ecto.Gen.Schema do
 
   defp parse({config, parsed, _invalid}) do
     parsed
-    |> Pow.schema_options_from_args()
+    |> Pow.validate_schema_args!(@mix_task)
     |> Map.merge(config)
   end
 

--- a/test/mix/tasks/ecto/pow.ecto.install_test.exs
+++ b/test/mix/tasks/ecto/pow.ecto.install_test.exs
@@ -46,6 +46,26 @@ defmodule Mix.Tasks.Pow.Ecto.InstallTest do
     end)
   end
 
+  test "raises error on invalid schema name or table" do
+    File.cd!(@tmp_path, fn ->
+      assert_raise Mix.Error, ~r/Invalid arguments/, fn ->
+        Install.run(~w(Users.User))
+      end
+
+      assert_raise Mix.Error, ~r/Expected the schema argument, "users.user", to be a valid module name/, fn ->
+        Install.run(~w(users.user users))
+      end
+
+      assert_raise Mix.Error, ~r/Expected the plural argument, "Users", to be all lowercase using snake_case convention/, fn ->
+        Install.run(~w(Users.User Users))
+      end
+
+      assert_raise Mix.Error, ~r/Expected the plural argument, "users:", to be all lowercase using snake_case convention/, fn ->
+        Install.run(~w(Users.User users:))
+      end
+    end)
+  end
+
   test "generates with extensions" do
     options = @options ++ ~w(--extension PowResetPassword --extension PowEmailConfirmation)
 


### PR DESCRIPTION
Conforms to how [Phoenix validates args](https://github.com/phoenixframework/phoenix/blob/05f288f978e1f200a187192a7e66d7414063bc81/lib/mix/tasks/phx.gen.schema.ex#L174-L201):

```shell
> mix pow.ecto.install Users.User

** (Mix) Invalid arguments

mix pow.ecto.install accepts both a module name and the plural of the resource:
    mix pow.ecto.install Users.User users
```

```shell
> mix pow.ecto.install users.user users

** (Mix) Expected the schema argument, "users.user", to be a valid module name

mix pow.ecto.install accepts both a module name and the plural of the resource:
    mix pow.ecto.install Users.User users
```

```shell
> mix pow.ecto.install Users.User Users

** (Mix) Expected the plural argument, "Users", to be all lowercase using snake_case convention

mix pow.ecto.install accepts both a module name and the plural of the resource:
    mix pow.ecto.install Users.User users
```