### PR TITLE
Filter so only new associations are added to schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 * Deprecated `Pow.Extension.Config.underscore_extension/1`
 * Deprecated `PowResetPassword.Ecto.Context.password_changeset/2`
+* Deprecated `Pow.Ecto.Schema.filter_new_fields/2`
 * Deprecated `:messages_backend_fallback` setting for extension controllers
 * Removed deprecated macro `router_helpers/1` in `Pow.Phoenix.Controller`
 

--- a/test/extensions/reset_password/phoenix/controllers/reset_password_controller_test.exs
+++ b/test/extensions/reset_password/phoenix/controllers/reset_password_controller_test.exs
@@ -64,10 +64,10 @@ defmodule PowResetPassword.Phoenix.ResetPasswordControllerTest do
     @valid_token "valid"
     @invalid_token "invalid"
 
-    setup %{conn: conn, ets: ets} do
+    setup %{ets: ets} do
       ResetTokenCache.put([backend: ets], @valid_token, @user)
 
-      {:ok, conn: conn, ets: ets}
+      :ok
     end
 
     test "already signed in", %{conn: conn} do
@@ -105,10 +105,10 @@ defmodule PowResetPassword.Phoenix.ResetPasswordControllerTest do
     @valid_params %{"user" => %{"password" => @password, "confirm_password" => @password}}
     @invalid_params %{"user" => %{"password" => @password, "confirm_password" => "invalid"}}
 
-    setup %{conn: conn, ets: ets} do
+    setup %{ets: ets} do
       ResetTokenCache.put([backend: ets], @valid_token, @user)
 
-      {:ok, conn: conn, ets: ets}
+      :ok
     end
 
     test "already signed in", %{conn: conn} do

--- a/test/pow/ecto/schema_test.exs
+++ b/test/pow/ecto/schema_test.exs
@@ -41,4 +41,31 @@ defmodule Pow.Ecto.SchemaTest do
     assert Map.has_key?(user, :password_hash)
     assert OverrideFieldUser.__schema__(:field_source, :password_hash) == :encrypted_password
   end
+
+  defmodule OverrideAssocUser do
+    @moduledoc false
+    use Ecto.Schema
+    use Pow.Ecto.Schema
+
+    @pow_assocs {:has_many, :users, __MODULE__}
+
+    @pow_assocs {:belongs_to, :parent, __MODULE__}
+    @pow_assocs {:has_many, :children, __MODULE__}
+
+    schema "users" do
+      belongs_to :parent, __MODULE__, on_replace: :mark_as_invalid
+      has_many :children, __MODULE__, on_delete: :delete_all
+
+      pow_user_fields()
+
+      timestamps()
+    end
+  end
+
+  test "schema/2 with overridden assocs" do
+    assert %{on_delete: :nothing} = OverrideAssocUser.__schema__(:association, :users)
+
+    assert %{on_replace: :mark_as_invalid} = OverrideAssocUser.__schema__(:association, :parent)
+    assert %{on_delete: :delete_all} = OverrideAssocUser.__schema__(:association, :children)
+  end
 end

--- a/test/support/mix/test_case.ex
+++ b/test/support/mix/test_case.ex
@@ -8,7 +8,7 @@ defmodule Pow.Test.Mix.TestCase do
     :ok
   end
 
-  setup context do
+  setup _context do
     current_shell = Mix.shell()
 
     on_exit fn ->
@@ -17,7 +17,7 @@ defmodule Pow.Test.Mix.TestCase do
 
     Mix.shell(Mix.Shell.Process)
 
-    context
+    :ok
   end
 
   defp clear_tmp_files, do: File.rm_rf!("tmp")


### PR DESCRIPTION
This permits users to override any associations like with fields:

```elixir

defmodule MyApp.Users.User do
  @moduledoc false
  use Ecto.Schema
  use Pow.Ecto.Schema
  use Pow.Extension.Ecto.Schema,
    extensions: [PowInvitation]

  schema "users" do
    has_many :invited_users, __MODULE__, foreign_key: :invited_by_id, on_delete: :delete_all

    pow_user_fields()

    timestamps()
  end
end
```