### PR TITLE
Use otp_app in generators for better support of umbrella app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.0.4 (TBA)
 
 * Added `PowInvitation` to the `mix pow.extension.phoenix.gen.templates` and `mix pow.extension.phoenix.mailer.gen.templates` tasks
+* Fixed issue in umbrella projects where extensions wasn't found in environment configuration
 
 ## v1.0.3 (2019-03-09)
 

--- a/lib/mix/pow.ex
+++ b/lib/mix/pow.ex
@@ -131,9 +131,9 @@ defmodule Mix.Pow do
     """)
   end
 
-  @doc """
-  Fetches context app for the project.
-  """
+  # TODO: Remove by 1.1.0
+  @doc false
+  @deprecated "Please use `Pow.Phoenix.parse_structure/1` instead"
   @spec context_app :: atom() | no_return
   def context_app do
     this_app = otp_app()
@@ -149,7 +149,9 @@ defmodule Mix.Pow do
     end
   end
 
-  defp otp_app do
+  @doc false
+  @spec otp_app :: atom() | no_return
+  def otp_app do
     Keyword.fetch!(Mix.Project.config(), :app)
   end
 

--- a/lib/mix/tasks/ecto/pow.ecto.gen.migration.ex
+++ b/lib/mix/tasks/ecto/pow.ecto.gen.migration.ex
@@ -51,7 +51,7 @@ defmodule Mix.Tasks.Pow.Ecto.Gen.Migration do
   end
 
   defp create_migration_files(%{repo: repo, binary_id: binary_id, schema_plural: schema_plural}) do
-    context_base = Pow.context_base(Pow.context_app())
+    context_base = Pow.context_base(Pow.otp_app())
     schema       = SchemaMigration.new(context_base, schema_plural, repo: repo, binary_id: binary_id)
     content      = SchemaMigration.gen(schema)
 

--- a/lib/mix/tasks/ecto/pow.ecto.gen.migration.ex
+++ b/lib/mix/tasks/ecto/pow.ecto.gen.migration.ex
@@ -51,9 +51,9 @@ defmodule Mix.Tasks.Pow.Ecto.Gen.Migration do
   end
 
   defp create_migration_files(%{repo: repo, binary_id: binary_id, schema_plural: schema_plural}) do
-    context_base  = Pow.context_base(Pow.context_app())
-    schema        = SchemaMigration.new(context_base, schema_plural, repo: repo, binary_id: binary_id)
-    content       = SchemaMigration.gen(schema)
+    context_base = Pow.context_base(Pow.context_app())
+    schema       = SchemaMigration.new(context_base, schema_plural, repo: repo, binary_id: binary_id)
+    content      = SchemaMigration.gen(schema)
 
     Migration.create_migration_files(repo, schema.migration_name, content)
   end

--- a/lib/mix/tasks/ecto/pow.ecto.gen.schema.ex
+++ b/lib/mix/tasks/ecto/pow.ecto.gen.schema.ex
@@ -4,15 +4,14 @@ defmodule Mix.Tasks.Pow.Ecto.Gen.Schema do
   @moduledoc """
   Generates a user schema.
 
-      mix pow.ecto.gen.schema -r MyApp.Repo
+      mix pow.ecto.gen.schema
 
-      mix pow.ecto.gen.schema -r MyApp.Repo --context-app my_app Accounts.Organization organizations
+      mix pow.ecto.gen.schema --context-app my_app Accounts.Organization organizations
 
   This generator will add a schema module file in `lib/my_app/users/user.ex`.
 
   ## Arguments
 
-    * `-r`, `--repo` - the repo module
     * `--binary-id` - use binary id for primary key and references
     * `--context-app` - context app to use for path and module names
   """
@@ -43,12 +42,12 @@ defmodule Mix.Tasks.Pow.Ecto.Gen.Schema do
   end
 
   defp create_schema_file(%{binary_id: binary_id, schema_name: schema_name, schema_plural: schema_plural} = config) do
-    context_app   = Map.get(config, :context_app, Pow.context_app())
-    context_base  = Pow.context_base(context_app)
-    schema        = SchemaModule.new(context_base, schema_name, schema_plural, binary_id: binary_id)
-    content       = SchemaModule.gen(schema)
-    dir_name      = dir_name(schema_name)
-    file_name     = file_name(schema.module)
+    context_app  = Map.get(config, :context_app, Pow.context_app())
+    context_base = Pow.context_base(context_app)
+    schema       = SchemaModule.new(context_base, schema_name, schema_plural, binary_id: binary_id)
+    content      = SchemaModule.gen(schema)
+    dir_name     = dir_name(schema_name)
+    file_name    = file_name(schema.module)
 
     context_app
     |> Pow.context_lib_path(dir_name)

--- a/lib/mix/tasks/ecto/pow.ecto.gen.schema.ex
+++ b/lib/mix/tasks/ecto/pow.ecto.gen.schema.ex
@@ -42,7 +42,7 @@ defmodule Mix.Tasks.Pow.Ecto.Gen.Schema do
   end
 
   defp create_schema_file(%{binary_id: binary_id, schema_name: schema_name, schema_plural: schema_plural} = config) do
-    context_app  = Map.get(config, :context_app, Pow.context_app())
+    context_app  = Map.get(config, :context_app) || Pow.otp_app()
     context_base = Pow.context_base(context_app)
     schema       = SchemaModule.new(context_base, schema_name, schema_plural, binary_id: binary_id)
     content      = SchemaModule.gen(schema)

--- a/lib/mix/tasks/extension/ecto/pow.extension.ecto.gen.migrations.ex
+++ b/lib/mix/tasks/extension/ecto/pow.extension.ecto.gen.migrations.ex
@@ -46,9 +46,9 @@ defmodule Mix.Tasks.Pow.Extension.Ecto.Gen.Migrations do
   end
 
   defp create_migrations_files(config, args) do
-    context_base = Pow.context_base(Pow.context_app())
-    otp_app      = String.to_atom(Macro.underscore(context_base))
-    extensions   = Extension.extensions(config, otp_app)
+    context_base = Pow.context_base(Pow.otp_app())
+    context_app  = String.to_atom(Macro.underscore(context_base))
+    extensions   = Extension.extensions(config, context_app)
 
     args
     |> Ecto.parse_repo()
@@ -56,7 +56,7 @@ defmodule Mix.Tasks.Pow.Extension.Ecto.Gen.Migrations do
     |> Enum.map(&Map.put(config, :repo, &1))
     |> Enum.each(&create_extension_migration_files(&1, extensions, context_base))
 
-    %{extensions: extensions, otp_app: otp_app}
+    %{extensions: extensions, context_app: context_app}
   end
 
   defp create_extension_migration_files(config, extensions, context_base) do
@@ -79,8 +79,8 @@ defmodule Mix.Tasks.Pow.Extension.Ecto.Gen.Migrations do
     do: true
   defp empty?(_schema), do: false
 
-  defp print_shell_instructions(%{extensions: [], otp_app: otp_app}) do
-    Extension.no_extensions_error(otp_app)
+  defp print_shell_instructions(%{extensions: [], context_app: context_app}) do
+    Extension.no_extensions_error(context_app)
   end
   defp print_shell_instructions(config), do: config
 end

--- a/lib/mix/tasks/extension/phoenix/pow.extension.phoenix.gen.templates.ex
+++ b/lib/mix/tasks/extension/phoenix/pow.extension.phoenix.gen.templates.ex
@@ -44,10 +44,11 @@ defmodule Mix.Tasks.Pow.Extension.Phoenix.Gen.Templates do
     structure  = Phoenix.parse_structure(config)
     web_module = structure[:web_module]
     web_prefix = structure[:web_prefix]
-    otp_app    = String.to_atom(Macro.underscore(structure[:context_base]))
+    web_app    = structure[:web_app]
+
     extensions =
       config
-      |> Extension.extensions(otp_app)
+      |> Extension.extensions(web_app)
       |> Enum.filter(&Keyword.has_key?(@extension_templates, &1))
       |> Enum.map(&{&1, @extension_templates[&1]})
 
@@ -58,11 +59,11 @@ defmodule Mix.Tasks.Pow.Extension.Phoenix.Gen.Templates do
       end)
     end)
 
-    %{extensions: extensions, otp_app: otp_app, structure: structure}
+    %{extensions: extensions, web_app: web_app, structure: structure}
   end
 
-  defp print_shell_instructions(%{extensions: [], otp_app: otp_app}) do
-    Extension.no_extensions_error(otp_app)
+  defp print_shell_instructions(%{extensions: [], web_app: web_app}) do
+    Extension.no_extensions_error(web_app)
   end
   defp print_shell_instructions(config), do: config
 end

--- a/lib/mix/tasks/extension/phoenix/pow.extension.phoenix.mailer.gen.templates.ex
+++ b/lib/mix/tasks/extension/phoenix/pow.extension.phoenix.mailer.gen.templates.ex
@@ -6,8 +6,6 @@ defmodule Mix.Tasks.Pow.Extension.Phoenix.Mailer.Gen.Templates do
 
       mix pow.extension.phoenix.mailer.gen.templates --extension PowEmailConfirmation --extension PowResetPassword
 
-      mix pow.extension.phoenix.mailer.gen.templates --context-app my_app --extension PowEmailConfirmation
-
   ## Arguments
 
     * `--extension` extension to generate templates for
@@ -47,10 +45,11 @@ defmodule Mix.Tasks.Pow.Extension.Phoenix.Mailer.Gen.Templates do
     structure  = Phoenix.parse_structure(config)
     web_module = structure[:web_module]
     web_prefix = structure[:web_prefix]
-    otp_app    = String.to_atom(Macro.underscore(structure[:context_base]))
+    web_app    = structure[:web_app]
+
     extensions =
       config
-      |> Extension.extensions(otp_app)
+      |> Extension.extensions(web_app)
       |> Enum.filter(&Keyword.has_key?(@extension_templates, &1))
       |> Enum.map(&{&1, @extension_templates[&1]})
 
@@ -62,11 +61,11 @@ defmodule Mix.Tasks.Pow.Extension.Phoenix.Mailer.Gen.Templates do
       end)
     end)
 
-    %{extensions: extensions, otp_app: otp_app, structure: structure}
+    %{extensions: extensions, web_app: web_app, structure: structure}
   end
 
-  defp print_shell_instructions(%{extensions: [], otp_app: otp_app}) do
-    Extension.no_extensions_error(otp_app)
+  defp print_shell_instructions(%{extensions: [], web_app: web_app}) do
+    Extension.no_extensions_error(web_app)
   end
   defp print_shell_instructions(%{structure: structure}) do
     web_base     = structure[:web_module]

--- a/lib/mix/tasks/phoenix/pow.phoenix.gen.templates.ex
+++ b/lib/mix/tasks/phoenix/pow.phoenix.gen.templates.ex
@@ -40,29 +40,32 @@ defmodule Mix.Tasks.Pow.Phoenix.Gen.Templates do
   ]
 
   defp create_template_files({config, _parsed, _invalid}) do
-    structure    = Phoenix.parse_structure(config)
-    context_base = structure[:context_base]
-    web_module   = structure[:web_module]
-    web_prefix   = structure[:web_prefix]
+    structure  = Phoenix.parse_structure(config)
+    web_module = structure[:web_module]
+    web_prefix = structure[:web_prefix]
 
     Enum.each(@templates, fn {name, actions} ->
       Phoenix.create_view_file(Elixir.Pow, name, web_module, web_prefix)
       Phoenix.create_templates(Elixir.Pow, name, web_prefix, actions)
     end)
 
-    %{context_base: context_base, web_module: web_module}
+    %{structure: structure}
   end
 
-  defp print_shell_instructions(%{context_base: context_base, web_module: web_base}, %{schema_name: schema_name}) do
+  defp print_shell_instructions(%{structure: structure}, %{schema_name: schema_name}) do
+    context_base = structure[:context_base]
+    web_app      = structure[:web_app]
+    web_module   = structure[:web_module]
+
     Mix.shell.info("""
     Pow Phoenix templates and views has been generated.
 
-    Please add `web_module: #{inspect(web_base)}` to your configuration.
+    Please add `web_module: #{inspect(web_module)}` to your configuration.
 
-    config :#{Macro.underscore(context_base)}, :pow,
+    config #{inspect(web_app)}, :pow,
       user: #{inspect(context_base)}.#{schema_name},
       repo: #{inspect(context_base)}.Repo,
-      web_module: #{inspect(web_base)}
+      web_module: #{inspect(web_module)}
     """)
   end
 end

--- a/lib/mix/tasks/phoenix/pow.phoenix.install.ex
+++ b/lib/mix/tasks/phoenix/pow.phoenix.install.ex
@@ -69,6 +69,7 @@ defmodule Mix.Tasks.Pow.Phoenix.Install do
     context_base = structure[:context_base]
     web_base     = structure[:web_module]
     web_prefix   = structure[:web_prefix]
+    web_app      = structure[:web_app]
 
     Mix.shell.info("""
     Pow has been installed in your phoenix app!
@@ -77,23 +78,23 @@ defmodule Mix.Tasks.Pow.Phoenix.Install do
 
     First, append this to `config/config.ex`:
 
-    config :#{Macro.underscore(context_base)}, :pow,
+    config #{inspect(web_app)}, :pow,
       user: #{inspect(context_base)}.#{schema_name},
       repo: #{inspect(context_base)}.Repo
 
     Next, add `Pow.Plug.Session` plug to `#{web_prefix}/endpoint.ex`:
 
     defmodule #{inspect(web_base)}.Endpoint do
-      use Phoenix.Endpoint, otp_app: :#{Macro.underscore(context_base)}
+      use Phoenix.Endpoint, web_app: #{inspect(web_app)}
 
       # ...
 
       plug Plug.Session,
         store: :cookie,
-        key: "_#{Macro.underscore(context_base)}_key",
+        key: "_#{web_app}_key",
         signing_salt: "secret"
 
-      plug Pow.Plug.Session, otp_app: :#{Macro.underscore(context_base)}
+      plug Pow.Plug.Session, otp_app: #{inspect(web_app)}
 
       # ...
     end

--- a/test/mix/tasks/extension/phoenix/pow.extension.phoenix.gen.templates_test.exs
+++ b/test/mix/tasks/extension/phoenix/pow.extension.phoenix.gen.templates_test.exs
@@ -59,31 +59,31 @@ defmodule Mix.Tasks.Pow.Extension.Phoenix.Gen.TemplatesTest do
     end)
   end
 
-  describe "with `:context_app` configuration" do
+  describe "with extensions in env config" do
     setup do
-      Application.put_env(:test, :pow, extensions: Enum.map(@expected_template_files, &elem(&1, 0)))
+      Application.put_env(:pow, :pow, extensions: Enum.map(@expected_template_files, &elem(&1, 0)))
       on_exit(fn ->
-        Application.delete_env(:test, :pow)
+        Application.delete_env(:pow, :pow)
       end)
     end
 
     test "generates templates" do
       File.cd!(@tmp_path, fn ->
-        Templates.run(~w(--context-app test))
+        Templates.run([])
 
         for {module, expected_templates} <- @expected_template_files do
-          templates_path = Path.join(["lib", "test_web", "templates", Macro.underscore(module)])
+          templates_path = Path.join(["lib", "pow_web", "templates", Macro.underscore(module)])
           dirs           = templates_path |> File.ls!() |> Enum.sort()
 
           assert dirs == Map.keys(expected_templates)
 
-          views_path = Path.join(["lib", "test_web", "views", Macro.underscore(module)])
+          views_path = Path.join(["lib", "pow_web", "views", Macro.underscore(module)])
 
           [base_name | _rest] = expected_templates |> Map.keys()
           view_content        = views_path |> Path.join(base_name <> "_view.ex") |> File.read!()
 
-          assert view_content =~ "defmodule TestWeb.#{inspect(module)}.#{Macro.camelize(base_name)}View do"
-          assert view_content =~ "use TestWeb, :view"
+          assert view_content =~ "defmodule PowWeb.#{inspect(module)}.#{Macro.camelize(base_name)}View do"
+          assert view_content =~ "use PowWeb, :view"
         end
       end)
     end

--- a/test/mix/tasks/extension/phoenix/pow.extension.phoenix.mailer.gen.templates_test.exs
+++ b/test/mix/tasks/extension/phoenix/pow.extension.phoenix.mailer.gen.templates_test.exs
@@ -77,37 +77,37 @@ defmodule Mix.Tasks.Pow.Extension.Phoenix.Mailer.Gen.TemplatesTest do
     end)
   end
 
-  describe "with `:context_app` configuration" do
+  describe "with extensions in env config" do
     setup do
-      Application.put_env(:test, :pow, extensions: Enum.map(@expected_template_files, &elem(&1, 0)))
+      Application.put_env(:pow, :pow, extensions: Enum.map(@expected_template_files, &elem(&1, 0)))
       on_exit(fn ->
-        Application.delete_env(:test, :pow)
+        Application.delete_env(:pow, :pow)
       end)
     end
 
     test "generates mailer templates" do
       File.cd!(@tmp_path, fn ->
-        Templates.run(~w(--context-app test))
+        Templates.run([])
 
         for {module, expected_templates} <- @expected_template_files do
-          templates_path = Path.join(["lib", "test_web", "templates", Macro.underscore(module)])
+          templates_path = Path.join(["lib", "pow_web", "templates", Macro.underscore(module)])
           dirs           = templates_path |> File.ls!() |> Enum.sort()
 
           assert dirs == Map.keys(expected_templates)
 
-          views_path          = Path.join(["lib", "test_web", "views", Macro.underscore(module)])
+          views_path          = Path.join(["lib", "pow_web", "views", Macro.underscore(module)])
           [base_name | _rest] = expected_templates |> Map.keys()
           view_content        = views_path |> Path.join(base_name <> "_view.ex") |> File.read!()
 
-          assert view_content =~ "defmodule TestWeb.#{inspect(module)}.#{Macro.camelize(base_name)}View do"
-          assert view_content =~ "use TestWeb, :mailer_view"
+          assert view_content =~ "defmodule PowWeb.#{inspect(module)}.#{Macro.camelize(base_name)}View do"
+          assert view_content =~ "use PowWeb, :mailer_view"
         end
 
         assert_received {:mix_shell, :info, ["Pow mailer templates has been installed in your phoenix app!" <> msg]}
-        assert msg =~ "lib/test_web.ex"
+        assert msg =~ "lib/pow_web.ex"
         assert msg =~ ":mailer_view"
         assert msg =~ "def mailer_view"
-        assert msg =~ "use Phoenix.View, root: \"lib/test_web/templates\""
+        assert msg =~ "use Phoenix.View, root: \"lib/pow_web/templates\""
       end)
     end
   end

--- a/test/mix/tasks/phoenix/pow.phoenix.gen.templates_test.exs
+++ b/test/mix/tasks/phoenix/pow.phoenix.gen.templates_test.exs
@@ -52,20 +52,20 @@ defmodule Mix.Tasks.Pow.Phoenix.Gen.TemplatesTest do
     File.cd!(@tmp_path, fn ->
       Templates.run(options)
 
-      templates_path = Path.join(["lib", "test_web", "templates", "pow"])
+      templates_path = Path.join(["lib", "pow", "templates", "pow"])
       dirs           = templates_path |> File.ls!() |> Enum.sort()
 
       assert dirs == Map.keys(@expected_template_files)
 
-      views_path   = Path.join(["lib", "test_web", "views", "pow"])
+      views_path   = Path.join(["lib", "pow", "views", "pow"])
       view_content = views_path |> Path.join("session_view.ex") |> File.read!()
 
-      assert view_content =~ "defmodule TestWeb.Pow.SessionView do"
-      assert view_content =~ "use TestWeb, :view"
+      assert view_content =~ "defmodule Pow.Pow.SessionView do"
+      assert view_content =~ "use Pow, :view"
 
       assert_received {:mix_shell, :info, ["Pow Phoenix templates and views has been generated." <> msg]}
-      assert msg =~ "config :test, :pow,"
-      assert msg =~ "web_module: TestWeb"
+      assert msg =~ "config :pow, :pow,"
+      assert msg =~ "web_module: Pow"
     end)
   end
 

--- a/test/mix/tasks/phoenix/pow.phoenix.gen.templates_test.exs
+++ b/test/mix/tasks/phoenix/pow.phoenix.gen.templates_test.exs
@@ -9,7 +9,7 @@ defmodule Mix.Tasks.Pow.Phoenix.Gen.TemplatesTest do
     "registration" => ["edit.html.eex", "new.html.eex"],
     "session" => ["new.html.eex"]
   }
-  @expected_views @expected_template_files |> Map.keys()
+  @expected_views  Map.keys(@expected_template_files)
 
   setup do
     File.rm_rf!(@tmp_path)

--- a/test/mix/tasks/phoenix/pow.phoenix.install_test.exs
+++ b/test/mix/tasks/phoenix/pow.phoenix.install_test.exs
@@ -3,13 +3,8 @@ defmodule Mix.Tasks.Pow.Phoenix.InstallTest do
 
   alias Mix.Tasks.Pow.Phoenix.Install
 
-  defmodule Repo do
-    def __adapter__, do: true
-    def config, do: [priv: "", otp_app: :pow]
-  end
-
   @tmp_path       Path.join(["tmp", inspect(Install)])
-  @options        ["-r", inspect(Repo)]
+  @options        []
   @web_path       Path.join(["lib", "pow_web"])
   @templates_path Path.join([@web_path, "templates", "pow"])
   @views_path     Path.join([@web_path, "views", "pow"])

--- a/test/mix/tasks/phoenix/pow.phoenix.install_test.exs
+++ b/test/mix/tasks/phoenix/pow.phoenix.install_test.exs
@@ -66,7 +66,9 @@ defmodule Mix.Tasks.Pow.Phoenix.InstallTest do
       Install.run(options)
 
       assert_received {:mix_shell, :info, ["Pow has been installed in your phoenix app!" <> msg]}
-      assert msg =~ "plug Pow.Plug.Session, otp_app: :test"
+      assert msg =~ "config :pow, :pow,"
+      assert msg =~ "user: Test.Users.User,"
+      assert msg =~ "plug Pow.Plug.Session, otp_app: :pow"
     end)
   end
 
@@ -86,6 +88,48 @@ defmodule Mix.Tasks.Pow.Phoenix.InstallTest do
         assert_raise Mix.Error, "mix pow.phoenix.install can only be run inside an application directory that has :phoenix as dependency", fn ->
           Install.run([])
         end
+      end)
+    end)
+  end
+
+  test "uses web app inside Phoenix umbrella app" do
+    options = @options ++ ~w(--templates --extension PowResetPassword --extension PowEmailConfirmation)
+    File.cd!(@tmp_path, fn ->
+      File.write!("mix.exs", """
+      defmodule MyAppWeb.MixProject do
+        use Mix.Project
+
+        def project do
+          [
+            app: :my_app_web,
+            deps: [
+              {:phoenix, ">= 0.0.0"}
+            ]
+          ]
+        end
+      end
+      """)
+
+      Application.put_env(:my_app_web, :generators, context_app: :my_app)
+
+      Mix.Project.in_project(:my_app_web, ".", fn _ ->
+        Install.run(options)
+
+        assert_received {:mix_shell, :info, ["Pow has been installed in your phoenix app!" <> msg]}
+        assert msg =~ "config :my_app_web, :pow,"
+        assert msg =~ "user: MyApp.Users.User,"
+        assert msg =~ "plug Pow.Plug.Session, otp_app: :my_app_web"
+
+        assert_received {:mix_shell, :info, ["Pow Phoenix templates and views has been generated." <> msg]}
+        assert msg =~ "repo: MyApp.Repo"
+        assert msg =~ "user: MyApp.Users.User"
+        assert msg =~ "web_module: MyAppWeb"
+
+        assert File.exists?(Path.join(["lib", "my_app_web", "templates", "pow"]))
+        assert File.exists?(Path.join(["lib", "my_app_web", "views", "pow"]))
+
+        assert File.exists?(Path.join(["lib", "my_app_web", "templates", "pow_reset_password"]))
+        assert File.exists?(Path.join(["lib", "my_app_web", "views", "pow_reset_password"]))
       end)
     end)
   end


### PR DESCRIPTION
The generators was too dependent on the context app. Previously the web app was built out from the context app definition. But since phoenix mix tasks are always run inside the web app, all we need to do is just fetch the current app name instead of guessing the web app name. The context app only refers to the ecto app, and should only be used for that.

I've added an umbrella app test too.