### PR TITLE
Better mix error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 * Added `PowInvitation` to the `mix pow.extension.phoenix.gen.templates` and `mix pow.extension.phoenix.mailer.gen.templates` tasks
 * Fixed issue in umbrella projects where extensions wasn't found in environment configuration
 * Shell instructions will only be printed if the configuration is missing
+* Now requires that `:ecto` or `:phoenix` are included in the dependency list for the app to run respective mix tasks
 * Deprecated `Mix.Pow.context_app/0`
+* Deprecated `Mix.Pow.ensure_dep!/3`
 
 ## v1.0.3 (2019-03-09)
 

--- a/lib/mix/tasks/pow.install.ex
+++ b/lib/mix/tasks/pow.install.ex
@@ -48,7 +48,14 @@ defmodule Mix.Tasks.Pow.Install do
 
   defp no_umbrella! do
     if Project.umbrella?() do
-      Mix.raise("mix #{@mix_task} can't be used in umbrella apps. Run mix pow.ecto.install in your ecto app directory, and optionally mix pow.phoenix.install in your phoenix app directory.")
+      Mix.raise(
+        """
+        mix #{@mix_task} has to be used inside an application directory, but this is an umbrella project.
+
+        Run mix pow.ecto.install inside your Ecto application directory to create schema module and migrations.
+
+        Run mix pow.phoenix.install in your Phoenix application directory for configuration instructions.
+        """)
     end
 
     :ok

--- a/test/mix/tasks/pow.install_test.exs
+++ b/test/mix/tasks/pow.install_test.exs
@@ -46,7 +46,7 @@ defmodule Mix.Tasks.Pow.InstallTest do
       """)
 
       Mix.Project.in_project(:umbrella, ".", fn _ ->
-        assert_raise Mix.Error, "mix pow.install can't be used in umbrella apps. Run mix pow.ecto.install in your ecto app directory, and optionally mix pow.phoenix.install in your phoenix app directory.", fn ->
+        assert_raise Mix.Error, ~r/mix pow.install has to be used inside an application directory/, fn ->
           Install.run([])
         end
       end)


### PR DESCRIPTION
Some improvements to messages and handling of errors.

Now top level dependency requirement for ecto or phoenix rather than accept inclusion from another dependency since Pow will always include ecto and phoenix. This can be removed again if I get #2 working, however, umbrella apps will include all dependencies from other apps so it should probably be reworked at that time.