### PR TITLE
Use `:namespace` environment config for web app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@
 
 * Added `PowInvitation` to the `mix pow.extension.phoenix.gen.templates` and `mix pow.extension.phoenix.mailer.gen.templates` tasks
 * Fixed issue in umbrella projects where extensions wasn't found in environment configuration
+* Fixed so `:namespace` environment config can be used as web app module name
 * Shell instructions will only be printed if the configuration is missing
 * Now requires that `:ecto` or `:phoenix` are included in the dependency list for the app to run respective mix tasks
 * Deprecated `Mix.Pow.context_app/0`
 * Deprecated `Mix.Pow.ensure_dep!/3`
+* Deprecated `Mix.Pow.context_base/1`
 
 ## v1.0.3 (2019-03-09)
 

--- a/lib/mix/pow.ex
+++ b/lib/mix/pow.ex
@@ -170,11 +170,17 @@ defmodule Mix.Pow do
     Keyword.fetch!(Mix.Project.config(), :app)
   end
 
+  # TODO: Remove by 1.1.0
+  @doc false
+  @deprecated "Use `app_base/1` instead"
+  @spec context_base(atom()) :: atom()
+  def context_base(app), do: app_base(app)
+
   @doc """
   Fetches the context base module for the app.
   """
-  @spec context_base(atom()) :: atom()
-  def context_base(app) do
+  @spec app_base(atom()) :: atom()
+  def app_base(app) do
     case Application.get_env(app, :namespace, app) do
       ^app ->
         app

--- a/lib/mix/pow/phoenix.ex
+++ b/lib/mix/pow/phoenix.ex
@@ -12,7 +12,7 @@ defmodule Mix.Pow.Phoenix do
   def parse_structure(config) do
     otp_app      = Pow.otp_app()
     context_app  = Map.get(config, :context_app) || context_app(otp_app)
-    context_base = Pow.context_base(context_app)
+    context_base = Pow.app_base(context_app)
     web_base     = web_base(context_app, otp_app, context_base)
     web_prefix   = web_prefix(context_app, otp_app)
 
@@ -38,7 +38,7 @@ defmodule Mix.Pow.Phoenix do
   end
 
   defp web_base(this_app, this_app, context_base), do: Module.concat(["#{context_base}Web"])
-  defp web_base(_this_app, web_app, _context_base), do: web_app |> to_string() |> Macro.camelize() |> List.wrap() |> Module.concat()
+  defp web_base(_this_app, web_app, _context_base), do: Pow.app_base(web_app)
 
   defp web_prefix(this_app, this_app), do: Path.join("lib", "#{this_app}_web")
   defp web_prefix(_context_app, this_app), do: Path.join("lib", "#{this_app}")

--- a/lib/mix/tasks/ecto/pow.ecto.gen.migration.ex
+++ b/lib/mix/tasks/ecto/pow.ecto.gen.migration.ex
@@ -51,7 +51,7 @@ defmodule Mix.Tasks.Pow.Ecto.Gen.Migration do
   end
 
   defp create_migration_files(%{repo: repo, binary_id: binary_id, schema_plural: schema_plural}) do
-    context_base = Pow.context_base(Pow.otp_app())
+    context_base = Pow.app_base(Pow.otp_app())
     schema       = SchemaMigration.new(context_base, schema_plural, repo: repo, binary_id: binary_id)
     content      = SchemaMigration.gen(schema)
 

--- a/lib/mix/tasks/ecto/pow.ecto.gen.schema.ex
+++ b/lib/mix/tasks/ecto/pow.ecto.gen.schema.ex
@@ -43,7 +43,7 @@ defmodule Mix.Tasks.Pow.Ecto.Gen.Schema do
 
   defp create_schema_file(%{binary_id: binary_id, schema_name: schema_name, schema_plural: schema_plural} = config) do
     context_app  = Map.get(config, :context_app) || Pow.otp_app()
-    context_base = Pow.context_base(context_app)
+    context_base = Pow.app_base(context_app)
     schema       = SchemaModule.new(context_base, schema_name, schema_plural, binary_id: binary_id)
     content      = SchemaModule.gen(schema)
     dir_name     = dir_name(schema_name)

--- a/lib/mix/tasks/extension/ecto/pow.extension.ecto.gen.migrations.ex
+++ b/lib/mix/tasks/extension/ecto/pow.extension.ecto.gen.migrations.ex
@@ -46,7 +46,7 @@ defmodule Mix.Tasks.Pow.Extension.Ecto.Gen.Migrations do
   end
 
   defp create_migrations_files(config, args) do
-    context_base = Pow.context_base(Pow.otp_app())
+    context_base = Pow.app_base(Pow.otp_app())
     context_app  = String.to_atom(Macro.underscore(context_base))
     extensions   = Extension.extensions(config, context_app)
 

--- a/test/mix/tasks/ecto/pow.ecto.install_test.exs
+++ b/test/mix/tasks/ecto/pow.ecto.install_test.exs
@@ -91,6 +91,23 @@ defmodule Mix.Tasks.Pow.Ecto.InstallTest do
     end)
   end
 
+  describe "with `:namespace` environment config set" do
+    setup do
+      Application.put_env(:pow, :namespace, POW)
+      on_exit(fn ->
+        Application.delete_env(:pow, :namespace)
+      end)
+    end
+
+    test "uses namespace for context module names" do
+      File.cd!(@tmp_path, fn ->
+        Install.run(@options)
+
+        assert File.read!("lib/pow/users/user.ex") =~ "defmodule POW.Users.User do"
+      end)
+    end
+  end
+
   # TODO: Refactor to just use Elixir 1.7 or higher by Pow 1.1.0
   defp deps() do
     case Kernel.function_exported?(Mix.Dep, :load_on_environment, 1) do


### PR DESCRIPTION
The phx.new mix task sets a `:namespace` environment config if `--module` arg is set.

This PR makes sure that the web app will use the namespace if set (was already working as expected for the context app).