### PR TITLE
Deprecate extension context base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Added `extension_messages/1` to extension controllers and callbacks
 * Improved feedback for when no templates are generated for an extension with `mix pow.extension.phoenix.gen.templates` and `mix pow.extension.phoenix.mailer.gen.templates` tasks
+* Deprecated `Pow.Extension.Ecto.Context.Base`
 
 ## v1.0.4 (2019-03-13)
 

--- a/lib/extensions/email_confirmation/ecto/context.ex
+++ b/lib/extensions/email_confirmation/ecto/context.ex
@@ -1,7 +1,5 @@
 defmodule PowEmailConfirmation.Ecto.Context do
   @moduledoc false
-  use Pow.Extension.Ecto.Context.Base
-
   alias Ecto.Changeset
   alias Pow.{Config, Ecto.Context}
   alias PowEmailConfirmation.Ecto.Schema

--- a/lib/extensions/invitation/ecto/context.ex
+++ b/lib/extensions/invitation/ecto/context.ex
@@ -1,7 +1,5 @@
 defmodule PowInvitation.Ecto.Context do
   @moduledoc false
-  use Pow.Extension.Ecto.Context.Base
-
   alias Ecto.Changeset
   alias Pow.Ecto.Context
   alias PowInvitation.Ecto.Schema

--- a/lib/extensions/invitation/plug.ex
+++ b/lib/extensions/invitation/plug.ex
@@ -3,8 +3,9 @@ defmodule PowInvitation.Plug do
   Plug helper methods.
   """
   alias Plug.Conn
-  alias Pow.Plug
-  alias PowInvitation.Ecto.{Context, Schema}
+  alias Pow.{Ecto.Context, Plug}
+  alias PowInvitation.Ecto.Context, as: InvitationContext
+  alias PowInvitation.Ecto.Schema
 
   @doc """
   Creates a new invited user by the current user in the connection.
@@ -15,7 +16,7 @@ defmodule PowInvitation.Plug do
 
     conn
     |> Plug.current_user()
-    |> Context.create(params, config)
+    |> InvitationContext.create(params, config)
     |> case do
       {:ok, user}         -> {:ok, user, conn}
       {:error, changeset} -> {:error, changeset, conn}
@@ -51,7 +52,7 @@ defmodule PowInvitation.Plug do
 
     conn
     |> invited_user()
-    |> Context.update(params, config)
+    |> InvitationContext.update(params, config)
     |> case do
       {:ok, user}         -> {:ok, user, Plug.get_mod(config).do_create(conn, user, config)}
       {:error, changeset} -> {:error, changeset, conn}
@@ -67,7 +68,7 @@ defmodule PowInvitation.Plug do
   def invited_user_from_token(conn, token) do
     config = Plug.fetch_config(conn)
 
-    Context.get_by_invitation_token(token, config)
+    InvitationContext.get_by_invitation_token(token, config)
   end
 
   @doc """

--- a/lib/extensions/reset_password/ecto/context.ex
+++ b/lib/extensions/reset_password/ecto/context.ex
@@ -1,8 +1,5 @@
 defmodule PowResetPassword.Ecto.Context do
   @moduledoc false
-  use Pow.Extension.Ecto.Context.Base
-
-  alias Ecto.Changeset
   alias Pow.{Config, Ecto.Context}
   alias PowResetPassword.Ecto.Schema
 

--- a/lib/extensions/reset_password/plug.ex
+++ b/lib/extensions/reset_password/plug.ex
@@ -3,8 +3,9 @@ defmodule PowResetPassword.Plug do
   Plug helper methods.
   """
   alias Plug.Conn
-  alias Pow.{Config, Plug, Store.Backend.EtsCache, UUID}
-  alias PowResetPassword.{Ecto.Context, Ecto.Schema, Store.ResetTokenCache}
+  alias Pow.{Config, Ecto.Context, Plug, Store.Backend.EtsCache, UUID}
+  alias PowResetPassword.Ecto.Context, as: ResetPasswordContext
+  alias PowResetPassword.{Ecto.Schema, Store.ResetTokenCache}
 
   @doc """
   Creates a changeset from the user fetched in the connection.
@@ -41,7 +42,7 @@ defmodule PowResetPassword.Plug do
     user   =
       params
       |> Map.get("email")
-      |> Context.get_by_email(config)
+      |> ResetPasswordContext.get_by_email(config)
 
     maybe_create_reset_token(conn, user, config)
   end
@@ -87,7 +88,7 @@ defmodule PowResetPassword.Plug do
 
     conn
     |> reset_password_user()
-    |> Context.update_password(params, config)
+    |> ResetPasswordContext.update_password(params, config)
     |> maybe_expire_token(conn, token, config)
   end
 

--- a/lib/pow/extension/ecto/context/base.ex
+++ b/lib/pow/extension/ecto/context/base.ex
@@ -1,32 +1,15 @@
 defmodule Pow.Extension.Ecto.Context.Base do
-  @moduledoc """
-  Used for extensions to add helpers for user contexts.
-
-  The macro will add two helper methods to the module:
-
-    * `user_schema_mod/1`
-    * `repo/1`
-
-  ## Usage
-
-      defmodule MyPowExtension.Ecto.Context do
-        use Pow.Extension.Ecto.Context.Base
-
-        def my_custom_action(_config) do
-          mod  = user_schema_mod(config)
-          repo = repo(config)
-
-          # ...
-        end
-      end
-  """
+  # TODO: Remove by 1.1.0
+  @moduledoc false
   alias Pow.Ecto.Context
 
   @doc false
   defmacro __using__(_opts) do
     quote do
-      def user_schema_mod(config), do: Context.user_schema_mod(config)
-      def repo(config), do: Context.repo(config)
+      IO.warn("use #{unquote(__MODULE__)} is deprecated, please use methods in #{Context} instead")
+
+      defdelegate user_schema_mod(config), to: Context
+      defdelegate repo(config), to: Context
     end
   end
 end


### PR DESCRIPTION
It only delegates to a few methods, so it's better to remove the macro, and have explicit references.