### PR TITLE
Multi-tenant support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.0.8 (TBA)
 
 * Added support for layout in mails with `Pow.Phoenix.Mailer.Mail` by setting `conn.private[:pow_mailer_layout]` same way as the Phoenix layout with `conn.private[:phoenix_layout]`
+* Added `:prefix` support for Ecto repo
 * Fixed bug in `Pow.Ecto.Schema.Changeset.current_password_changeset/3` where an exception would be thrown if the virtual `:current_password` field of the user struct was set and either the `:current_password` change was blank or identical
 * Removed `@changeset.data.__struct__.pow_user_id_field()` in template in favor of using `Pow.Phoenix.ViewHelpers.user_id_field/1`
 * Renamed `Mix.Pow.Ecto.Migration.create_migration_files/3` to `Mix.Pow.Ecto.Migration.create_migration_file/3`

--- a/lib/pow/ecto/context.ex
+++ b/lib/pow/ecto/context.ex
@@ -33,6 +33,7 @@ defmodule Pow.Ecto.Context do
 
     * `:repo` - the ecto repo module (required)
     * `:user` - the user schema module (required)
+    * `:repo_opts` - keyword list options for the repo, `:prefix` can be set here
   """
   alias Pow.Config
   alias Pow.Ecto.Schema
@@ -145,7 +146,9 @@ defmodule Pow.Ecto.Context do
   """
   @spec delete(user(), Config.t()) :: {:ok, user()} | {:error, changeset()}
   def delete(user, config) do
-    Config.repo!(config).delete(user)
+    opts = prefix_opts(config)
+
+    Config.repo!(config).delete(user, opts)
   end
 
   @doc """
@@ -157,8 +160,9 @@ defmodule Pow.Ecto.Context do
   def get_by(clauses, config) do
     user_mod = Config.user!(config)
     clauses  = normalize_user_id_field_value(user_mod, clauses)
+    opts     = prefix_opts(config)
 
-    repo(config).get_by(user_mod, clauses)
+    repo(config).get_by(user_mod, clauses, opts)
   end
 
   defp normalize_user_id_field_value(user_mod, clauses) do
@@ -177,8 +181,10 @@ defmodule Pow.Ecto.Context do
   """
   @spec do_insert(changeset(), Config.t()) :: {:ok, user()} | {:error, changeset()}
   def do_insert(changeset, config) do
+    opts = prefix_opts(config)
+
     changeset
-    |> Config.repo!(config).insert()
+    |> Config.repo!(config).insert(opts)
     |> reload_after_write(config)
   end
 
@@ -189,8 +195,10 @@ defmodule Pow.Ecto.Context do
   """
   @spec do_update(changeset(), Config.t()) :: {:ok, user()} | {:error, changeset()}
   def do_update(changeset, config) do
+    opts = prefix_opts(config)
+
     changeset
-    |> Config.repo!(config).update()
+    |> Config.repo!(config).update(opts)
     |> reload_after_write(config)
   end
 
@@ -198,7 +206,8 @@ defmodule Pow.Ecto.Context do
   defp reload_after_write({:ok, user}, config) do
     # When ecto updates/inserts, has_many :through associations are set to nil.
     # So we'll just reload when writes happen.
-    user = Config.repo!(config).get!(user.__struct__, user.id)
+    opts = prefix_opts(config)
+    user = Config.repo!(config).get!(user.__struct__, user.id, opts)
 
     {:ok, user}
   end
@@ -206,6 +215,16 @@ defmodule Pow.Ecto.Context do
   # TODO: Remove by 1.1.0
   @deprecated "Use `Pow.Config.repo!/1` instead"
   defdelegate repo(config), to: Config, as: :repo!
+
+  defp prefix_opts(config) do
+    config
+    |> Config.get(:repo_opts, [])
+    |> Keyword.get(:prefix, nil)
+    |> case do
+      nil    -> []
+      prefix -> [prefix: prefix]
+    end
+  end
 
   # TODO: Remove by 1.1.0
   @deprecated "Use `Pow.Config.user!/1` instead"

--- a/test/extensions/email_confirmation/ecto/schema_test.exs
+++ b/test/extensions/email_confirmation/ecto/schema_test.exs
@@ -64,13 +64,13 @@ defmodule PowEmailConfirmation.Ecto.SchemaTest do
 
   test "changeset/2 doesn't update when email already taken by another user" do
     changeset = User.changeset(@edit_user, Map.put(@valid_edit_params, :email, "taken@example.com"))
-    {:error, changeset} = RepoMock.update(changeset)
+    {:error, changeset} = RepoMock.update(changeset, [])
     assert changeset.errors[:email] == {"has already been taken", [validation: :unsafe_unique, fields: [:email]]}
     assert changeset.changes.email == "taken@example.com"
     assert changeset.changes.unconfirmed_email == "taken@example.com"
 
     changeset = User.changeset(@edit_user, Map.put(@valid_edit_params, :email, "new@example.com"))
-    {:ok, user} = RepoMock.update(changeset)
+    {:ok, user} = RepoMock.update(changeset, [])
     assert user.email == "test@example.com"
     assert user.unconfirmed_email == "new@example.com"
   end

--- a/test/support/extensions/email_confirmation/repo_mock.ex
+++ b/test/support/extensions/email_confirmation/repo_mock.ex
@@ -17,31 +17,31 @@ defmodule PowEmailConfirmation.Test.RepoMock do
     end
   end
 
-  def get_by(User, email: "test@example.com") do
-    get_by(User, email_confirmation_token: "valid")
+  def get_by(User, [email: "test@example.com"], opts) do
+    get_by(User, [email_confirmation_token: "valid"], opts)
   end
-  def get_by(User, email: "confirmed@example.com") do
-    get_by(User, email_confirmation_token: "valid_confirmed")
+  def get_by(User, [email: "confirmed@example.com"], opts) do
+    get_by(User, [email_confirmation_token: "valid_confirmed"], opts)
   end
-  def get_by(User, email_confirmation_token: "valid"),
+  def get_by(User, [email_confirmation_token: "valid"], _opts),
     do: Ecto.put_meta(@user, state: :loaded)
-  def get_by(User, email_confirmation_token: "invalid"),
+  def get_by(User, [email_confirmation_token: "invalid"], _opts),
     do: nil
-  def get_by(User, email_confirmation_token: "valid_confirmed") do
-    %{get_by(User, email_confirmation_token: "valid") | email_confirmed_at: DateTime.utc_now()}
+  def get_by(User, [email_confirmation_token: "valid_confirmed"], opts) do
+    %{get_by(User, [email_confirmation_token: "valid"], opts) | email_confirmed_at: DateTime.utc_now()}
   end
-  def get_by(User, email_confirmation_token: "valid_unconfirmed_email") do
-    user = get_by(User, email_confirmation_token: "valid_confirmed")
+  def get_by(User, [email_confirmation_token: "valid_unconfirmed_email"], opts) do
+    user = get_by(User, [email_confirmation_token: "valid_confirmed"], opts)
 
     %{user | unconfirmed_email: "new@example.com"}
   end
 
-  def update(%{changes: %{email: "taken@example.com"}} = changeset) do
+  def update(%{changes: %{email: "taken@example.com"}} = changeset, _opts) do
     changeset = Ecto.Changeset.add_error(changeset, :email, "has already been taken")
 
     {:error, changeset}
   end
-  def update(%{valid?: true} = changeset) do
+  def update(%{valid?: true} = changeset, _opts) do
     %{changeset | repo: __MODULE__}
     |> run_prepare()
     |> do_update()
@@ -61,7 +61,7 @@ defmodule PowEmailConfirmation.Test.RepoMock do
     |> Enum.reduce(changeset, & &1.(&2))
   end
 
-  def insert(%{valid?: true} = changeset) do
+  def insert(%{valid?: true} = changeset, _opts) do
     token = Ecto.Changeset.get_field(changeset, :email_confirmation_token)
     email = Ecto.Changeset.get_field(changeset, :email)
     user  = %{@user | email_confirmation_token: token, email: email}
@@ -71,17 +71,17 @@ defmodule PowEmailConfirmation.Test.RepoMock do
     {:ok, user}
   end
 
-  def get!(User, 1), do: Process.get({:user, 1})
+  def get!(User, 1, _opts), do: Process.get({:user, 1})
 
   defmodule Invitation do
     @moduledoc false
     alias PowEmailConfirmation.PowInvitation.Test.Users.User
     alias PowEmailConfirmation.Test.RepoMock
 
-    def get_by(User, invitation_token: "token"), do: Ecto.put_meta(%User{id: 1, email: "test@example.com"}, state: :loaded)
+    def get_by(User, [invitation_token: "token"], _opts), do: Ecto.put_meta(%User{id: 1, email: "test@example.com"}, state: :loaded)
 
-    def update(changeset), do: RepoMock.update(changeset)
+    def update(changeset, opts), do: RepoMock.update(changeset, opts)
 
-    def get!(User, 1), do: Process.get({:user, 1})
+    def get!(User, 1, _opts), do: Process.get({:user, 1})
   end
 end

--- a/test/support/extensions/invitation/repo_mock.ex
+++ b/test/support/extensions/invitation/repo_mock.ex
@@ -5,7 +5,7 @@ defmodule PowInvitation.Test.RepoMock do
 
   @user %User{id: 1, email: "test@example.com"}
 
-  def insert(%{valid?: true} = changeset) do
+  def insert(%{valid?: true} = changeset, _opts) do
     user = %{Ecto.Changeset.apply_changes(changeset) | id: 1}
 
     # We store the user in the process because the user is force reloaded with `get!/2`
@@ -13,21 +13,21 @@ defmodule PowInvitation.Test.RepoMock do
 
     {:ok, user}
   end
-  def insert(%{changes: %{email: "no_email"}} = changeset) do
+  def insert(%{changes: %{email: "no_email"}} = changeset, opts) do
     changeset
     |> Map.put(:valid?, true)
     |> Ecto.Changeset.put_change(:email, nil)
     |> Ecto.Changeset.put_change(:invitation_token, "valid")
-    |> insert()
+    |> insert(opts)
   end
-  def insert(%{valid?: false} = changeset), do: {:error, %{changeset | action: :insert}}
+  def insert(%{valid?: false} = changeset, _opts), do: {:error, %{changeset | action: :insert}}
 
-  def get!(User, 1), do: Process.get({:user, 1})
+  def get!(User, 1, _opts), do: Process.get({:user, 1})
 
-  def get_by(User, [invitation_token: "valid"]), do: %{@user | invitation_token: "valid"}
-  def get_by(User, [invitation_token: "valid_but_accepted"]), do: %{@user | invitation_accepted_at: :now}
-  def get_by(User, [invitation_token: "invalid"]), do: nil
+  def get_by(User, [invitation_token: "valid"], _opts), do: %{@user | invitation_token: "valid"}
+  def get_by(User, [invitation_token: "valid_but_accepted"], _opts), do: %{@user | invitation_accepted_at: :now}
+  def get_by(User, [invitation_token: "invalid"], _opts), do: nil
 
-  def update(%{valid?: true} = changeset), do: {:ok, Ecto.Changeset.apply_changes(changeset)}
-  def update(%{valid?: false} = changeset), do: {:error, %{changeset | action: :update}}
+  def update(%{valid?: true} = changeset, _opts), do: {:ok, Ecto.Changeset.apply_changes(changeset)}
+  def update(%{valid?: false} = changeset, _opts), do: {:error, %{changeset | action: :update}}
 end

--- a/test/support/extensions/persistent_session/repo_mock.ex
+++ b/test/support/extensions/persistent_session/repo_mock.ex
@@ -3,9 +3,9 @@ defmodule PowPersistentSession.Test.RepoMock do
   alias Pow.Ecto.Schema.Password
   alias PowPersistentSession.Test.Users.User
 
-  def get_by(User, id: 1), do: %User{id: 1}
-  def get_by(User, id: -1), do: nil
+  def get_by(User, [id: 1], _opts), do: %User{id: 1}
+  def get_by(User, [id: -1], _opts), do: nil
 
-  def get_by(User, email: "test@example.com"),
+  def get_by(User, [email: "test@example.com"], _opts),
     do: %User{id: 1, password_hash: Password.pbkdf2_hash("secret1234")}
 end

--- a/test/support/extensions/reset_password/repo_mock.ex
+++ b/test/support/extensions/reset_password/repo_mock.ex
@@ -4,10 +4,10 @@ defmodule PowResetPassword.Test.RepoMock do
 
   @user %User{id: 1}
 
-  def get_by(User, [email: "test@example.com"]), do: @user
-  def get_by(User, [email: "invalid@example.com"]), do: nil
+  def get_by(User, [email: "test@example.com"], _opts), do: @user
+  def get_by(User, [email: "invalid@example.com"], _opts), do: nil
 
-  def update(%{valid?: true} = changeset) do
+  def update(%{valid?: true} = changeset, _opts) do
     user = Ecto.Changeset.apply_changes(changeset)
 
     # We store the user in the process because the user is force reloaded with `get!/2`
@@ -15,8 +15,8 @@ defmodule PowResetPassword.Test.RepoMock do
 
     {:ok, user}
   end
-  def update(%{valid?: false} = changeset), do: {:error, %{changeset | action: :update}}
+  def update(%{valid?: false} = changeset, _opts), do: {:error, %{changeset | action: :update}}
 
-  def get!(User, 1), do: Process.get({:user, 1})
-  def get!(User, :missing), do: nil
+  def get!(User, 1, _opts), do: Process.get({:user, 1})
+  def get!(User, :missing, _opts), do: nil
 end


### PR DESCRIPTION
Proposed solution for #139.

Repo opts can be set in the config, to propagate the `:prefix` option:

```elixir
config :my_app, :pow,
  repo_opts: [prefix: "tenant_a"]
```