### PR TITLE
fix scope example in PowInvitation README

### DIFF
--- a/lib/extensions/invitation/README.md
+++ b/lib/extensions/invitation/README.md
@@ -45,7 +45,7 @@ defmodule MyAppWeb.Router do
     plug MyAppWeb.EnsureRolePlug, :admin
   end
 
-  scope "/", MyAppWeb do
+  scope "/" do
     pipe_through [:browser, :authenticated, :admin_role]
 
     resource "/invitations", PowInvitation.Phoenix.InvitationController, only: [:new, :create, :show]


### PR DESCRIPTION
As mentioned in #22 , `scope` cannot be... scoped to the `MyApp` context when dealing with Pow or Pow extension controllers. The README has been updated to reflect a working example.