### PR TITLE
Fix migration bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Added `extension_messages/1` to extension controllers and callbacks
 * Improved feedback for when no templates are generated for an extension with `mix pow.extension.phoenix.gen.templates` and `mix pow.extension.phoenix.mailer.gen.templates` tasks
+* Fixed bug in the migration generator where `references/2` wasn't called with options
 * Deprecated `Pow.Extension.Ecto.Context.Base`
 
 ## v1.0.4 (2019-03-13)

--- a/lib/pow/ecto/schema/migration.ex
+++ b/lib/pow/ecto/schema/migration.ex
@@ -25,7 +25,7 @@ defmodule Pow.Ecto.Schema.Migration do
       create table(:<%= schema.table %><%= if schema.binary_id do %>, primary_key: false<% end %>) do
   <%= if schema.binary_id do %>      add :id, :binary_id, primary_key: true
   <% end %><%= for {k, v} <- schema.attrs do %>      add <%= inspect k %>, <%= inspect v %><%= schema.migration_defaults[k] %>
-  <% end %><%= for {_, i, _, s} <- schema.assocs do %>      add <%= if(String.ends_with?(inspect(i), "_id"), do: inspect(i), else: inspect(i) <> "_id") %>, references(<%= inspect(s) %>), on_delete: :nothing<%= if schema.binary_id do %>, type: :binary_id<% end %>
+  <% end %><%= for {_, i, _, s} <- schema.assocs do %>      add <%= if(String.ends_with?(inspect(i), "_id"), do: inspect(i), else: inspect(i) <> "_id") %>, references(<%= inspect(s) %>, on_delete: :nothing<%= if schema.binary_id do %>, type: :binary_id<% end %>)
   <% end %>
         timestamps()
       end

--- a/test/pow/ecto/schema/migration_test.exs
+++ b/test/pow/ecto/schema/migration_test.exs
@@ -44,10 +44,10 @@ defmodule Pow.Ecto.Schema.MigrationTest do
     assert content =~ "create unique_index(:organizations, [:email])"
 
     content = Migration.gen(Migration.new(Pow, "users", attrs: [{:organization_id, {:references, "organizations"}}]))
-    assert content =~ "add :organization_id, references(\"organizations\"), on_delete: :nothing"
+    assert content =~ "add :organization_id, references(\"organizations\", on_delete: :nothing)"
 
     content = Migration.gen(Migration.new(Pow, "users", attrs: [{:organization_id, {:references, "organizations"}}], binary_id: true))
-    assert content =~ "add :organization_id, references(\"organizations\"), on_delete: :nothing, type: :binary_id"
+    assert content =~ "add :organization_id, references(\"organizations\", on_delete: :nothing, type: :binary_id)"
 
     content = Migration.gen(Migration.new(Pow, "users", indexes: [{:key, true}]))
     assert content =~ "create unique_index(:users, [:key])"


### PR DESCRIPTION
Migration associations with `references/2` was generated with the options outside of the method. This is only ever used in PowAssent, since the extension migrations did generate the it correctly.

Resolves https://github.com/danschultzer/pow_assent/issues/51