### PR TITLE
Only override error flash messages when message is not nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Added `extension_messages/1` to extension controllers and callbacks
 * Improved feedback for when no templates are generated for an extension with `mix pow.extension.phoenix.gen.templates` and `mix pow.extension.phoenix.mailer.gen.templates` tasks
+* Error flash is no longer overridden in `Pow.Phoenix.PlugErrorHandler` if the error message is nil
 * Fixed bug in the migration generator where `references/2` wasn't called with options
 * Support any `:plug` version below `2.0.0`
 * Deprecated `Pow.Extension.Ecto.Context.Base`

--- a/lib/pow/phoenix/controllers/plug_error_handler.ex
+++ b/lib/pow/phoenix/controllers/plug_error_handler.ex
@@ -23,12 +23,15 @@ defmodule Pow.Phoenix.PlugErrorHandler do
   @spec call(Conn.t(), atom()) :: Conn.t()
   def call(conn, :not_authenticated) do
     conn
-    |> Controller.put_flash(:error, messages(conn, Messages).user_not_authenticated(conn))
+    |> maybe_set_error_flash(messages(conn, Messages).user_not_authenticated(conn))
     |> Controller.redirect(to: routes(conn, Routes).user_not_authenticated_path(conn))
   end
   def call(conn, :already_authenticated) do
     conn
-    |> Controller.put_flash(:error, messages(conn, Messages).user_already_authenticated(conn))
+    |> maybe_set_error_flash(messages(conn, Messages).user_already_authenticated(conn))
     |> Controller.redirect(to: routes(conn, Routes).user_already_authenticated_path(conn))
   end
+
+  defp maybe_set_error_flash(conn, nil), do: conn
+  defp maybe_set_error_flash(conn, error), do: Controller.put_flash(conn, :error, error)
 end

--- a/test/pow/phoenix/controllers/plug_error_handler_test.exs
+++ b/test/pow/phoenix/controllers/plug_error_handler_test.exs
@@ -31,6 +31,17 @@ defmodule Pow.Phoenix.PlugErrorHandlerTest do
     assert ConnTest.get_flash(conn, :error) == :not_authenticated
   end
 
+  test "call/2 :not_authenticated doesn't override flash if message is nil", %{conn: conn} do
+    conn =
+      conn
+      |> Conn.put_private(:pow_config, [])
+      |> Phoenix.Controller.put_flash(:error, "Existing error")
+      |> PlugErrorHandler.call(:not_authenticated)
+
+    assert ConnTest.redirected_to(conn) == "/session/new?request_path=%2F"
+    assert ConnTest.get_flash(conn, :error) == "Existing error"
+  end
+
   test "call/2 :already_authenticated", %{conn: conn} do
     conn = PlugErrorHandler.call(conn, :already_authenticated)
 


### PR DESCRIPTION
This resolves https://github.com/danschultzer/pow_assent/issues/58.

It makes more sense to not override the flash message, unless there is actually a message to override with.