### PR TITLE
Prevent users from changing emails with PowEmailConfirmation when already taken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.0.6 (TBA)
 
 * Fixed bug where custom layout setting raised exception in `Pow.Phoenix.ViewHelpers.layout/1`
+* Prevent users from changing their email to one already taken when the PowEmailConfirmation extension has been enabled
 
 ## v1.0.5 (2019-04-09)
 

--- a/lib/extensions/email_confirmation/ecto/schema.ex
+++ b/lib/extensions/email_confirmation/ecto/schema.ex
@@ -69,6 +69,21 @@ defmodule PowEmailConfirmation.Ecto.Schema do
     changeset
     |> Changeset.put_change(:email, current_email)
     |> Changeset.put_change(:unconfirmed_email, new_email)
+    |> Changeset.prepare_changes(&validate_unique_email/1)
   end
   defp maybe_set_unconfirmed_email(changeset, _state, _current_email, _new_email), do: changeset
+
+  defp validate_unique_email(changeset) do
+    opts = Keyword.take(changeset.repo_opts, [:prefix])
+    unconfirmed_email = Changeset.get_change(changeset, :unconfirmed_email)
+    unique_email_changeset =
+      changeset
+      |> Changeset.put_change(:email, unconfirmed_email)
+      |> Changeset.unsafe_validate_unique(:email, changeset.repo, opts)
+
+    case unique_email_changeset.valid? do
+      true  -> changeset
+      false -> unique_email_changeset
+    end
+  end
 end


### PR DESCRIPTION
Resolves #157.

This does a lookup using `Ecto.Changeset.prepare_changes/2` and `Ecto.Changeset.unsafe_validate_unique/2`. During prepare a new changeset is created where `:email` is set to what `:unconfirmed_email` is, and the database is looked up. This is the earliest possible time that this lookup can happen, since before that the repo is unknown.