### PR TITLE
Modifies email field ref to pow_user_id_field

### DIFF
--- a/lib/extensions/email_confirmation/README.md
+++ b/lib/extensions/email_confirmation/README.md
@@ -12,7 +12,7 @@ Follow the instructions for extensions in [README.md](../../../README.md), and s
 
 ## Configuration
 
-Add the following section to your `WEB_PATH/templates/pow/registration/edit.html.eex` template (you may need to generate the templates first) after the e-mail field:
+Add the following section to your `WEB_PATH/templates/pow/registration/edit.html.eex` template (you may need to generate the templates first) after the `pow_user_id_field` field:
 
 ```elixir
 <%= if @changeset.data.unconfirmed_email do %>


### PR DESCRIPTION
The PowInvitation configuration notes reference adding the `unconfirmed_email` after the `email` field, but the actual template uses the name `pow_user_id_field`