### PR TITLE
Fix bug with polluted current_password virtual field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.0.8 (TBA)
+
+* Fixed bug in `Pow.Ecto.Schema.Changeset.current_password_changeset/3` where an exception would be thrown if the virtual `:current_password` field of the user struct was set and either the `:current_password` change was blank or identical
+
 ## v1.0.7 (2019-05-01)
 
 * Fixed bug with Phoenix 1.4.4 scoped routes

--- a/lib/pow/ecto/schema/changeset.ex
+++ b/lib/pow/ecto/schema/changeset.ex
@@ -101,8 +101,16 @@ defmodule Pow.Ecto.Schema.Changeset do
   @spec current_password_changeset(Ecto.Schema.t() | Changeset.t(), map(), Config.t()) :: Changeset.t()
   def current_password_changeset(user_or_changeset, params, config) do
     user_or_changeset
+    |> reset_current_password_field()
     |> Changeset.cast(params, [:current_password])
     |> maybe_validate_current_password(config)
+  end
+
+  defp reset_current_password_field(%{data: user} = changeset) do
+    %{changeset | data: reset_current_password_field(user)}
+  end
+  defp reset_current_password_field(user) do
+    %{user | current_password: nil}
   end
 
   defp maybe_validate_email_format(changeset, :email) do

--- a/test/pow/ecto/schema/changeset_test.exs
+++ b/test/pow/ecto/schema/changeset_test.exs
@@ -91,7 +91,7 @@ defmodule Pow.Ecto.Schema.ChangesetTest do
       assert changeset.errors[:username] == {"has already been taken", [constraint: :unique, constraint_name: "users_username_index"]}
     end
 
-    test "requires password when no password_hash is nil" do
+    test "requires password when password_hash is nil" do
       params = Map.delete(@valid_params, "password")
       changeset = User.changeset(%User{}, params)
 
@@ -161,6 +161,10 @@ defmodule Pow.Ecto.Schema.ChangesetTest do
       assert changeset.valid?
 
       changeset = User.changeset(user, @valid_params)
+      refute changeset.valid?
+      assert changeset.errors[:current_password] == {"can't be blank", [validation: :required]}
+
+      changeset = User.changeset(%{user | current_password: "secret1234"}, @valid_params)
       refute changeset.valid?
       assert changeset.errors[:current_password] == {"can't be blank", [validation: :required]}
 


### PR DESCRIPTION
Resolves an issue where an exception was thrown if the `:current_password` virtual field has been set in the struct, and the change is identical or blank.

This example shows what goes wrong:

```elixir
user =
  %MyApp.Users.User{}
  |> MyApp.Users.User.changeset(%{email: "test@example.com", current_password: "secret1234", password: "secret1234", confirm_password: "secret1234")
  |> MyApp.Repo.insert!()

MyApp.Users.User.changeset(user, %{})

** (FunctionClauseError) no function clause matching in Pow.Ecto.Schema.Changeset.validate_current_password/2

     The following arguments were given to Pow.Ecto.Schema.Changeset.validate_current_password/2:
     
         # 1
         #Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #MyApp.Users.User<>, valid?: true>
     
         # 2
         []
     
     Attempted function clauses (showing 1 out of 1):
     
         defp validate_current_password(%{data: user, changes: %{current_password: password}} = changeset, config)
```