### PR TITLE
Add custom assigns to mail render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v1.0.8 (TBA)
 
+* Added `assigns/2` method support in mailer views so assigns can be modified
 * Fixed bug in `Pow.Ecto.Schema.Changeset.current_password_changeset/3` where an exception would be thrown if the virtual `:current_password` field of the user struct was set and either the `:current_password` change was blank or identical
 * Renamed `Mix.Pow.Ecto.Migration.create_migration_files/3` to `Mix.Pow.Ecto.Migration.create_migration_file/3`
 * Deprecated `Mix.Pow.Ecto.Migration.create_migration_files/3`

--- a/lib/pow/phoenix/mailer/mail.ex
+++ b/lib/pow/phoenix/mailer/mail.ex
@@ -1,6 +1,40 @@
 defmodule Pow.Phoenix.Mailer.Mail do
   @moduledoc """
   Module that renders html and text version of e-mails.
+
+  When a new email is generated, `subject/2` and `render/2` with both text and
+  html version will be called on the view.
+
+  If you wish to modify `assigns` before your custom email templates are
+  rendered, then you should update your `:mailer_view` macro with and
+  `assigns/2` method:
+
+    defmodule MyAppWeb do
+      # ...
+
+      def mailer_view do
+        quote do
+          use Phoenix.View, root: "lib/my_app_web/templates",
+                            namespace: MyAppWeb
+
+          use Phoenix.HTML
+
+          def assigns(_template, assigns), do: Keyword.put(assigns, :layout, {MyAppWeb.LayoutView, :email})
+        end
+      end
+
+      # ...
+
+    end
+
+  You can also add the `assigns/2` method to individual views:
+
+    defmodule MyAppWeb.PowEmailConfirmation.MailerView do
+      @moduledoc false
+      use MyAppWeb, :mailer_view
+
+      def assigns(_template, assigns), do: Keyword.put(assigns, :layout, {MyAppWeb.LayoutView, :email})
+    end
   """
   alias Plug.Conn
   alias Pow.{Config, Plug}
@@ -19,9 +53,9 @@ defmodule Pow.Phoenix.Mailer.Mail do
   def new(conn, user, {view_module, template}, assigns) do
     config       = Plug.fetch_config(conn)
     web_module   = Config.get(config, :web_mailer_module)
+    view_module  = Pow.Phoenix.ViewHelpers.build_view_module(view_module, web_module)
+    assigns      = maybe_assigns(view_module, template, assigns)
     view_assigns = Keyword.merge([conn: conn, user: user], assigns)
-
-    view_module = Pow.Phoenix.ViewHelpers.build_view_module(view_module, web_module)
 
     subject = view_module.subject(template, view_assigns)
     text    = view_module.render("#{template}.text", view_assigns)
@@ -32,5 +66,13 @@ defmodule Pow.Phoenix.Mailer.Mail do
       |> IO.iodata_to_binary()
 
     struct(__MODULE__, user: user, subject: subject, text: text, html: html, assigns: assigns)
+  end
+
+  def maybe_assigns(view_module, template, assigns) do
+    if function_exported?(view_module, :assigns, 2) do
+      view_module.assigns(template, assigns)
+    else
+      assigns
+    end
   end
 end

--- a/test/pow/phoenix/mailer/mail_test.exs
+++ b/test/pow/phoenix/mailer/mail_test.exs
@@ -40,8 +40,8 @@ defmodule Pow.Phoenix.Mailer.MailTest do
     assert mail = Mail.new(conn, :user, {MailerView, :mail_test}, value: "test")
 
     assert mail.user == :user
-    assert mail.subject == ":web_mailer_module subject :user"
-    assert mail.html == "<p>:web_mailer_module html mail :user</p>"
-    assert mail.text == ":web_mailer_module text mail :user"
+    assert mail.subject == ":web_mailer_module subject :user :custom_assign"
+    assert mail.html == "<p>:web_mailer_module html mail :user :custom_assign</p>"
+    assert mail.text == ":web_mailer_module text mail :user :custom_assign"
   end
 end

--- a/test/support/phoenix/views/pow/mailer_view.ex
+++ b/test/support/phoenix/views/pow/mailer_view.ex
@@ -2,5 +2,7 @@ defmodule Pow.Test.Phoenix.Pow.MailerView do
   @moduledoc false
   use Pow.Test.Phoenix.Web, :mailer_view
 
-  def subject(:mail_test, assigns), do: ":web_mailer_module subject #{inspect assigns[:user]}"
+  def subject(:mail_test, assigns), do: ":web_mailer_module subject #{inspect assigns[:user]} #{inspect assigns[:custom_assign]}"
+
+  def assigns(:mail_test, assigns), do: Keyword.put(assigns, :custom_assign, :custom_assign)
 end

--- a/test/support/phoenix/web_module/templates/mailer/mail_test.html.eex
+++ b/test/support/phoenix/web_module/templates/mailer/mail_test.html.eex
@@ -1,1 +1,1 @@
-<%= content_tag(:p, ":web_mailer_module html mail #{inspect @user}") %>
+<%= content_tag(:p, ":web_mailer_module html mail #{inspect @user} #{inspect @custom_assign}") %>

--- a/test/support/phoenix/web_module/templates/mailer/mail_test.text.eex
+++ b/test/support/phoenix/web_module/templates/mailer/mail_test.text.eex
@@ -1,1 +1,1 @@
-<%= ":web_mailer_module text mail #{inspect @user}" %>
+<%= ":web_mailer_module text mail #{inspect @user} #{inspect @custom_assign}" %>


### PR DESCRIPTION
This is experimental work for solving #188.

To set a custom layout you can set up your `:mailer_view` macro like this:

```elixir
defmodule MyAppWeb do
  # ...

  def mailer_view do
    quote do
      use Phoenix.View, root: "lib/my_app_web/templates",
                        namespace: MyAppWeb

      use Phoenix.HTML

      def assigns(_template, assigns), do: Keyword.put(assigns, :layout, {MyAppWeb.LayoutView, :email})
    end
  end

  # ...

end
```

Or you can set up the individual views:

```elixir
defmodule MyAppWeb.PowEmailConfirmation.MailerView do
  @moduledoc false
  use MyAppWeb, :mailer_view

  def assigns(_template, assigns), do: Keyword.put(assigns, :layout, {MyAppWeb.LayoutView, :email})
end
```

I'm not completely sure this is the most appropriate way. The big issue is that there is no plugs/conn/controller handling on mails so you can just add it to the pipeline. Maybe if conn gets assigned a `:phoenix_mailer_layout`, that can be used instead?