### PR TITLE
Add email layout support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v1.0.8 (TBA)
 
+* Added support for layout in mails with `Pow.Phoenix.Mailer.Mail` by setting `conn.private[:pow_mailer_layout]` same way as the Phoenix layout with `conn.private[:phoenix_layout]`
 * Fixed bug in `Pow.Ecto.Schema.Changeset.current_password_changeset/3` where an exception would be thrown if the virtual `:current_password` field of the user struct was set and either the `:current_password` change was blank or identical
 * Renamed `Mix.Pow.Ecto.Migration.create_migration_files/3` to `Mix.Pow.Ecto.Migration.create_migration_file/3`
 * Deprecated `Mix.Pow.Ecto.Migration.create_migration_files/3`

--- a/lib/pow/phoenix/mailer/mail.ex
+++ b/lib/pow/phoenix/mailer/mail.ex
@@ -1,6 +1,38 @@
 defmodule Pow.Phoenix.Mailer.Mail do
   @moduledoc """
   Module that renders html and text version of e-mails.
+
+  ## Custom layout
+
+  By default no layout is used to render the templates. You can set
+  `:pow_mailer_layout` in `conn.private` the same way as you set
+  `:phoenix_layout` to render a layout for the template.
+
+  This is how you can set the mailer layout:
+
+      defmodule MyAppWeb.Router do
+        # ...
+
+        pipeline :pow_email_layout do
+          plug :put_pow_mailer_layout, {MyAppWeb.LayoutView, :email}
+        end
+
+        # ...
+
+        scope "/" do
+          pipe_through [:browser, :pow_email_layout]
+
+          pow_routes()
+        end
+
+        # ...
+
+        defp put_pow_mailer_layout(conn, layout), do: put_private(conn, :pow_mailer_layout, layout)
+      end
+
+  You can use atom or binary as template. If a binary is used then only format
+  that it ends with will be used, e.g. using "email.html" will result in no
+  text layout being used.
   """
   alias Plug.Conn
   alias Pow.{Config, Plug}
@@ -20,17 +52,42 @@ defmodule Pow.Phoenix.Mailer.Mail do
     config       = Plug.fetch_config(conn)
     web_module   = Config.get(config, :web_mailer_module)
     view_assigns = Keyword.merge([conn: conn, user: user], assigns)
+    view_module  = Pow.Phoenix.ViewHelpers.build_view_module(view_module, web_module)
 
-    view_module = Pow.Phoenix.ViewHelpers.build_view_module(view_module, web_module)
-
-    subject = view_module.subject(template, view_assigns)
-    text    = view_module.render("#{template}.text", view_assigns)
-    html    =
-      "#{template}.html"
-      |> view_module.render(view_assigns)
-      |> Phoenix.Template.HTML.encode_to_iodata!()
-      |> IO.iodata_to_binary()
+    subject = render_subject(view_module, template, view_assigns)
+    text    = render(view_module, template, conn, view_assigns, :text)
+    html    = render(view_module, template, conn, view_assigns, :html)
 
     struct(__MODULE__, user: user, subject: subject, text: text, html: html, assigns: assigns)
   end
+
+  defp render_subject(view_module, template, assigns) do
+    view_module.subject(template, assigns)
+  end
+
+  defp render(view_module, template, conn, assigns, format) do
+    view_assigns = prepare_assigns(conn, assigns, format)
+
+    Phoenix.View.render_to_string(view_module, "#{template}.#{format}", view_assigns)
+  end
+
+  defp prepare_assigns(conn, assigns, format) do
+    layout =
+      conn.private
+      |> Map.get(:pow_mailer_layout, false)
+      |> layout(format)
+
+    assigns
+    |> Keyword.put(:layout, layout)
+    |> Keyword.merge(assigns)
+  end
+
+  defp layout({view, layout}, format) when is_atom(layout), do: {view, "#{layout}.#{format}"}
+  defp layout({view, layout}, format) when is_binary(layout) do
+    case String.ends_with?(layout, ".#{format}") do
+      true  -> {view, layout}
+      false -> false
+    end
+  end
+  defp layout(false, _format), do: false
 end

--- a/test/support/phoenix/templates/layout/email.html.eex
+++ b/test/support/phoenix/templates/layout/email.html.eex
@@ -1,0 +1,3 @@
+<h1>Pow e-mail</h1>
+
+<%= render @view_module, @view_template, assigns %>

--- a/test/support/phoenix/templates/layout/email.text.eex
+++ b/test/support/phoenix/templates/layout/email.text.eex
@@ -1,0 +1,3 @@
+# Pow e-mail
+
+<%= render @view_module, @view_template, assigns %>


### PR DESCRIPTION
Resolves issue in #188, and supersedes #190.

I prefer this way as it's closer to how Phoenix works. If a `:pow_mailer_layout` private key is present, it'll be used to render the templates:

```elixir
pipeline :pow_email_layout do
  plug :put_pow_mailer_layout, {MyAppWeb.LayoutView, :email}
end

scope "/" do
  pipe_through [:browser, :pow_email_layout]

  pow_routes()
end

defp put_pow_mailer_layout(conn, layout), do: put_private(conn, :pow_mailer_layout, layout)
```

You can make it so only HTML layout is used if you use a binary like `{MyAppWeb.LayoutView, "email.html"}`. The docs has been updated for `Pow.Phoenix.Mailer.Mail`: https://github.com/danschultzer/pow/blob/mailer-layout/lib/pow/phoenix/mailer/mail.ex