### PR TITLE
Decouple user id field changeset in template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Added support for layout in mails with `Pow.Phoenix.Mailer.Mail` by setting `conn.private[:pow_mailer_layout]` same way as the Phoenix layout with `conn.private[:phoenix_layout]`
 * Fixed bug in `Pow.Ecto.Schema.Changeset.current_password_changeset/3` where an exception would be thrown if the virtual `:current_password` field of the user struct was set and either the `:current_password` change was blank or identical
+* Removed `@changeset.data.__struct__.pow_user_id_field()` in template in favor of using `Pow.Phoenix.ViewHelpers.user_id_field/1`
 * Renamed `Mix.Pow.Ecto.Migration.create_migration_files/3` to `Mix.Pow.Ecto.Migration.create_migration_file/3`
 * Deprecated `Mix.Pow.Ecto.Migration.create_migration_files/3`
 * Deprecated `Pow.Ecto.Context.repo/1` and moved it to `Pow.Config.repo!/1`

--- a/lib/pow/phoenix/html/form_template.ex
+++ b/lib/pow/phoenix/html/form_template.ex
@@ -75,6 +75,6 @@ defmodule Pow.Phoenix.HTML.FormTemplate do
 
   @doc false
   @spec inspect_key(any()) :: binary()
-  def inspect_key({:changeset, :pow_user_id_field}), do: "@changeset.data.__struct__.pow_user_id_field()"
+  def inspect_key({:changeset, :pow_user_id_field}), do: "Pow.Phoenix.ViewHelpers.user_id_field(@changeset)"
   def inspect_key(key), do: inspect(key)
 end

--- a/lib/pow/phoenix/views/view_helpers.ex
+++ b/lib/pow/phoenix/views/view_helpers.ex
@@ -118,4 +118,8 @@ defmodule Pow.Phoenix.ViewHelpers do
     |> Atom.to_string()
     |> String.split(".Phoenix.")
   end
+
+  @spec user_id_field(map()) :: atom()
+  def user_id_field(%{data: %struct{}}), do: struct.pow_user_id_field()
+  def user_id_field(_changeset), do: :email
 end

--- a/test/pow/phoenix/html/form_template_test.exs
+++ b/test/pow/phoenix/html/form_template_test.exs
@@ -12,6 +12,9 @@ defmodule Pow.Phoenix.HTML.FormTemplateTest do
     ])
 
     refute html =~ "<div class=\"form-group\">"
+    assert html =~ "<%= label f, Pow.Phoenix.ViewHelpers.user_id_field(@changeset) %>"
+    assert html =~ "<%= text_input f, Pow.Phoenix.ViewHelpers.user_id_field(@changeset) %>"
+    assert html =~ "<%= error_tag f, Pow.Phoenix.ViewHelpers.user_id_field(@changeset) %>"
     assert html =~ "<%= label f, :password %>"
     assert html =~ "<%= password_input f, :password %>"
     assert html =~ "<%= error_tag f, :password %>"
@@ -25,6 +28,9 @@ defmodule Pow.Phoenix.HTML.FormTemplateTest do
     ], bootstrap: true)
 
     assert html =~ "<div class=\"form-group\">"
+    assert html =~ "<%= label f, Pow.Phoenix.ViewHelpers.user_id_field(@changeset), class: \"control-label\" %>"
+    assert html =~ "<%= text_input f, Pow.Phoenix.ViewHelpers.user_id_field(@changeset), class: \"form-control\" %>"
+    assert html =~ "<%= error_tag f, Pow.Phoenix.ViewHelpers.user_id_field(@changeset) %>"
     assert html =~ "<%= label f, :password, class: \"control-label\" %>"
     assert html =~ "<%= password_input f, :password, class: \"form-control\" %>"
     assert html =~ "<%= error_tag f, :password %>"


### PR DESCRIPTION
Based on https://elixirforum.com/t/using-pow-without-ecto-or-an-rdbms/22496 I have been looking at how to decouple Phoenix from Ecto. This is the final piece for decoupling it completely. I think maybe protocols can be used.