### PR TITLE
Add support for multi-tenancy

### DIFF
--- a/lib/pow/ecto/context.ex
+++ b/lib/pow/ecto/context.ex
@@ -145,7 +145,7 @@ defmodule Pow.Ecto.Context do
   """
   @spec delete(user(), Config.t()) :: {:ok, user()} | {:error, changeset()}
   def delete(user, config) do
-    Config.repo!(config).delete(user)
+    Config.repo!(config).delete(user, prefix: config[:prefix])
   end
 
   @doc """
@@ -158,7 +158,7 @@ defmodule Pow.Ecto.Context do
     user_mod = Config.user!(config)
     clauses  = normalize_user_id_field_value(user_mod, clauses)
 
-    repo(config).get_by(user_mod, clauses)
+    repo(config).get_by(user_mod, clauses, prefix: config[:prefix])
   end
 
   defp normalize_user_id_field_value(user_mod, clauses) do
@@ -178,7 +178,7 @@ defmodule Pow.Ecto.Context do
   @spec do_insert(changeset(), Config.t()) :: {:ok, user()} | {:error, changeset()}
   def do_insert(changeset, config) do
     changeset
-    |> Config.repo!(config).insert()
+    |> Config.repo!(config).insert(prefix: config[:prefix])
     |> reload_after_write(config)
   end
 
@@ -190,7 +190,7 @@ defmodule Pow.Ecto.Context do
   @spec do_update(changeset(), Config.t()) :: {:ok, user()} | {:error, changeset()}
   def do_update(changeset, config) do
     changeset
-    |> Config.repo!(config).update()
+    |> Config.repo!(config).update(prefix: config[:prefix])
     |> reload_after_write(config)
   end
 
@@ -198,7 +198,7 @@ defmodule Pow.Ecto.Context do
   defp reload_after_write({:ok, user}, config) do
     # When ecto updates/inserts, has_many :through associations are set to nil.
     # So we'll just reload when writes happen.
-    user = Config.repo!(config).get!(user.__struct__, user.id)
+    user = Config.repo!(config).get!(user.__struct__, user.id, prefix: config[:prefix])
 
     {:ok, user}
   end

--- a/lib/pow/plug.ex
+++ b/lib/pow/plug.ex
@@ -45,12 +45,32 @@ defmodule Pow.Plug do
   end
 
   @doc """
+  Fetch configuration for multi-tenancy from the private key in the connection.
+
+  It'll raise an error if configuration hasn't been set as a private key.
+  """
+  @spec fetch_config(Conn.t(%{required(:private) => map(), required(:assigns) => %{required(:current_tenant) => String.t()}})) :: Config.t()
+  def fetch_config(%Conn{private: private, assigns: %{current_tenant: current_tenant}}) do
+    Keyword.put(fetch_config(private), :prefix, current_tenant)
+  end
+
+  @doc """
   Fetch configuration from the private key in the connection.
 
   It'll raise an error if configuration hasn't been set as a private key.
   """
-  @spec fetch_config(Conn.t()) :: Config.t()
+  @spec fetch_config(Conn.t(%{required(:private) => map()})) :: Config.t()
   def fetch_config(%Conn{private: private}) do
+    fetch_config(private)
+  end
+
+  @doc """
+  Fetch configuration from the private key in a map.
+
+  It'll raise an error if configuration hasn't been set as a private key.
+  """
+  @spec fetch_config(map()) :: Config.t()
+  def fetch_config(private) do
     private[@private_config_key] || no_config_error()
   end
 

--- a/test/support/extensions/invitation/repo_mock.ex
+++ b/test/support/extensions/invitation/repo_mock.ex
@@ -5,7 +5,8 @@ defmodule PowInvitation.Test.RepoMock do
 
   @user %User{id: 1, email: "test@example.com"}
 
-  def insert(%{valid?: true} = changeset) do
+  def insert(changeset, opts \\ %{})
+  def insert(%{valid?: true} = changeset, _opts) do
     user = %{Ecto.Changeset.apply_changes(changeset) | id: 1}
 
     # We store the user in the process because the user is force reloaded with `get!/2`
@@ -13,21 +14,23 @@ defmodule PowInvitation.Test.RepoMock do
 
     {:ok, user}
   end
-  def insert(%{changes: %{email: "no_email"}} = changeset) do
+  def insert(%{changes: %{email: "no_email"}} = changeset, opts) do
     changeset
     |> Map.put(:valid?, true)
     |> Ecto.Changeset.put_change(:email, nil)
     |> Ecto.Changeset.put_change(:invitation_token, "valid")
-    |> insert()
+    |> insert(opts)
   end
-  def insert(%{valid?: false} = changeset), do: {:error, %{changeset | action: :insert}}
+  def insert(%{valid?: false} = changeset, _opts), do: {:error, %{changeset | action: :insert}}
 
-  def get!(User, 1), do: Process.get({:user, 1})
+  def get!(User, 1, _opts \\ %{}), do: Process.get({:user, 1})
 
-  def get_by(User, [invitation_token: "valid"]), do: %{@user | invitation_token: "valid"}
-  def get_by(User, [invitation_token: "valid_but_accepted"]), do: %{@user | invitation_accepted_at: :now}
-  def get_by(User, [invitation_token: "invalid"]), do: nil
+  def get_by(schema, params, opts \\ %{})
+  def get_by(User, [invitation_token: "valid"], _opts), do: %{@user | invitation_token: "valid"}
+  def get_by(User, [invitation_token: "valid_but_accepted"], _opts), do: %{@user | invitation_accepted_at: :now}
+  def get_by(User, [invitation_token: "invalid"], _opts), do: nil
 
-  def update(%{valid?: true} = changeset), do: {:ok, Ecto.Changeset.apply_changes(changeset)}
-  def update(%{valid?: false} = changeset), do: {:error, %{changeset | action: :update}}
+  def update(changeset, opts \\ %{})
+  def update(%{valid?: true} = changeset, _opts), do: {:ok, Ecto.Changeset.apply_changes(changeset)}
+  def update(%{valid?: false} = changeset, _opts), do: {:error, %{changeset | action: :update}}
 end

--- a/test/support/extensions/mocks.ex
+++ b/test/support/extensions/mocks.ex
@@ -20,10 +20,10 @@ defmodule Pow.Test.ExtensionMocks do
       alias Pow.Ecto.Schema.Password
       alias PowPersistentSession.Test.Users.User
 
-      def get_by(User, id: 1), do: %User{id: 1}
-      def get_by(User, id: -1), do: nil
+      def get_by(User, [id: 1], _opts), do: %User{id: 1}
+      def get_by(User, [id: -1], _opts), do: nil
 
-      def get_by(User, email: "test@example.com"),
+      def get_by(User, [email: "test@example.com"], _opts),
         do: %User{id: 1, password_hash: Password.pbkdf2_hash("secret1234")}
     end
   """

--- a/test/support/extensions/persistent_session/repo_mock.ex
+++ b/test/support/extensions/persistent_session/repo_mock.ex
@@ -3,9 +3,10 @@ defmodule PowPersistentSession.Test.RepoMock do
   alias Pow.Ecto.Schema.Password
   alias PowPersistentSession.Test.Users.User
 
-  def get_by(User, id: 1), do: %User{id: 1}
-  def get_by(User, id: -1), do: nil
+  def get_by(schema, params, opts \\ %{})
+  def get_by(User, [id: 1], _opts), do: %User{id: 1}
+  def get_by(User, [id: -1], _opts), do: nil
 
-  def get_by(User, email: "test@example.com"),
+  def get_by(User, [email: "test@example.com"], _opts),
     do: %User{id: 1, password_hash: Password.pbkdf2_hash("secret1234")}
 end

--- a/test/support/extensions/reset_password/repo_mock.ex
+++ b/test/support/extensions/reset_password/repo_mock.ex
@@ -4,10 +4,12 @@ defmodule PowResetPassword.Test.RepoMock do
 
   @user %User{id: 1}
 
-  def get_by(User, [email: "test@example.com"]), do: @user
-  def get_by(User, [email: "invalid@example.com"]), do: nil
+  def get_by(schema, params, opts \\ %{})
+  def get_by(User, [email: "test@example.com"], _opts), do: @user
+  def get_by(User, [email: "invalid@example.com"], _opts), do: nil
 
-  def update(%{valid?: true} = changeset) do
+  def update(changeset, opts \\ %{})
+  def update(%{valid?: true} = changeset, _opts) do
     user = Ecto.Changeset.apply_changes(changeset)
 
     # We store the user in the process because the user is force reloaded with `get!/2`
@@ -15,8 +17,9 @@ defmodule PowResetPassword.Test.RepoMock do
 
     {:ok, user}
   end
-  def update(%{valid?: false} = changeset), do: {:error, %{changeset | action: :update}}
+  def update(%{valid?: false} = changeset, _opts), do: {:error, %{changeset | action: :update}}
 
-  def get!(User, 1), do: Process.get({:user, 1})
-  def get!(User, :missing), do: nil
+  def get!(schema, id, opts \\ %{})
+  def get!(User, 1, _opts), do: Process.get({:user, 1})
+  def get!(User, :missing, _opts), do: nil
 end


### PR DESCRIPTION
So this is a first go on adding multi-tenancy support 😄 

I modified the plug to look for the `:current_tenant` parameter in the `conn.assigns` map. It should also possible to set the tenant in the config of a custom context. Could also easily add another method to get the tenant from the query params.

I modified the tests to support the extra attribute in all the methods.

I didn't write tests yet for the tenant config option, I wanted first to hear your ideas / comments regarding this approach.

