### PR TITLE
Better decoupled user id field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,19 @@
 
 ## v1.0.8 (TBA)
 
+### Changes
+
 * Added support for layout in mails with `Pow.Phoenix.Mailer.Mail` by setting `conn.private[:pow_mailer_layout]` same way as the Phoenix layout with `conn.private[:phoenix_layout]`
-* Added `:prefix` support for Ecto repo
+* Added `:prefix` repo opts support to use in multitenant apps
+* Removed `@changeset.data.__struct__.pow_user_id_field()` in template in favor of using `Pow.Ecto.Schema.user_id_field/1`
+
+### Bug fixes
+
 * Fixed bug in `Pow.Ecto.Schema.Changeset.current_password_changeset/3` where an exception would be thrown if the virtual `:current_password` field of the user struct was set and either the `:current_password` change was blank or identical
-* Removed `@changeset.data.__struct__.pow_user_id_field()` in template in favor of using `Pow.Phoenix.ViewHelpers.user_id_field/1`
-* Renamed `Mix.Pow.Ecto.Migration.create_migration_files/3` to `Mix.Pow.Ecto.Migration.create_migration_file/3`
-* Deprecated `Mix.Pow.Ecto.Migration.create_migration_files/3`
+
+### Deprecations
+
+* Deprecated `Mix.Pow.Ecto.Migration.create_migration_files/3` and moved it to `Mix.Pow.Ecto.Migration.create_migration_file/3`
 * Deprecated `Pow.Ecto.Context.repo/1` and moved it to `Pow.Config.repo!/1`
 * Deprecated `Pow.Ecto.Context.user_schema_mod/1` and moved it to `Pow.Config.user!/1`
 

--- a/lib/pow/ecto/schema.ex
+++ b/lib/pow/ecto/schema.ex
@@ -246,12 +246,15 @@ defmodule Pow.Ecto.Schema do
   end
 
   @doc """
-  Get user id field key from configuration.
+  Get user id field key from changeset or configuration.
 
   Defaults to `:email`.
   """
-  @spec user_id_field(Config.t()) :: atom()
-  def user_id_field(config \\ []), do: Config.get(config, :user_id_field, :email)
+  @default_user_id_field :email
+  @spec user_id_field(Changeset.t() | Config.t()) :: atom()
+  def user_id_field(%Changeset{data: %user_mod{}}), do: user_mod.pow_user_id_field()
+  def user_id_field(config) when is_list(config), do: Config.get(config, :user_id_field, @default_user_id_field)
+  def user_id_field(_any), do: @default_user_id_field
 
   @doc """
   Normalizes the user id field.

--- a/lib/pow/phoenix/html/form_template.ex
+++ b/lib/pow/phoenix/html/form_template.ex
@@ -75,6 +75,6 @@ defmodule Pow.Phoenix.HTML.FormTemplate do
 
   @doc false
   @spec inspect_key(any()) :: binary()
-  def inspect_key({:changeset, :pow_user_id_field}), do: "Pow.Phoenix.ViewHelpers.user_id_field(@changeset)"
+  def inspect_key({:changeset, :pow_user_id_field}), do: "Pow.Ecto.Schema.user_id_field(@changeset)"
   def inspect_key(key), do: inspect(key)
 end

--- a/lib/pow/phoenix/views/view_helpers.ex
+++ b/lib/pow/phoenix/views/view_helpers.ex
@@ -118,8 +118,4 @@ defmodule Pow.Phoenix.ViewHelpers do
     |> Atom.to_string()
     |> String.split(".Phoenix.")
   end
-
-  @spec user_id_field(map()) :: atom()
-  def user_id_field(%{data: %struct{}}), do: struct.pow_user_id_field()
-  def user_id_field(_changeset), do: :email
 end

--- a/test/pow/phoenix/html/form_template_test.exs
+++ b/test/pow/phoenix/html/form_template_test.exs
@@ -12,9 +12,9 @@ defmodule Pow.Phoenix.HTML.FormTemplateTest do
     ])
 
     refute html =~ "<div class=\"form-group\">"
-    assert html =~ "<%= label f, Pow.Phoenix.ViewHelpers.user_id_field(@changeset) %>"
-    assert html =~ "<%= text_input f, Pow.Phoenix.ViewHelpers.user_id_field(@changeset) %>"
-    assert html =~ "<%= error_tag f, Pow.Phoenix.ViewHelpers.user_id_field(@changeset) %>"
+    assert html =~ "<%= label f, Pow.Ecto.Schema.user_id_field(@changeset) %>"
+    assert html =~ "<%= text_input f, Pow.Ecto.Schema.user_id_field(@changeset) %>"
+    assert html =~ "<%= error_tag f, Pow.Ecto.Schema.user_id_field(@changeset) %>"
     assert html =~ "<%= label f, :password %>"
     assert html =~ "<%= password_input f, :password %>"
     assert html =~ "<%= error_tag f, :password %>"
@@ -28,9 +28,9 @@ defmodule Pow.Phoenix.HTML.FormTemplateTest do
     ], bootstrap: true)
 
     assert html =~ "<div class=\"form-group\">"
-    assert html =~ "<%= label f, Pow.Phoenix.ViewHelpers.user_id_field(@changeset), class: \"control-label\" %>"
-    assert html =~ "<%= text_input f, Pow.Phoenix.ViewHelpers.user_id_field(@changeset), class: \"form-control\" %>"
-    assert html =~ "<%= error_tag f, Pow.Phoenix.ViewHelpers.user_id_field(@changeset) %>"
+    assert html =~ "<%= label f, Pow.Ecto.Schema.user_id_field(@changeset), class: \"control-label\" %>"
+    assert html =~ "<%= text_input f, Pow.Ecto.Schema.user_id_field(@changeset), class: \"form-control\" %>"
+    assert html =~ "<%= error_tag f, Pow.Ecto.Schema.user_id_field(@changeset) %>"
     assert html =~ "<%= label f, :password, class: \"control-label\" %>"
     assert html =~ "<%= password_input f, :password, class: \"form-control\" %>"
     assert html =~ "<%= error_tag f, :password %>"


### PR DESCRIPTION
Update to #192. I didn't like having `Pow.Phoenix.ViewHelpers.user_id_field/1`. It makes more sense to call the `Pow.Ecto.Schema.user_id_field/1` with the changeset, since it'll handle changeset there.