### PR TITLE
Make sure nil values doesn't throw exceptions for authentication and get_by

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## v1.0.9 (TBA)
 
 * Removed call to `Pow.Ecto.Context.repo/1`
+* Fixed bug with exception raised in `Pow.Ecto.Schema.normalize_user_id_field_value/1` when calling `Pow.Ecto.Context.get_by/2` with a non binary user id
+* Fixed bug with exception raised in `Pow.Ecto.Schema.normalize_user_id_field_value/1` when calling `Pow.Ecto.Context.authenticate/2` with a non binary user id
+* `Pow.Ecto.Context.authenticate/2` now returns nil if user id or password is nil
 
 ## v1.0.8 (2019-05-24)
 

--- a/test/pow/ecto/context_test.exs
+++ b/test/pow/ecto/context_test.exs
@@ -55,6 +55,13 @@ defmodule Pow.Ecto.ContextTest do
       assert Context.authenticate(%{"username" => "JOHN.doE", "password" => @password}, @username_config) == username_user
     end
 
+    test "handles nil values" do
+      refute Context.authenticate(%{"password" => @password}, @config)
+      refute Context.authenticate(%{"email" => nil, "password" => @password}, @config)
+      refute Context.authenticate(%{"email" => "test@example.com"}, @config)
+      refute Context.authenticate(%{"email" => "test@example.com", "password" => nil}, @config)
+    end
+
     test "authenticates with extra trailing and leading whitespace for user id field", %{user: user, username_user: username_user} do
       assert Context.authenticate(%{"email" => " test@example.com ", "password" => @password}, @config) == user
       assert Context.authenticate(%{"username" => " john.doe ", "password" => @password}, @username_config) == username_user
@@ -171,6 +178,12 @@ defmodule Pow.Ecto.ContextTest do
 
       get_by_user = Context.get_by([username: "JOHN.DOE"], @username_config)
       assert get_by_user.id == username_user.id
+    end
+
+    test "handles nil value before normalization of user id field value" do
+      assert_raise ArgumentError, ~r/Comparison with nil is forbidden as it is unsafe/, fn ->
+        Context.get_by([email: nil], @config)
+      end
     end
 
     test "as `use Pow.Ecto.Context`", %{user: user} do


### PR DESCRIPTION
Resolves #200 so nil values are now handled before calling `Pow.Ecto.Schema.normalize_user_id_field_value/1`. Also `Pow.Ecto.Context.authenticate/2` will just return nil early if either user id or password is nil.