### PR TITLE
Sync user guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,7 +498,7 @@ You can use the following Phoenix link to add logout link to your Phoenix templa
 
 Enables session-based authorization. The user struct will be collected from a cache store through a GenServer using a unique token generated for the session. The token will be reset every time the authorization level changes (handled by [`Pow.Plug`](lib/pow/plug.ex)).
 
-The user struct fetched can be out of sync with the database if the row in the database is updated by actions outside Pow. In this case it's recommended to add a plug that reloads the user struct and reassigns it to the connection.
+The user struct fetched can be out of sync with the database if the row in the database is updated by actions outside Pow. In this case it's recommended to [add a plug](guides/SYNC_USER.md) that reloads the user struct and reassigns it to the connection.
 
 #### Cache store
 

--- a/guides/SYNC_USER.md
+++ b/guides/SYNC_USER.md
@@ -1,0 +1,79 @@
+# How to sync changes to the user made by actions outside of Pow
+
+Let's say you added a `plan` column on your `users` table and have the following controller which updates the plan your user is subscribed to:
+
+```elixir
+def update_plan(conn, %{"plan" => plan}) do
+  case Users.update_plan(conn.assigns.current_user, plan) do
+    {:ok, user} ->
+      conn
+      |> put_flash(:info, "Plan updated successfully.")
+      |> redirect(to: Routes.profile_path(conn, :show))
+
+    {:error, %Ecto.Changeset{} = changeset} ->
+      render(conn, "plan.html", changeset: changeset)
+  end
+end
+```
+
+The change in the `plan` will not be reflected in `conn.assigns.user` because it is cached. In order to fix this you can notify the `EnsureUserInSync` plug of the change by setting the `:sync_user` session property to true:
+
+```elixir
+def update_plan(conn, %{"plan" => plan}) do
+  case Users.update_plan(conn.assigns.current_user, plan) do
+    {:ok, user} ->
+      conn
+      |> put_session(:sync_user, true)
+      |> put_flash(:info, "Plan updated successfully.")
+      |> redirect(to: Routes.profile_path(conn, :show))
+
+    {:error, %Ecto.Changeset{} = changeset} ->
+      render(conn, "plan.html", changeset: changeset)
+  end
+end
+```
+
+## Add ensure user in sync plug
+
+```elixir
+defmodule MyAppWeb.EnsureUserInSync do
+  @moduledoc """
+  This plug ensures that the current user in the session is in sync with the database.
+
+  ## Example
+
+      plug MyAppWeb.EnsureUserInSync
+  """
+
+  alias Plug.Conn
+
+  @doc false
+  @spec init(any()) :: any()
+  def init(config), do: config
+
+  @doc false
+  @spec call(Conn.t(), list) :: Conn.t()
+  def call(conn, config) do
+    conn
+    |> Conn.get_session(:sync_user)
+    |> maybe_sync_user(conn)
+  end
+
+  defp maybe_sync_user(true, %{assigns: %{current_user: %{id: user_id}}} = conn) do
+    config = Pow.Plug.fetch_config(conn)
+    user   = Pow.Ecto.Context.get_by([id: user_id], config)
+
+    conn
+    |> Conn.delete_session(:sync_user)
+    |> Pow.Plug.Session.do_create(user, config)
+  end
+  defp maybe_sync_user(_, conn), do: conn
+end
+```
+
+Add `plug MyAppWeb.EnsureUserInSync` to your pipeline under `lib/myapp_web/endpoint.ex`:
+
+```elixir
+plug Pow.Plug.Session, otp_app: :my_app
+plug MyAppWeb.EnsureUserInSync
+```

--- a/mix.exs
+++ b/mix.exs
@@ -113,6 +113,10 @@ defmodule Pow.MixProject do
           filename: "Multitenancy",
           title: "Multitenancy with Pow"
         ],
+        "guides/SYNC_USER.md": [
+          filename: "SyncUser",
+          title: "Synchronize user in credentials cache"
+        ],
         "lib/extensions/email_confirmation/README.md": [
           filename: "PowEmailConfirmation",
           title: "PowEmailConfirmation"


### PR DESCRIPTION
A first draft on adding a guid to syncing the user object in case it was updated outside of Pow.