### PR TITLE
Rename `Pow.Plug.get_mod` to `Pow.Plug.get_plug`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,21 @@
 
 ## v1.0.9 (TBA)
 
+### Changes
+
 * `Pow.Phoenix.Router` will now only add specific routes if there is no matching route already defined
-* Removed call to `Pow.Ecto.Context.repo/1`
+* Added `Pow.Plug.get_plug/1` and instead of `:mod`, `:plug` is used in config
+* `Pow.Ecto.Context.authenticate/2` now returns nil if user id or password is nil
+
+### Bug fixes
+
 * Fixed bug with exception raised in `Pow.Ecto.Schema.normalize_user_id_field_value/1` when calling `Pow.Ecto.Context.get_by/2` with a non binary user id
 * Fixed bug with exception raised in `Pow.Ecto.Schema.normalize_user_id_field_value/1` when calling `Pow.Ecto.Context.authenticate/2` with a non binary user id
-* `Pow.Ecto.Context.authenticate/2` now returns nil if user id or password is nil
+
+### Deprecations
+
+* Deprecated `Pow.Plug.get_mod/1`
+* Removed call to `Pow.Ecto.Context.repo/1`
 
 ## v1.0.8 (2019-05-24)
 

--- a/lib/extensions/email_confirmation/plug.ex
+++ b/lib/extensions/email_confirmation/plug.ex
@@ -34,7 +34,7 @@ defmodule PowEmailConfirmation.Plug do
 
   defp maybe_renew_conn(conn, %{id: user_id} = user, config) do
     case Plug.current_user(conn, config) do
-      %{id: ^user_id} -> Plug.get_mod(config).do_create(conn, user, config)
+      %{id: ^user_id} -> Plug.get_plug(config).do_create(conn, user, config)
       _any            -> conn
     end
   end

--- a/lib/extensions/invitation/plug.ex
+++ b/lib/extensions/invitation/plug.ex
@@ -54,7 +54,7 @@ defmodule PowInvitation.Plug do
     |> invited_user()
     |> InvitationContext.update(params, config)
     |> case do
-      {:ok, user}         -> {:ok, user, Plug.get_mod(config).do_create(conn, user, config)}
+      {:ok, user}         -> {:ok, user, Plug.get_plug(config).do_create(conn, user, config)}
       {:error, changeset} -> {:error, changeset, conn}
     end
   end

--- a/lib/extensions/persistent_session/plug.ex
+++ b/lib/extensions/persistent_session/plug.ex
@@ -10,9 +10,9 @@ defmodule PowPersistentSession.Plug do
   """
   @spec create(Conn.t(), map()) :: Conn.t()
   def create(conn, user) do
-    {mod, config} = pow_persistent_session(conn)
+    {plug, config} = pow_persistent_session(conn)
 
-    mod.create(conn, user, config)
+    plug.create(conn, user, config)
   end
 
   @doc """
@@ -20,17 +20,17 @@ defmodule PowPersistentSession.Plug do
   """
   @spec delete(Conn.t()) :: Conn.t()
   def delete(conn) do
-    {mod, config} = pow_persistent_session(conn)
+    {plug, config} = pow_persistent_session(conn)
 
-    mod.delete(conn, config)
+    plug.delete(conn, config)
   end
 
   defp pow_persistent_session(conn) do
-    conn.private[:pow_persistent_session] || raise_no_mod_error()
+    conn.private[:pow_persistent_session] || raise_no_plug_error()
   end
 
-  @spec raise_no_mod_error :: no_return
-  defp raise_no_mod_error do
+  @spec raise_no_plug_error :: no_return
+  defp raise_no_plug_error do
     Config.raise_error("PowPersistentSession plug module not installed. Please add the PowPersistentSession.Plug.Cookie plug to your endpoint.")
   end
 end

--- a/lib/extensions/persistent_session/plug/cookie.ex
+++ b/lib/extensions/persistent_session/plug/cookie.ex
@@ -129,7 +129,7 @@ defmodule PowPersistentSession.Plug.Cookie do
         conn
         |> delete(config)
         |> create(user, config)
-        |> Plug.get_mod(config).do_create(user, config)
+        |> Plug.get_plug(config).do_create(user, config)
     end
   end
 

--- a/lib/pow/plug/base.ex
+++ b/lib/pow/plug/base.ex
@@ -51,18 +51,24 @@ defmodule Pow.Plug.Base do
       @doc """
       Initializes the connection for Pow, and assigns current user.
 
-      If a user is not already assigned, `do_fetch/2` will be called. `:mod` is
+      If a user is not already assigned, `do_fetch/2` will be called. `:plug` is
       added to the private pow configuration key, so it can be used in
       subsequent calls to create, update and delete user credentials from the
       connection.
       """
       def call(conn, config) do
-        config = Config.put(config, :mod, __MODULE__)
+        config = put_plug(config)
         conn   = Plug.put_config(conn, config)
 
         conn
         |> Plug.current_user(config)
         |> maybe_fetch_user(conn, config)
+      end
+
+      defp put_plug(config) do
+        config
+        |> Config.put(:plug, __MODULE__)
+        |> Config.put(:mod, __MODULE__) # TODO: Remove by 1.1.0, this is only for backwards compability
       end
 
       @doc """

--- a/test/extensions/persistent_session/plug/cookie_test.exs
+++ b/test/extensions/persistent_session/plug/cookie_test.exs
@@ -34,9 +34,9 @@ defmodule PowPersistentSession.Plug.CookieTest do
     %{conn | req_cookies: cookies, cookies: cookies}
   end
 
-  test "call/2 sets pow_persistent_session_mod in conn", %{conn: conn, config: config} do
+  test "call/2 sets pow_persistent_session plug in conn", %{conn: conn, config: config} do
     conn            = Cookie.call(conn, Cookie.init([]))
-    expected_config = [mod: Session] ++ config
+    expected_config = [mod: Session, plug: Session] ++ config
 
     assert {Cookie, ^expected_config} = conn.private[:pow_persistent_session]
     refute conn.resp_cookies["persistent_session_cookie"]

--- a/test/pow/plug/session_test.exs
+++ b/test/pow/plug/session_test.exs
@@ -3,7 +3,7 @@ defmodule Pow.Plug.SessionTest do
   doctest Pow.Plug.Session
 
   alias Plug.Conn
-  alias Pow.{Config, Plug, Plug.Session, Store.CredentialsCache}
+  alias Pow.{Plug, Plug.Session, Store.CredentialsCache}
   alias Pow.Test.ConnHelpers
 
   @ets Pow.Test.EtsCacheMock
@@ -24,12 +24,13 @@ defmodule Pow.Plug.SessionTest do
     {:ok, %{conn: conn}}
   end
 
-  test "call/2 sets mod in :pow_config", %{conn: conn} do
+  test "call/2 sets plug in :pow_config", %{conn: conn} do
     opts = Session.init(@default_opts)
     conn = Session.call(conn, opts)
+    expected_config = [mod: Session, plug: Session] ++ @default_opts
 
     assert is_nil(conn.assigns[:current_user])
-    assert conn.private[:pow_config] == Config.put(@default_opts, :mod, Session)
+    assert conn.private[:pow_config] == expected_config
   end
 
   test "call/2 with assigned current_user", %{conn: conn} do

--- a/test/pow/plug_test.exs
+++ b/test/pow/plug_test.exs
@@ -83,6 +83,12 @@ defmodule Pow.PlugTest do
     end
   end
 
+  test "authenticate_user/2 with missing plug config" do
+    assert_raise ConfigError, "Pow plug was not found in config. Please use a Pow plug that puts the `:plug` in the Pow configuration.", fn ->
+      Plug.authenticate_user(conn(), %{"email" => "test@example.com", "password" => "secret"})
+    end
+  end
+
   test "clear_authenticated_user/1" do
     @ets.init()
 


### PR DESCRIPTION
I think `:mod` in config wasn't very descriptive. Now it's changed to `:plug` which makes it much easier to understand.