### PR TITLE
Last login extension

### DIFF
--- a/lib/extensions/last_login/README.md
+++ b/lib/extensions/last_login/README.md
@@ -1,0 +1,15 @@
+# PowLasLogin
+
+This extension adds the ability to track when and from which IP address a user logged in.
+
+You can then add to your templates a message such as:
+
+```elixir
+You last logged in <%= Timex.format!(@conn.assigns.current_user.last_login_at, "{relative}", :relative) %> from <%= @conn.assigns.current_user.last_login_from %>.
+```
+
+Time formatting courtesy of [timex](https://github.com/bitwalker/timex), thanks ;)
+
+## Installation
+
+Follow the instructions for extensions in [README.md](../../../README.md), and set `PowLastLogin` in the `:extensions` list.

--- a/lib/extensions/last_login/ecto/context.ex
+++ b/lib/extensions/last_login/ecto/context.ex
@@ -1,0 +1,15 @@
+defmodule PowLastLogin.Ecto.Context do
+  @moduledoc false
+  alias Pow.{Config, Ecto.Context}
+  alias PowLastLogin.Ecto.Schema
+
+  @doc """
+  Updates `last_login_at` and `last_login_from`.
+  """
+  @spec update_last_login(Context.user(), binary, Config.t()) :: {:ok, Context.user()} | {:error, Context.changeset()}
+  def update_last_login(user, login_from, config) do
+    user
+    |> Schema.last_login_changeset(login_from)
+    |> Context.do_update(config)
+  end
+end

--- a/lib/extensions/last_login/ecto/schema.ex
+++ b/lib/extensions/last_login/ecto/schema.ex
@@ -1,0 +1,31 @@
+defmodule PowLastLogin.Ecto.Schema do
+  @moduledoc false
+  use Pow.Extension.Ecto.Schema.Base
+  alias Ecto.Changeset
+
+  @impl true
+  def attrs(_config) do
+    [
+      {:current_login_at, :utc_datetime},
+      {:current_login_from, :string},
+      {:last_login_at, :utc_datetime},
+      {:last_login_from, :string}
+    ]
+  end
+
+  @spec last_login_changeset(Ecto.Schema.t(), String.t()) :: Changeset.t()
+  def last_login_changeset(%Changeset{data: %user_mod{} = user} = changeset, login_from) do
+    login_at = Pow.Ecto.Schema.__timestamp_for__(user_mod, :last_login_at)
+
+    changeset
+    |> Changeset.put_change(:last_login_at, user.current_login_at)
+    |> Changeset.put_change(:last_login_from, user.current_login_from)
+    |> Changeset.put_change(:current_login_at, login_at)
+    |> Changeset.put_change(:current_login_from, login_from)
+  end
+  def last_login_changeset(user, login_from) do
+    user
+    |> Changeset.change()
+    |> last_login_changeset(login_from)
+  end
+end

--- a/lib/extensions/last_login/phoenix/controllers/controller_callbacks.ex
+++ b/lib/extensions/last_login/phoenix/controllers/controller_callbacks.ex
@@ -1,0 +1,35 @@
+defmodule PowLastLogin.Phoenix.ControllerCallbacks do
+  @moduledoc false
+  use Pow.Extension.Phoenix.ControllerCallbacks.Base
+
+  alias Pow.Plug
+  alias PowLastLogin.Ecto.Context
+
+  @impl true
+  def before_respond(Pow.Phoenix.SessionController, :create, {:ok, conn}, config) do
+    conn
+    |> Plug.current_user()
+    |> update_last_login(conn, config)
+  end
+
+  defp update_last_login(user, conn, config) do
+    remote_ip =
+      conn.remote_ip
+      |> :inet_parse.ntoa
+      |> to_string()
+
+    user
+    |> Context.update_last_login(remote_ip, config)
+    |> case do
+      {:error, _changeset} -> {:error, conn}
+      {:ok, user}          -> {:ok, maybe_renew_conn(conn, user, config)}
+    end
+  end
+
+  defp maybe_renew_conn(conn, %{id: user_id} = user, config) do
+    case Plug.current_user(conn, config) do
+      %{id: ^user_id} -> Plug.get_plug(config).do_create(conn, user, config)
+      _any            -> conn
+    end
+  end
+end

--- a/test/extensions/last_login/ecto/schema_test.exs
+++ b/test/extensions/last_login/ecto/schema_test.exs
@@ -1,0 +1,49 @@
+defmodule PowLastLogin.Ecto.SchemaTest do
+  use ExUnit.Case
+  doctest PowLastLogin.Ecto.Schema
+
+  alias PowLastLogin.Ecto.Schema
+  alias PowLastLogin.Test.{Users.User}
+
+  @password      "secret1234"
+  @user          Ecto.put_meta(%User{email: "test@example.com", password: @password, confirm_password: @password}, state: :loaded)
+
+  @first_login_at    DateTime.utc_now()
+  @first_login_from  "127.0.0.1"
+  @second_login_from "127.0.0.2"
+
+  test "user_schema/1" do
+    user = %User{}
+
+    assert Map.has_key?(user, :current_login_at)
+    assert Map.has_key?(user, :current_login_from)
+    assert Map.has_key?(user, :last_login_at)
+    assert Map.has_key?(user, :last_login_from)
+  end
+
+  test "last_login_changeset/2 sets :current_login_from and :current_login_at" do
+    changeset = Schema.last_login_changeset(@user, @first_login_from)
+    assert changeset.valid?
+
+    assert changeset.changes.current_login_from == @first_login_from
+    assert Ecto.Changeset.get_change(changeset, :current_login_at)
+    refute Ecto.Changeset.get_change(changeset, :last_login_at)
+    refute Ecto.Changeset.get_change(changeset, :last_login_from)
+    refute changeset.errors[:current_login_at]
+    refute changeset.errors[:current_login_from]
+    refute changeset.errors[:last_login_at]
+    refute changeset.errors[:last_login_from]
+  end
+
+  test "last_login_changeset/2 puts :current_login_at as :last_login_at and :current_login_from as :last_login_from" do
+    user = %{@user | current_login_at: @first_login_at, current_login_from: @first_login_from}
+
+    changeset = Schema.last_login_changeset(user, @second_login_from)
+    assert changeset.valid?
+
+    refute changeset.changes.current_login_at == user.current_login_at
+    assert changeset.changes.current_login_from == @second_login_from
+    assert changeset.changes.last_login_at == @first_login_at
+    assert changeset.changes.last_login_from == @first_login_from
+  end
+end

--- a/test/extensions/last_login/phoenix/controllers/controller_callbacks_test.exs
+++ b/test/extensions/last_login/phoenix/controllers/controller_callbacks_test.exs
@@ -1,0 +1,18 @@
+defmodule PowLastLogin.Phoenix.ControllerCallbacksTest do
+  use PowLastLogin.TestWeb.Phoenix.ConnCase
+
+  alias Pow.{Plug}
+
+  @password "secret1234"
+
+  describe "Pow.Phoenix.SessionController.create/2" do
+    @valid_params %{"email" => "test@example.com", "password" => @password}
+
+    test "sets current_login_from and current_login_at", %{conn: conn} do
+      conn = post conn, Routes.pow_session_path(conn, :create, %{"user" => @valid_params})
+
+      assert %{current_login_from: "127.0.0.1", current_login_at: current_login_at} = Plug.current_user(conn)
+      refute current_login_at == nil
+    end
+  end
+end

--- a/test/support/extensions/last_login/pow.ex
+++ b/test/support/extensions/last_login/pow.ex
@@ -1,0 +1,5 @@
+defmodule PowLastLogin.Test do
+  @moduledoc false
+  use Pow.Test.ExtensionMocks,
+    extensions: [PowLastLogin]
+end


### PR DESCRIPTION
I added an extension to make it easy to track the current & last time and IP a user logged in. It's quite straightforward, adds 4 columns to the database.

The only thing is that I couldn't get the controller test to work. It keeps on crashing saying:
```
  1) test Pow.Phoenix.SessionController.create/2 sets current_login_from and current_login_at (PowLastLogin.Phoenix.ControllerCallbacksTest)
     test/extensions/last_login/phoenix/controllers/controller_callbacks_test.exs:11
     ** (ArgumentError) argument error
     code: conn = post conn, Routes.pow_session_path(conn, :create, %{"user" => @valid_params})
     stacktrace:
       (stdlib) :ets.lookup(PowLastLogin.TestWeb.Phoenix.Endpoint, :secret_key_base)
       (pow) lib/phoenix/endpoint.ex:642: PowLastLogin.TestWeb.Phoenix.Endpoint.config/2
       (elixir) lib/map.ex:752: Map.update!/3
       (pow) test/support/extensions/mocks.ex:150: PowLastLogin.TestWeb.Phoenix.Endpoint.call/2
       (phoenix) lib/phoenix/test/conn_test.ex:235: Phoenix.ConnTest.dispatch/5
       test/extensions/last_login/phoenix/controllers/controller_callbacks_test.exs:12: (test)
```

I've spent an hour trying to find out why, I give up! 😆 

Anyway what do you think about adding this extension? I needed it for a couple of project I'm working on now ... 