### PR TITLE
Prevent browser cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v1.0.10 (TBA)
 
+* Prevent browser cache of `Pow.Phoenix.SessionController.new/2`, `Pow.Phoenix.RegistrationController.new/2` and `PowInvitation.Phoenix.InvitationController.edit/2` by setting "Cache-Control" header unless it already has been customized
 * All links in docs generated with `mix docs` and on [hexdocs.pm](http://hexdocs.pm/pow/) now works
 * Generated docs now uses lower case file name except for `README`, `CONTRIBUTING` and `CHANGELOG`
 * Removed duplicate call for `Pow.Plug.Session.delete/2` in `Pow.Plug.Sesssion.create/3`

--- a/lib/extensions/invitation/phoenix/controllers/invitation_controller.ex
+++ b/lib/extensions/invitation/phoenix/controllers/invitation_controller.ex
@@ -11,6 +11,7 @@ defmodule PowInvitation.Phoenix.InvitationController do
   plug :load_user_from_invitation_token when action in [:show, :edit, :update]
   plug :assign_create_path when action in [:new, :create]
   plug :assign_update_path when action in [:edit, :update]
+  plug :put_no_cache_header when action in [:edit]
 
   @spec process_new(Conn.t(), map()) :: {:ok, map(), Conn.t()}
   def process_new(conn, _params) do

--- a/lib/pow/phoenix/controllers/registration_controller.ex
+++ b/lib/pow/phoenix/controllers/registration_controller.ex
@@ -9,6 +9,7 @@ defmodule Pow.Phoenix.RegistrationController do
   plug :require_authenticated when action in [:edit, :update, :delete]
   plug :assign_create_path when action in [:new, :create]
   plug :assign_update_path when action in [:edit, :update]
+  plug :put_no_cache_header when action in [:new]
 
   @spec process_new(Conn.t(), map()) :: {:ok, map(), Conn.t()}
   def process_new(conn, _params) do

--- a/lib/pow/phoenix/controllers/session_controller.ex
+++ b/lib/pow/phoenix/controllers/session_controller.ex
@@ -14,6 +14,7 @@ defmodule Pow.Phoenix.SessionController do
   plug :require_authenticated when action in [:delete]
   plug :assign_request_path when action in [:new, :create]
   plug :assign_create_path when action in [:new, :create]
+  plug :put_no_cache_header when action in [:new]
 
   @doc false
   @spec process_new(Conn.t(), map()) :: {:ok, map(), Conn.t()}

--- a/test/extensions/invitation/phoenix/controllers/invitation_controller_test.exs
+++ b/test/extensions/invitation/phoenix/controllers/invitation_controller_test.exs
@@ -129,6 +129,8 @@ defmodule PowInvitation.Phoenix.InvitationControllerTest do
     test "shows", %{conn: conn} do
       conn = get conn, Routes.pow_invitation_invitation_path(conn, :edit, "valid")
 
+      assert Conn.get_resp_header(conn, "cache-control") == ["no-cache, no-store, must-revalidate"]
+
       assert html = html_response(conn, 200)
       assert html =~ "<label for=\"user_email\">Email</label>"
       assert html =~ "<input id=\"user_email\" name=\"user[email]\" type=\"text\" value=\"test@example.com\">"

--- a/test/pow/phoenix/controllers/registration_controller_test.exs
+++ b/test/pow/phoenix/controllers/registration_controller_test.exs
@@ -8,6 +8,8 @@ defmodule Pow.Phoenix.RegistrationControllerTest do
     test "shows", %{conn: conn} do
       conn = get(conn, Routes.pow_registration_path(conn, :new))
 
+      assert Conn.get_resp_header(conn, "cache-control") == ["no-cache, no-store, must-revalidate"]
+
       assert html = html_response(conn, 200)
       assert html =~ Routes.pow_registration_path(conn, :create)
       assert html =~ "<label for=\"user_email\">Email</label>"

--- a/test/pow/phoenix/controllers/session_controller_test.exs
+++ b/test/pow/phoenix/controllers/session_controller_test.exs
@@ -17,6 +17,8 @@ defmodule Pow.Phoenix.SessionControllerTest do
     test "shows", %{conn: conn} do
       conn = get(conn, Routes.pow_session_path(conn, :new))
 
+      assert Conn.get_resp_header(conn, "cache-control") == ["no-cache, no-store, must-revalidate"]
+
       assert html = html_response(conn, 200)
       assert html =~ Routes.pow_session_path(conn, :create)
       refute html =~ "request_path="


### PR DESCRIPTION
Resolves #212 

This will set the "cache-control" header to "no-cache, no-store, must-revalidate" on login/signup pages, only if the current header is just the default struct value. This prevents back button from showing the login/signup pages when user has been authenticated. Developers can easily override this default behavior by setting their own cache control header (albeit this will not work if it's identical to the default struct value).