### PR TITLE
[Guide] Add Logging for adapter errors

### DIFF
--- a/guides/swoosh_mailer.md
+++ b/guides/swoosh_mailer.md
@@ -23,7 +23,8 @@ defmodule MyAppWeb.PowMailer do
   end
 
   def process(email) do
-    deliver(email)
+    email
+    |> deliver()
     |> log_warnings()
   end
 
@@ -31,7 +32,7 @@ defmodule MyAppWeb.PowMailer do
     Logger.warn("Mailer backend failed with: #{inspect(reason)}")
   end
 
-  defp log_warnings(ok), do: ok
+  defp log_warnings({:ok, response}), do: {:ok, response}
 end
 ```
 

--- a/guides/swoosh_mailer.md
+++ b/guides/swoosh_mailer.md
@@ -10,6 +10,8 @@ defmodule MyAppWeb.PowMailer do
   use Swoosh.Mailer, otp_app: :my_app
 
   import Swoosh.Email
+  
+  require Logger
 
   def cast(%{user: user, subject: subject, text: text, html: html}) do
     %Swoosh.Email{}
@@ -22,7 +24,14 @@ defmodule MyAppWeb.PowMailer do
 
   def process(email) do
     deliver(email)
+    |> log_warnings()
   end
+
+  defp log_warnings({:error, reason}) do
+    Logger.warn("Mailer backend failed with: #{inspect(reason)}")
+  end
+
+  defp log_warnings(ok), do: ok
 end
 ```
 


### PR DESCRIPTION
[`Swoosh.Mailer.deliver/2`](https://hexdocs.pm/swoosh/Swoosh.Mailer.html#deliver/2) can return  [`{ :error, term() } | { :ok, term() }`](https://hexdocs.pm/swoosh/Swoosh.Adapter.html#c:deliver/2). The problem with the old method here is that we are swallowing any useful errors that would arise from configuration issues. I ran into an unrelated issue earlier (my doing) and I came across this.