### PR TITLE
Add note about @pow_config

### DIFF
--- a/lib/pow/ecto/schema.ex
+++ b/lib/pow/ecto/schema.ex
@@ -2,7 +2,7 @@ defmodule Pow.Ecto.Schema do
   @moduledoc """
   Handles the Ecto schema for user.
 
-  The macro will create a `@pow_fields` module attribute, and append fields to
+  `__using__/1` will create a `@pow_fields` module attribute, and append fields to
   it using the attributes from `Pow.Ecto.Schema.Fields.attrs/1`. The
   `pow_user_fields/0` macro will use these attributes to create fields in the
   ecto schema.
@@ -77,8 +77,7 @@ defmodule Pow.Ecto.Schema do
         end
       end
       
-  Note that @pow_config is set by `use Pow.Ecto.Schema` which should already 
-  exist in your file.
+  Note that the `__using__/1` macro creates the `@pow_config` module attribute.
 
   ## Configuration options
 
@@ -91,7 +90,13 @@ defmodule Pow.Ecto.Schema do
   @callback changeset(Ecto.Schema.t() | Changeset.t(), map()) :: Changeset.t()
   @callback verify_password(Ecto.Schema.t(), binary()) :: boolean()
 
-  @doc false
+  @doc """
+  Scaffolds your schema module. It adds `@pow_fields` and `@pow_config` attributes to the module,
+  and defines default `changeset/2` and `verify_password/2` functions that you can override.
+  It is automatically invoked when calling 
+      use Pow.Ecto.Schema
+  in your module.
+  """
   defmacro __using__(config) do
     quote do
       @behaviour unquote(__MODULE__)

--- a/lib/pow/ecto/schema.ex
+++ b/lib/pow/ecto/schema.ex
@@ -22,7 +22,7 @@ defmodule Pow.Ecto.Schema do
   Finally `pow_user_id_field/0` method is added to the module that is used to
   fetch the user id field name.
 
-  A `@pow_config` module attribute is created containing the options that was
+  A `@pow_config` module attribute is created containing the options that were
   passed to the macro with the `use Pow.Ecto.Schema, ...` call.
 
   ## Usage
@@ -97,7 +97,7 @@ defmodule Pow.Ecto.Schema do
   ## Customize Pow changeset
 
   You can extract individual changeset methods to modify the changeset flow
-  entirely. As an example, this  is how you can remove the validation check for
+  entirely. As an example, this is how you can remove the validation check for
   confirm password in the changeset method:
 
       defmodule MyApp.Users.User do
@@ -116,7 +116,7 @@ defmodule Pow.Ecto.Schema do
         end
       end
 
-  Note that the changeset methods in `Pow.Ecto.Schema.Changeset` requires the
+  Note that the changeset methods in `Pow.Ecto.Schema.Changeset` require the
   Pow ecto module configuration that is passed to the
   `use Pow.Ecto.Schema, ...` call. This can be fetched by using the
   `@pow_config` module attribute.

--- a/lib/pow/ecto/schema.ex
+++ b/lib/pow/ecto/schema.ex
@@ -76,6 +76,9 @@ defmodule Pow.Ecto.Schema do
           |> new_password_changeset(attrs, @pow_config)
         end
       end
+      
+  Note that @pow_config is set by `use Pow.Ecto.Schema` which should already 
+  exist in your file.
 
   ## Configuration options
 


### PR DESCRIPTION
The current documentation on customizing a changeset appears to have a "magic" `@pow_config` module attribute. This change makes it clear as per what was mentioned in #86.