### PR TITLE
Distributed cluster support in MnesiaCache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: elixir
-elixir: 1.8
+elixir: 1.9
 otp_release: 22.0
 services:
   - postgresql
@@ -12,7 +12,7 @@ jobs:
         - mix test
         - MIX_ENV=test mix credo --ignore design.tagtodo
     - stage: test
-      elixir: 1.9.0-rc.0
+      elixir: 1.8
       script: *test_scripts
     - stage: test
       script: *test_scripts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * `PowPersistentSession.Plug.Base` now accepts `:persistent_session_ttl` which will pass the TTL to the cache backend and used for the max age of the sesion cookie in `PowPersistentSession.Plug.Cookie`
 * Deprecated `:persistent_session_cookie_max_age` configuration setting
 * `Pow.Store.Backend.MnesiaCache` now handles distributed cluster
+* Removed `:nodes` config option for `Pow.Store.Backend.MnesiaCache`
 
 ## v1.0.11 (2019-06-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * To prevent timing attacks, the UUID is always generated in `PowResetPassword.Plug.create_reset_token/2` whether the user exists or not.
 * `PowPersistentSession.Plug.Base` now accepts `:persistent_session_ttl` which will pass the TTL to the cache backend and used for the max age of the sesion cookie in `PowPersistentSession.Plug.Cookie`
 * Deprecated `:persistent_session_cookie_max_age` configuration setting
+* `Pow.Store.Backend.MnesiaCache` now handles distributed cluster
 
 ## v1.0.11 (2019-06-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * To prevent timing attacks, the UUID is always generated in `PowResetPassword.Plug.create_reset_token/2` whether the user exists or not.
 * `PowPersistentSession.Plug.Base` now accepts `:persistent_session_ttl` which will pass the TTL to the cache backend and used for the max age of the sesion cookie in `PowPersistentSession.Plug.Cookie`
 * Deprecated `:persistent_session_cookie_max_age` configuration setting
-* `Pow.Store.Backend.MnesiaCache` will now auto join distributed clusters
+* `Pow.Store.Backend.MnesiaCache` can now auto join clusters
 * `Pow.Store.Backend.MnesiaCache.Unsplit` module added for self-healing after network split
 * Removed `:nodes` config option for `Pow.Store.Backend.MnesiaCache`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 * To prevent timing attacks, the UUID is always generated in `PowResetPassword.Plug.create_reset_token/2` whether the user exists or not.
 * `PowPersistentSession.Plug.Base` now accepts `:persistent_session_ttl` which will pass the TTL to the cache backend and used for the max age of the sesion cookie in `PowPersistentSession.Plug.Cookie`
 * Deprecated `:persistent_session_cookie_max_age` configuration setting
-* `Pow.Store.Backend.MnesiaCache` now handles distributed cluster
+* `Pow.Store.Backend.MnesiaCache` will now auto join distributed clusters
+* `Pow.Store.Backend.MnesiaCache.Unsplit` module added for self-healing after network split
 * Removed `:nodes` config option for `Pow.Store.Backend.MnesiaCache`
 
 ## v1.0.11 (2019-06-13)

--- a/README.md
+++ b/README.md
@@ -524,6 +524,9 @@ defmodule MyAppWeb.Application do
       MyApp.Repo,
       MyAppWeb.Endpoint,
       Pow.Store.Backend.MnesiaCache
+      # # Or in a distributed system:
+      # {Pow.Store.Backend.MnesiaCache, extra_db_nodes: Node.list()},
+      # Pow.Store.Backend.MnesiaCache.Unsplit # Recovers the MnesiaCache from split-brain
     ]
 
     opts = [strategy: :one_for_one, name: MyAppWeb.Supervisor]

--- a/README.md
+++ b/README.md
@@ -536,7 +536,7 @@ end
 
 Update the config `cache_store_backend: Pow.Store.Backend.MnesiaCache`.
 
-Remember to add `:mnesia` to your `:included_applications` so it'll be available for your release build.
+Remember to add `:mnesia` to your `:extra_applications` so it'll be available for your release build.
 
 The MnesiaCache requires write access. If you've a read-only file system you should take a look at the [Redis cache backend store guide](guides/redis_cache_store_backend.md).
 

--- a/README.md
+++ b/README.md
@@ -526,7 +526,7 @@ defmodule MyAppWeb.Application do
       Pow.Store.Backend.MnesiaCache
       # # Or in a distributed system:
       # {Pow.Store.Backend.MnesiaCache, extra_db_nodes: Node.list()},
-      # Pow.Store.Backend.MnesiaCache.Unsplit # Recovers the MnesiaCache from split-brain
+      # Pow.Store.Backend.MnesiaCache.Unsplit # Recover from netsplit
     ]
 
     opts = [strategy: :one_for_one, name: MyAppWeb.Supervisor]

--- a/README.md
+++ b/README.md
@@ -523,7 +523,7 @@ defmodule MyAppWeb.Application do
     children = [
       MyApp.Repo,
       MyAppWeb.Endpoint,
-      {Pow.Store.Backend.MnesiaCache, nodes: [node()]}
+      Pow.Store.Backend.MnesiaCache
     ]
 
     opts = [strategy: :one_for_one, name: MyAppWeb.Supervisor]

--- a/lib/pow/store/backend/ets_cache.ex
+++ b/lib/pow/store/backend/ets_cache.ex
@@ -54,7 +54,7 @@ defmodule Pow.Store.Backend.EtsCache do
   @impl GenServer
   @spec init(Config.t()) :: {:ok, map()}
   def init(_config) do
-    table_init()
+    init_table()
 
     {:ok, %{invalidators: %{}}}
   end
@@ -124,7 +124,7 @@ defmodule Pow.Store.Backend.EtsCache do
 
   defp table_delete(config, key), do: :ets.delete(@ets_cache_tab, ets_key(config, key))
 
-  defp table_init do
+  defp init_table do
     :ets.new(@ets_cache_tab, [:set, :protected, :named_table])
   end
 

--- a/lib/pow/store/backend/mnesia_cache.ex
+++ b/lib/pow/store/backend/mnesia_cache.ex
@@ -27,6 +27,34 @@ defmodule Pow.Store.Backend.MnesiaCache do
 
       config :mnesia, dir: System.get_env("MNESIA_DIR")
 
+  MnesiaCache can also handle netsplit scenarios if you start up
+  `Pow.Store.Backend.MnesiaCache.Unsplit` on your node. The oldest node will be
+  used as the master node, and the data will be force reloaded from that node.
+
+  ## Usage
+
+  To start the GenServer, add it to your application `start/2` method:
+
+      defmodule MyAppWeb.Application do
+        use Application
+
+        def start(_type, _args) do
+          children = [
+            MyApp.Repo,
+            MyAppWeb.Endpoint,
+            Pow.Store.Backend.MnesiaCache
+            # # Or in a distributed system:
+            # {Pow.Store.Backend.MnesiaCache, extra_db_nodes: Node.list()},
+            # Pow.Store.Backend.MnesiaCache.Unsplit # Recovers the MnesiaCache from split-brain
+          ]
+
+          opts = [strategy: :one_for_one, name: MyAppWeb.Supervisor]
+          Supervisor.start_link(children, opts)
+        end
+
+        # ...
+      end
+
   ## Initialization options
 
     * `:extra_db_nodes` - list of nodes in cluster to connect to.

--- a/lib/pow/store/backend/mnesia_cache.ex
+++ b/lib/pow/store/backend/mnesia_cache.ex
@@ -304,7 +304,8 @@ defmodule Pow.Store.Backend.MnesiaCache do
   end
 
   defp join_cluster(config, cluster_nodes) do
-    with :ok <- maybe_set_mnesia_master_nodes(cluster_nodes),
+    with :ok <- set_mnesia_master_nodes(cluster_nodes),
+         :ok <- start_mnesia(),
          :ok <- connect_to_cluster(cluster_nodes),
          :ok <- change_table_copy_type(config),
          :ok <- sync_table(config, cluster_nodes),
@@ -327,7 +328,7 @@ defmodule Pow.Store.Backend.MnesiaCache do
     end
   end
 
-  defp maybe_set_mnesia_master_nodes(cluster_nodes) do
+  defp set_mnesia_master_nodes(cluster_nodes) do
     case :mnesia.system_info(:running_db_nodes) do
       [] ->
         :ok
@@ -337,10 +338,6 @@ defmodule Pow.Store.Backend.MnesiaCache do
 
         :mnesia.set_master_nodes(@mnesia_cache_tab, cluster_nodes)
     end
-
-    start_mnesia()
-
-    :ok
   end
 
   defp change_table_copy_type(config) do

--- a/lib/pow/store/backend/mnesia_cache.ex
+++ b/lib/pow/store/backend/mnesia_cache.ex
@@ -6,9 +6,33 @@ defmodule Pow.Store.Backend.MnesiaCache do
   keys using the `expire` value. If the `expire` datetime is past, it'll
   send call the invalidator immediately.
 
+  ## Distribution
+
+  The MnesiaCache is built to handle multi-node setup.
+
+  If you initialize with `extra_db_nodes: Node.list()`, it'll automatically
+  connect to the cluster. If there is no other nodes available, the data
+  persisted to disk will be loaded, but if a cluster is running, the persisted
+  data (if any) will be purged on initialization, and the data from the cluster
+  will be loaded to the server.
+
+  When a cache key expires, the expiration will be verified before deletion to
+  ensure that it hasn't been updated by another node. When a key is updated on
+  a node, the node will ping all other nodes to refresh their invalidators so
+  the new TTL is used.
+
+  All nodes spun up will by default persist to disk. If you run multiple nodes
+  from the same directory you should make sure that each node has a separate
+  dir path configured. This can be done using different config files, or by
+  using system environment variables:
+
+      config :mnesia, dir: System.get_env("MNESIA_DIR")
+
   ## Initialization options
 
     * `:nodes` - list of nodes to use. This value defaults to `[node()]`.
+
+    * `:extra_db_nodes` - list of nodes in cluster to connect to.
 
     * `:table_opts` - options to add to table definition. This value defaults
       to `[disc_copies: nodes]`.
@@ -25,6 +49,8 @@ defmodule Pow.Store.Backend.MnesiaCache do
   """
   use GenServer
   alias Pow.{Config, Store.Base}
+
+  require Logger
 
   @behaviour Base
   @mnesia_cache_tab __MODULE__
@@ -63,7 +89,7 @@ defmodule Pow.Store.Backend.MnesiaCache do
   @impl GenServer
   @spec init(Config.t()) :: {:ok, map()}
   def init(config) do
-    table_init(config)
+    init_mnesia(config)
 
     {:ok, %{invalidators: init_invalidators(config)}}
   end
@@ -71,8 +97,10 @@ defmodule Pow.Store.Backend.MnesiaCache do
   @impl GenServer
   @spec handle_cast({:cache, Config.t(), binary(), any(), integer()}, map()) :: {:noreply, map()}
   def handle_cast({:cache, config, key, value, ttl}, %{invalidators: invalidators} = state) do
-    invalidators = update_invalidators(config, invalidators, key, ttl)
     table_update(config, key, value, ttl)
+
+    invalidators = update_invalidators(config, invalidators, key, ttl)
+    refresh_invalidators_in_cluster(config)
 
     {:noreply, %{state | invalidators: invalidators}}
   end
@@ -85,14 +113,35 @@ defmodule Pow.Store.Backend.MnesiaCache do
     {:noreply, %{state | invalidators: invalidators}}
   end
 
+  @spec handle_cast({:refresh_invalidators, Config.t()}, map()) :: {:noreply, map()}
+  def handle_cast({:refresh_invalidators, config}, %{invalidators: invalidators} = state) do
+    clear_invalidators(invalidators)
+
+    {:noreply, %{state | invalidators: init_invalidators(config)}}
+  end
+
   @impl GenServer
   @spec handle_info({:invalidate, Config.t(), binary()}, map()) :: {:noreply, map()}
   def handle_info({:invalidate, config, key}, %{invalidators: invalidators} = state) do
     invalidators = clear_invalidator(invalidators, key)
-
-    table_delete(config, key)
+    invalidators =
+      config
+      |> fetch(key)
+      |> delete_or_reschedule(config, invalidators)
 
     {:noreply, %{state | invalidators: invalidators}}
+  end
+
+  defp delete_or_reschedule(nil, _config, invalidators), do: invalidators
+  defp delete_or_reschedule({key, _value, key_config, expire}, config, invalidators) do
+    case Enum.max([expire - timestamp(), 0]) do
+      0 ->
+        table_delete(config, key)
+
+        invalidators
+      ttl ->
+        update_invalidators(key_config, invalidators, key, ttl)
+    end
   end
 
   defp update_invalidators(config, invalidators, key, ttl) do
@@ -100,6 +149,19 @@ defmodule Pow.Store.Backend.MnesiaCache do
     invalidator  = trigger_ttl(config, key, ttl)
 
     Map.put(invalidators, key, invalidator)
+  end
+
+  defp refresh_invalidators_in_cluster(config) do
+    :running_db_nodes
+    |> :mnesia.system_info()
+    |> Enum.reject(& &1 == node())
+    |> Enum.each(&:rpc.call(&1, GenServer, :cast, [__MODULE__, {:refresh_invalidators, config}]))
+  end
+
+  defp clear_invalidators(invalidators) do
+    Enum.reduce(invalidators, invalidators, fn {key, _ref}, invalidators ->
+      clear_invalidator(invalidators, key)
+    end)
   end
 
   defp clear_invalidator(invalidators, key) do
@@ -112,16 +174,22 @@ defmodule Pow.Store.Backend.MnesiaCache do
   end
 
   defp table_get(config, key) do
+    config
+    |> fetch(key)
+    |> case do
+      {_key, value, _config, _expire} -> value
+      nil                             -> :not_found
+    end
+  end
+
+  defp fetch(config, key) do
     mnesia_key = mnesia_key(config, key)
 
     {@mnesia_cache_tab, mnesia_key}
     |> :mnesia.dirty_read()
     |> case do
-      [{@mnesia_cache_tab, ^mnesia_key, {_key, value, _config, _expire}} | _rest] ->
-        value
-
-      [] ->
-        :not_found
+      [{@mnesia_cache_tab, ^mnesia_key, {_key, value, config, expire}} | _rest] -> {key, value, config, expire}
+      [] -> nil
     end
   end
 
@@ -130,7 +198,7 @@ defmodule Pow.Store.Backend.MnesiaCache do
     expire     = timestamp() + ttl
     value      = {key, value, config, expire}
 
-    :mnesia.transaction(fn ->
+    :mnesia.sync_transaction(fn ->
       :mnesia.write({@mnesia_cache_tab, mnesia_key, value})
     end)
   end
@@ -138,7 +206,7 @@ defmodule Pow.Store.Backend.MnesiaCache do
   defp table_delete(config, key) do
     mnesia_key = mnesia_key(config, key)
 
-    :mnesia.transaction(fn ->
+    :mnesia.sync_transaction(fn ->
       :mnesia.delete({@mnesia_cache_tab, mnesia_key})
     end)
   end
@@ -146,10 +214,17 @@ defmodule Pow.Store.Backend.MnesiaCache do
   defp table_keys(config, opts \\ []) do
     namespace = mnesia_key(config, "")
 
-    @mnesia_cache_tab
-    |> :mnesia.dirty_all_keys()
+    sync_all_keys()
     |> Enum.filter(&String.starts_with?(&1, namespace))
     |> maybe_remove_namespace(namespace, opts)
+  end
+
+  defp sync_all_keys() do
+    {:atomic, keys} = :mnesia.sync_transaction(fn ->
+      :mnesia.all_keys(@mnesia_cache_tab)
+    end)
+
+    keys
   end
 
   defp maybe_remove_namespace(keys, namespace, opts) do
@@ -163,25 +238,154 @@ defmodule Pow.Store.Backend.MnesiaCache do
     end
   end
 
-  defp table_init(config) do
-    nodes      = Config.get(config, :nodes, [node()])
-    table_opts = Config.get(config, :table_opts, disc_copies: nodes)
-    table_def  = Keyword.merge(table_opts, [type: :set])
-    timeout    = Config.get(config, :timeout, :timer.seconds(15))
-
-    case :mnesia.create_schema(nodes) do
-      :ok                                 -> :ok
-      {:error, {_, {:already_exists, _}}} -> :ok
+  defp init_mnesia(config) do
+    config
+    |> find_active_cluster_nodes()
+    |> case do
+      []    -> init_cluster(config)
+      nodes -> join_cluster(config, nodes)
     end
+  end
 
-    :rpc.multicall(nodes, :mnesia, :start, [])
+  defp find_active_cluster_nodes(config) do
+    visible_nodes = Node.list()
+    db_nodes      = Config.get(config, :extra_db_nodes, [])
+
+    db_nodes
+    |> Enum.filter(& &1 in visible_nodes)
+    |> Enum.filter(&:rpc.block_call(&1, :mnesia, :system_info, [:is_running]) == :yes)
+  end
+
+  defp init_cluster(config) do
+    nodes = nodes(config)
+
+    with :ok <- start_mnesia(nodes),
+         :ok <- change_table_copy_type(config, nodes),
+         :ok <- create_table(config, nodes),
+         :ok <- wait_for_table(config) do
+
+      Logger.info("[#{inspect __MODULE__}] Mnesia cluster initiated on #{inspect nodes}")
+    else
+      {:error, reason} ->
+        Logger.error("[inspect __MODULE__}] Couldn't initialize mnesia cluster because: #{inspect reason}")
+        {:error, reason}
+    end
+  end
+
+  defp join_cluster(config, cluster_nodes) do
+    nodes = nodes(config)
+
+    with :ok <- reset_mnesia(nodes, cluster_nodes),
+         :ok <- connect_to_cluster(nodes, cluster_nodes),
+         :ok <- change_table_copy_type(config, nodes),
+         :ok <- sync_table(config, nodes, cluster_nodes),
+         :ok <- wait_for_table(config) do
+
+      Logger.info("[#{inspect __MODULE__}] Joined mnesia cluster nodes #{inspect cluster_nodes} for #{inspect nodes}")
+
+      :ok
+    else
+      {:error, reason} ->
+        Logger.error("[inspect __MODULE__}] Couldn't join mnesia cluster because: #{inspect reason}")
+        {:error, reason}
+    end
+  end
+
+  defp nodes(config), do: Config.get(config, :nodes, [node()])
+
+  defp start_mnesia(nodes) when is_list(nodes) do
+    Enum.each(nodes, &:ok = start_mnesia(&1))
+  end
+  defp start_mnesia(node) do
+    node
+    |> block_call(Application, :start, [:mnesia])
+    |> case do
+      {:error, {:already_started, :mnesia}} -> :ok
+      :ok                                   -> :ok
+    end
+  end
+
+  defp reset_mnesia(nodes, cluster_nodes) when is_list(nodes) do
+    Enum.each(nodes, &:ok = reset_mnesia(&1, cluster_nodes))
+  end
+  defp reset_mnesia(node, [cluster_node | _rest]) do
+    block_call(node, Application, :stop, [:mnesia])
+
+    :ok = block_call(node, :mnesia, :delete_schema, [[node]])
+    {:atomic, :ok} = block_call(cluster_node, :mnesia, :del_table_copy, [:schema, node])
+
+    start_mnesia(node)
+
+    :ok
+  end
+
+  defp change_table_copy_type(config, nodes) when is_list(nodes) do
+    Enum.each(nodes, &:ok = change_table_copy_type(config, &1))
+  end
+  defp change_table_copy_type(config, node) do
+    copy_type = get_copy_type(config, node)
+
+    case :mnesia.change_table_copy_type(:schema, node, copy_type) do
+      {:atomic, :ok}                               -> :ok
+      {:aborted, {:already_exists, :schema, _, _}} -> :ok
+    end
+  end
+
+  defp get_copy_type(config, node) do
+    types      = [:ram_copies, :disc_copies, :disc_only_copies]
+    table_opts = Config.get(config, :table_opts, [])
+
+    Enum.find(types, :disc_copies, fn type ->
+      nodes = table_opts[type] || []
+
+      node in nodes
+    end)
+  end
+
+  defp create_table(config, nodes) do
+    table_opts = Config.get(config, :table_opts, [disc_copies: nodes])
+    table_def  = Keyword.merge(table_opts, [type: :set])
 
     case :mnesia.create_table(@mnesia_cache_tab, table_def) do
       {:atomic, :ok}                                   -> :ok
       {:aborted, {:already_exists, @mnesia_cache_tab}} -> :ok
     end
+  end
 
-    :ok = :mnesia.wait_for_tables([@mnesia_cache_tab], timeout)
+  defp sync_table(config, nodes, cluster_nodes) when is_list(nodes) do
+    Enum.each(nodes, &{:atomic, :ok} = sync_table(config, &1, cluster_nodes))
+  end
+  defp sync_table(_config, node, [cluster_node | _rest]) do
+    copy_type = block_call(cluster_node, :mnesia, :table_info, [@mnesia_cache_tab, :storage_type])
+
+    block_call(node, :mnesia, :add_table_copy, [@mnesia_cache_tab, node, copy_type])
+  end
+
+  defp block_call(node, module, method, args) do
+    this_node = node()
+
+    case node do
+      ^this_node -> apply(module, method, args)
+      node       -> :rpc.block_call(node, module, method, args)
+    end
+  end
+
+  defp wait_for_table(config) do
+    timeout = Config.get(config, :timeout, :timer.seconds(15))
+
+    :mnesia.wait_for_tables([@mnesia_cache_tab], timeout)
+  end
+
+  defp connect_to_cluster(nodes, cluster_nodes) when is_list(nodes) do
+    Enum.each(nodes, &:ok = connect_to_cluster(&1, cluster_nodes))
+  end
+  defp connect_to_cluster(node, [cluster_node | _cluster_nodes]) do
+    node
+    |> block_call(:mnesia, :change_config, [:extra_db_nodes, [cluster_node]])
+    |> case do
+      {:ok, _}         -> :ok
+      {:error, reason} -> {:error, reason}
+    end
   end
 
   defp mnesia_key(config, key) do

--- a/lib/pow/store/backend/mnesia_cache.ex
+++ b/lib/pow/store/backend/mnesia_cache.ex
@@ -83,7 +83,10 @@ defmodule Pow.Store.Backend.MnesiaCache do
   @spec start_link(Config.t()) :: GenServer.on_start()
   def start_link(config) do
     # TODO: Remove by 1.1.0
-    IO.warn("use of `:nodes` config value for #{inspect unquote(__MODULE__)} is no longer used")
+    case Config.get(config, :nodes) do
+      nil    -> :ok
+      _nodes -> IO.warn("use of `:nodes` config value for #{inspect unquote(__MODULE__)} is no longer used")
+    end
 
     GenServer.start_link(__MODULE__, config, name: __MODULE__)
   end

--- a/lib/pow/store/backend/mnesia_cache/unsplit.ex
+++ b/lib/pow/store/backend/mnesia_cache/unsplit.ex
@@ -1,0 +1,151 @@
+defmodule Pow.Store.Backend.MnesiaCache.Unsplit do
+  @moduledoc """
+  GenServer that handles netsplit recovery for `Pow.Store.Backend.MnesiaCache`.
+
+  This GenServer should be run on node(s) that has the
+  `Pow.Store.Backend.MnesiaCache` GenServer running. It'll subscribe to the
+  Mnesia system messages, and listen `:inconsistent_database` Mnesia system
+  events. The first node to set the global lock will find the island with the
+  oldest disc node and use that to force reload the table into the nodes of the
+  other island.
+
+  If a table unrelated to Pow is affected, an error will be returned.
+
+  For fine control, you can use `unsplit` instead of this module and decide
+  what to do in each case.
+
+  ## Usage
+
+  To start the GenServer, add it to your application `start/2` method:
+
+      defmodule MyAppWeb.Application do
+        use Application
+
+        def start(_type, _args) do
+          children = [
+            MyApp.Repo,
+            MyAppWeb.Endpoint,
+            {Pow.Store.Backend.MnesiaCache, extra_db_nodes: Node.list()},
+            Pow.Store.Backend.MnesiaCache.Unsplit
+          ]
+
+          opts = [strategy: :one_for_one, name: MyAppWeb.Supervisor]
+          Supervisor.start_link(children, opts)
+        end
+
+        # ...
+      end
+  """
+  use GenServer
+  require Logger
+
+  alias Pow.Config
+
+  @mnesia_cache_tab Pow.Store.Backend.MnesiaCache
+
+  @spec start_link(Config.t()) :: GenServer.on_start()
+  def start_link(config) do
+    GenServer.start_link(__MODULE__, config, name: __MODULE__)
+  end
+
+  # Callbacks
+
+  @impl true
+  @spec init(Config.t()) :: {:ok, map()}
+  def init(_config) do
+    :mnesia.subscribe(:system)
+
+    {:ok, %{}}
+  end
+
+  @impl true
+  @spec handle_info({:mnesia_system_event, {:inconsistent_database, any(), any()}}, map()) :: {:no_reply, map()}
+  def handle_info({:mnesia_system_event, {:inconsistent_database, _context, node}}, state) do
+    :global.trans({__MODULE__, self()}, fn -> autoheal(node) end)
+
+    {:noreply, state}
+  end
+
+  @impl true
+  @spec handle_info(any(), map()) :: {:noreply, map()}
+  def handle_info(_event, state) do
+    {:noreply, state}
+  end
+
+  defp autoheal(node) do
+    :running_db_nodes
+    |> :mnesia.system_info()
+    |> Enum.member?(node)
+    |> case do
+      true ->
+        Logger.info("[#{inspect __MODULE__}] #{inspect node} has already healed and joined #{inspect node()}")
+
+        :ok
+
+      false ->
+        Logger.warn("[#{inspect __MODULE__}] Detected netsplit on #{inspect node}")
+
+        heal(node)
+    end
+  end
+
+  defp heal(node) do
+    node
+    |> affected_tables()
+    |> force_reload(node)
+  end
+
+  defp affected_tables(node) do
+    :tables
+    |> :mnesia.system_info()
+    |> List.delete(:schema)
+    |> List.foldl([], fn table, acc ->
+      nodes     = get_all_nodes_for_table(table)
+      is_shared = Enum.member?(nodes, node) && Enum.member?(nodes, node())
+
+      case is_shared do
+        true  -> [table | acc]
+        false -> acc
+      end
+    end)
+  end
+
+  defp get_all_nodes_for_table(table) do
+    [:ram_copies, :disc_copies, :disc_only_copies]
+    |> Enum.map(&:mnesia.table_info(table, &1))
+    |> Enum.concat()
+  end
+
+  defp force_reload([@mnesia_cache_tab], node) do
+    [master_nodes, nodes] = sorted_cluster_islands(node)
+
+    for node <- nodes do
+      :stopped = :rpc.call(node, :mnesia, :stop, [])
+      :ok = :rpc.call(node, :mnesia, :set_master_nodes, [@mnesia_cache_tab, master_nodes])
+      :ok = :rpc.block_call(node, :mnesia, :start, [])
+
+      Logger.info("[#{inspect __MODULE__}] #{inspect node} has been healed and joined #{inspect master_nodes}")
+    end
+  end
+  defp force_reload(tables, _node) do
+    Logger.error("[#{inspect __MODULE__}] Can't force reload unexpected tables #{inspect tables}")
+
+    {:error, {:unexpected_tables, tables}}
+  end
+
+  defp sorted_cluster_islands(node) do
+    island_a    = :mnesia.system_info(:running_db_nodes)
+    island_b    = :rpc.call(node, :mnesia, :system_info, [:running_db_nodes])
+
+    Enum.sort([island_a, island_b], &older?/2)
+  end
+
+  defp older?(island_a, island_b) do
+    all_nodes    = get_all_nodes_for_table(@mnesia_cache_tab)
+    island_nodes = Enum.concat(island_a, island_b)
+
+    oldest_node = all_nodes |> Enum.reverse() |> Enum.find(&Enum.member?(island_nodes, &1))
+
+    Enum.member?(island_a, oldest_node)
+  end
+end

--- a/lib/pow/store/backend/mnesia_cache/unsplit.ex
+++ b/lib/pow/store/backend/mnesia_cache/unsplit.ex
@@ -14,7 +14,8 @@ defmodule Pow.Store.Backend.MnesiaCache.Unsplit do
   of your tables in Mnesia, you can set `flush_tables: :all` to restore all the
   affected tables from the oldest node in the cluster.
 
-  For better control, you can use `unsplit` instead of this module.
+  For better control, you can use
+  [`unsplit`](https://github.com/uwiger/unsplit) instead of this module.
 
   ## Usage
 

--- a/lib/pow/store/backend/mnesia_cache/unsplit.ex
+++ b/lib/pow/store/backend/mnesia_cache/unsplit.ex
@@ -39,12 +39,23 @@ defmodule Pow.Store.Backend.MnesiaCache.Unsplit do
         # ...
       end
 
+  ## Strategy for multiple libraries using the mnesia instance
+
+  It's strongly recommended to take into account any libraries that will be
+  using Mnesia for storage before using this module.
+
+  A common example would be a job queue, where a potential solution to prevent
+  data loss is to simply keep the job queue table on only one server instead of
+  replicating it among all nodes. When a network partition occurs, it won't be
+  part of the affected tables so this module can self-heal without specifying
+  the queue table in `:flush_tables`.
+
   ## Initialization options
 
     * `:flush_tables` - list of tables that may be flushed and restored from
       the oldest node in the cluster. Defaults to `false` when only the
       MnesiaCache table will be flushed. Use `:all` if you want to flush all
-      affected tables.
+      affected tables. Be aware that this may cause data loss.
   """
   use GenServer
   require Logger

--- a/lib/pow/store/backend/mnesia_cache/unsplit.ex
+++ b/lib/pow/store/backend/mnesia_cache/unsplit.ex
@@ -39,7 +39,7 @@ defmodule Pow.Store.Backend.MnesiaCache.Unsplit do
         # ...
       end
 
-  ## Strategy for multiple libraries using the mnesia instance
+  ## Strategy for multiple libraries using the Mnesia instance
 
   It's strongly recommended to take into account any libraries that will be
   using Mnesia for storage before using this module.
@@ -47,8 +47,8 @@ defmodule Pow.Store.Backend.MnesiaCache.Unsplit do
   A common example would be a job queue, where a potential solution to prevent
   data loss is to simply keep the job queue table on only one server instead of
   replicating it among all nodes. When a network partition occurs, it won't be
-  part of the affected tables so this module can self-heal without specifying
-  the queue table in `:flush_tables`.
+  part of the affected tables so this module can self-heal without the job
+  queue table set in `:flush_tables`.
 
   ## Initialization options
 

--- a/test/pow/store/backend/mnesia_cache_test.exs
+++ b/test/pow/store/backend/mnesia_cache_test.exs
@@ -6,66 +6,198 @@ defmodule Pow.Store.Backend.MnesiaCacheTest do
 
   @default_config [namespace: "pow:test", ttl: :timer.hours(1)]
 
-  setup do
-    :mnesia.kill()
+  setup_all do
+    # Turn node into a distributed node with the given long name
+    :net_kernel.start([:"master@127.0.0.1"])
 
-    File.rm_rf!("tmp/mnesia")
-    File.mkdir_p!("tmp/mnesia")
+    # Allow spawned nodes to fetch all code from this node
+    :erl_boot_server.start([])
+    {:ok, ipv4} = :inet.parse_ipv4_address('127.0.0.1')
+    :erl_boot_server.add_slave(ipv4)
 
-    {:ok, pid} = MnesiaCache.start_link([])
-
-    {:ok, pid: pid}
+    :ok
   end
 
-  test "can put, get and delete records with persistent storage", %{pid: pid} do
-    assert MnesiaCache.get(@default_config, "key") == :not_found
+  describe "single node" do
+    setup do
+      :mnesia.kill()
 
-    MnesiaCache.put(@default_config, "key", "value")
-    :timer.sleep(100)
-    assert MnesiaCache.get(@default_config, "key") == "value"
+      File.rm_rf!("tmp/mnesia")
+      File.mkdir_p!("tmp/mnesia")
 
-    restart(pid, @default_config)
+      start_supervised!(MnesiaCache)
 
-    assert MnesiaCache.get(@default_config, "key") == "value"
+      :ok
+    end
 
-    MnesiaCache.delete(@default_config, "key")
-    :timer.sleep(100)
-    assert MnesiaCache.get(@default_config, "key") == :not_found
-  end
+    test "can put, get and delete records with persistent storage" do
+      assert MnesiaCache.get(@default_config, "key") == :not_found
 
-  test "with no `:ttl` opt" do
-    assert_raise ConfigError, "`:ttl` configuration option is required for Pow.Store.Backend.MnesiaCache", fn ->
-      MnesiaCache.put([namespace: "pow:test"], "key", "value")
+      MnesiaCache.put(@default_config, "key", "value")
+      :timer.sleep(100)
+      assert MnesiaCache.get(@default_config, "key") == "value"
+
+      restart(@default_config)
+
+      assert MnesiaCache.get(@default_config, "key") == "value"
+
+      MnesiaCache.delete(@default_config, "key")
+      :timer.sleep(100)
+      assert MnesiaCache.get(@default_config, "key") == :not_found
+    end
+
+    test "with no `:ttl` opt" do
+      assert_raise ConfigError, "`:ttl` configuration option is required for Pow.Store.Backend.MnesiaCache", fn ->
+        MnesiaCache.put([namespace: "pow:test"], "key", "value")
+      end
+    end
+
+    test "fetch keys" do
+      MnesiaCache.put(@default_config, "key1", "value")
+      MnesiaCache.put(@default_config, "key2", "value")
+      :timer.sleep(100)
+
+      assert MnesiaCache.keys(@default_config) == ["key1", "key2"]
+    end
+
+    test "records auto purge with persistent storage" do
+      config = Config.put(@default_config, :ttl, 100)
+
+      MnesiaCache.put(config, "key", "value")
+      :timer.sleep(50)
+      assert MnesiaCache.get(config, "key") == "value"
+      :timer.sleep(100)
+      assert MnesiaCache.get(config, "key") == :not_found
+
+      MnesiaCache.put(config, "key", "value")
+      :timer.sleep(50)
+      restart(config)
+      assert MnesiaCache.get(config, "key") == "value"
+      :timer.sleep(100)
+      assert MnesiaCache.get(config, "key") == :not_found
     end
   end
 
-  test "fetch keys" do
-    MnesiaCache.put(@default_config, "key1", "value")
-    MnesiaCache.put(@default_config, "key2", "value")
-    :timer.sleep(100)
-
-    assert MnesiaCache.keys(@default_config) == ["key1", "key2"]
-  end
-
-  test "records auto purge with persistent storage", %{pid: pid} do
-    config = Config.put(@default_config, :ttl, 100)
-
-    MnesiaCache.put(config, "key", "value")
-    :timer.sleep(50)
-    assert MnesiaCache.get(config, "key") == "value"
-    :timer.sleep(100)
-    assert MnesiaCache.get(config, "key") == :not_found
-
-    MnesiaCache.put(config, "key", "value")
-    restart(pid, config)
-    assert MnesiaCache.get(config, "key") == "value"
-    :timer.sleep(100)
-    assert MnesiaCache.get(config, "key") == :not_found
-  end
-
-  defp restart(pid, config) do
-    GenServer.stop(pid)
+  defp restart(config) do
+    :ok = stop_supervised(MnesiaCache)
     :mnesia.stop()
-    MnesiaCache.start_link(config)
+
+    start_supervised!({MnesiaCache, config})
+  end
+
+  describe "distributed nodes" do
+    setup do
+      File.rm_rf!("tmp/mnesia_multi")
+      File.mkdir_p!("tmp/mnesia_multi")
+
+      on_exit(fn ->
+        :slave.stop(:'a@127.0.0.1')
+        :slave.stop(:'b@127.0.0.1')
+      end)
+
+      :ok
+    end
+
+    @startup_wait_time 3_000
+
+    test "will join cluster" do
+      # Init node a and write to it
+      node_a = spawn_node("a")
+      {:ok, _pid} = :rpc.call(node_a, MnesiaCache, :start_link, [@default_config])
+      assert :rpc.call(node_a, :mnesia, :table_info, [MnesiaCache, :storage_type]) == :disc_copies
+      assert :rpc.call(node_a, :mnesia, :system_info, [:extra_db_nodes]) == []
+      assert :rpc.call(node_a, :mnesia, :system_info, [:running_db_nodes]) == [node_a]
+      assert :rpc.call(node_a, MnesiaCache, :put, [@default_config, "key_set_on_a", "value"])
+      :timer.sleep(50)
+      assert :rpc.call(node_a, MnesiaCache, :get, [@default_config, "key_set_on_a"]) == "value"
+
+      # Join cluster with node b and ensures that it has node a data
+      node_b = spawn_node("b")
+      config = @default_config ++ [extra_db_nodes: [node_a]]
+      {:ok, _pid} = :rpc.call(node_b, MnesiaCache, :start_link, [config])
+      assert :rpc.call(node_b, :mnesia, :table_info, [MnesiaCache, :storage_type]) == :disc_copies
+      assert :rpc.call(node_b, :mnesia, :system_info, [:extra_db_nodes]) == [node_a]
+      assert :rpc.call(node_b, :mnesia, :system_info, [:running_db_nodes]) == [node_a, node_b]
+      assert :rpc.call(node_b, MnesiaCache, :get, [@default_config, "key_set_on_a"]) == "value"
+
+      # Write to node b can be fetched on node a
+      assert :rpc.call(node_b, MnesiaCache, :put, [@default_config, "key_set_on_b", "value"])
+      :timer.sleep(50)
+      assert :rpc.call(node_a, MnesiaCache, :get, [@default_config, "key_set_on_b"]) == "value"
+
+      # Set short TTL on node a
+      config = Config.put(@default_config, :ttl, 150)
+      assert :rpc.call(node_a, MnesiaCache, :put, [config, "short_ttl_key_set_on_a", "value"])
+      :timer.sleep(50)
+
+      # Stop node a
+      :ok = :slave.stop(node_a)
+      :timer.sleep(50)
+      assert :rpc.call(node_b, :mnesia, :system_info, [:running_db_nodes]) == [node_b]
+
+      # Ensure that node b invalidates with TTL set on node a
+      assert :rpc.call(node_b, MnesiaCache, :get, [config, "short_ttl_key_set_on_a"]) == "value"
+      :timer.sleep(50)
+      assert :rpc.call(node_b, MnesiaCache, :get, [config, "short_ttl_key_set_on_a"]) == :not_found
+
+      # Continue writing to node b with short TTL
+      config = Config.put(@default_config, :ttl, @startup_wait_time + 100)
+      assert :rpc.call(node_b, MnesiaCache, :put, [config, "short_ttl_key_2_set_on_b", "value"])
+      :timer.sleep(50)
+      assert :rpc.call(node_b, MnesiaCache, :get, [config, "short_ttl_key_2_set_on_b"]) == "value"
+
+      # Start node a and join cluster
+      startup_timestamp = :os.system_time(:millisecond)
+      node_a = spawn_node("a")
+      config = @default_config ++ [extra_db_nodes: [node_b]]
+      {:ok, _pid} = :rpc.call(node_a, MnesiaCache, :start_link, [config])
+      assert :rpc.call(node_b, :mnesia, :system_info, [:running_db_nodes]) == [node_a, node_b]
+      assert :rpc.call(node_b, MnesiaCache, :get, [config, "short_ttl_key_2_set_on_b"]) == "value"
+      assert :rpc.call(node_a, MnesiaCache, :get, [config, "short_ttl_key_2_set_on_b"]) == "value"
+
+      # Stop node b
+      :ok = :slave.stop(node_b)
+
+      # Node a invalidates short TTL value written on node b
+      startup_time = :os.system_time(:millisecond) - startup_timestamp
+      :timer.sleep(@startup_wait_time - startup_time + 100)
+      assert :rpc.call(node_a, MnesiaCache, :get, [config, "short_ttl_key_2_set_on_b"]) == :not_found
+    end
+  end
+
+  defp spawn_node(sname) do
+    fn -> init_node(sname) end
+    |> Task.async()
+    |> Task.await(30_000)
+  end
+
+  defp init_node(sname) do
+    {:ok, node} = :slave.start('127.0.0.1', String.to_atom(sname), '-loader inet -hosts 127.0.0.1 -setcookie #{:erlang.get_cookie()}')
+
+    # Copy code
+    rpc(node, :code, :add_paths, [:code.get_path()])
+
+    # Copy all config
+    for {app_name, _, _} <- Application.loaded_applications() do
+      for {key, val} <- Application.get_all_env(app_name) do
+        rpc(node, Application, :put_env, [app_name, key, val])
+      end
+    end
+
+    # Set mnesia directory
+    rpc(node, Application, :put_env, [:mnesia, :dir, 'tmp/mnesia_multi/#{sname}'])
+
+    # Start all apps
+    rpc(node, Application, :ensure_all_started, [:mix])
+    rpc(node, Mix, :env, [Mix.env()])
+    for {app_name, _, _} <- Application.started_applications() do
+      rpc(node, Application, :ensure_all_started, [app_name])
+    end
+
+    node
+  end
+
+  defp rpc(node, module, function, args) do
+    :rpc.block_call(node, module, function, args)
   end
 end

--- a/test/pow/store/backend/mnesia_cache_test.exs
+++ b/test/pow/store/backend/mnesia_cache_test.exs
@@ -234,6 +234,7 @@ defmodule Pow.Store.Backend.MnesiaCacheTest do
       assert :rpc.call(node_a, :mnesia, :system_info, [:running_db_nodes]) == [node_b, node_a]
       disconnect(node_b, node_a)
       connect(node_b, node_a)
+      assert :rpc.call(node_a, :mnesia, :system_info, [:running_db_nodes]) == [node_a]
       :rpc.call(node_a, MnesiaCache.Unsplit, :__heal__, [node_b, [flush_tables: :all]])
       assert :rpc.call(node_a, :mnesia, :system_info, [:running_db_nodes]) == [node_b, node_a]
     end
@@ -268,6 +269,7 @@ defmodule Pow.Store.Backend.MnesiaCacheTest do
       rpc(node, Application, :ensure_all_started, [app_name])
     end
 
+    # Remove logger
     rpc(node, Logger, :remove_backend, [:console])
 
     node

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -28,3 +28,6 @@ for extension <- Application.get_env(:pow, :extension_test_modules) do
 
   {:ok, _pid} = endpoint_module.start_link()
 end
+
+# Make sure we can run distribution tests
+:os.cmd('epmd -daemon')


### PR DESCRIPTION
This is WIP and the tests aren't finished yet.

The tests currently fail, and I still need to make sure that one node doesn't expire a cache element that has been updated in another node.

Resolves #220 and supersedes #221

A few things I want to check:

- [x] Verify how this will work in environments with other libraries using mnesia (e.g. que)
- ~~[ ] Maybe handle invalidation by running interval checks, this would simplify invalidation~~
- [x] Handle split brain with [:mnesia.subscribe/1](http://erlang.org/doc/apps/mnesia/Mnesia_chap5.html#system-events), maybe similar to [rabbitmq autoheal](https://github.com/rabbitmq/rabbitmq-server/blob/626033a8c415be7ffc8360eac985f97d054935b3/src/rabbit_node_monitor.erl#L355-L360)