### PR TITLE
Unify TTL configuration setting in PowPersistentSession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.0.12 (TBA)
+
+* `PowPersistentSession.Plug.Base` now accepts `:persistent_session_ttl` which will pass the TTL to the cache backend and used for the max age of the sesion cookie in `PowPersistentSession.Plug.Cookie`
+* Deprecated `:persistent_session_cookie_max_age` configuration setting
+
 ## v1.0.11 (2019-06-13)
 
 * Fixed bug in router filters with Phoenix 1.4.7

--- a/lib/extensions/persistent_session/plug/base.ex
+++ b/lib/extensions/persistent_session/plug/base.ex
@@ -12,6 +12,10 @@ defmodule PowPersistentSession.Plug.Base do
 
     * `:cache_store_backend` - the backend cache store. This value defaults to
       `EtsCache`.
+
+    * `:persistent_session_ttl` - integer value in milliseconds for TTL of
+      persistent session in the backend store. This defaults to 30 days in
+      miliseconds.
   """
 
   alias Plug.Conn
@@ -55,7 +59,13 @@ defmodule PowPersistentSession.Plug.Base do
 
   defp default_store(config) do
     backend = Config.get(config, :cache_store_backend, EtsCache)
+    ttl     = ttl(config)
 
-    {PersistentSessionCache, [backend: backend]}
+    {PersistentSessionCache, [backend: backend, ttl: ttl]}
   end
+
+  @ttl :timer.hours(24) * 30
+
+  @doc false
+  def ttl(config), do: Config.get(config, :persistent_session_ttl, @ttl)
 end

--- a/test/extensions/persistent_session/plug/cookie_test.exs
+++ b/test/extensions/persistent_session/plug/cookie_test.exs
@@ -109,4 +109,14 @@ defmodule PowPersistentSession.Plug.CookieTest do
     refute Plug.current_user(conn)
     assert conn.resp_cookies["persistent_session_cookie"] == %{max_age: -1, path: "/", value: ""}
   end
+
+  test "create/3 with custom TTL", %{conn: conn, config: config} do
+    config = Keyword.put(config, :persistent_session_ttl, 1000)
+    conn   = Cookie.create(conn, %User{id: 1}, config)
+
+    assert_received {:ets, :put, _key, _value, config}
+    assert config[:ttl] == 1000
+
+    assert %{max_age: 1, path: "/"} = conn.resp_cookies["persistent_session_cookie"]
+  end
 end

--- a/test/support/ets_cache_mock.ex
+++ b/test/support/ets_cache_mock.ex
@@ -20,6 +20,7 @@ defmodule Pow.Test.EtsCacheMock do
   end
 
   def put(config, key, value) do
+    send(self(), {:ets, :put, key, value, config})
     :ets.insert(@tab, {ets_key(config, key), value})
   end
 


### PR DESCRIPTION
Resolves #235 

Now you can a `:persistent_session_ttl` configuration value can be set that will propagate the TTL to both the session cache backend and the cookie.