### PR TITLE
Add reset password store config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v1.0.12 (TBA)
 
+* Added `:reset_password_token_store` configuration setting
 * To prevent timing attacks, `Pow.Ecto.Context.authenticate/2` now verifies password on a blank user struct when no user can be found for the provided user id, but will always return nil. The blank user struct has a nil `:password_hash` value. The struct will be passed along with a blank password to the `verify_password/2` method in the user schema module.
 * To prevent timing attacks, when `Pow.Ecto.Schema.Changeset.verify_password/3` receives a struct with a nil `:password_hash` value, it'll hash a blank password, but always return false.
 * To prevent timing attacks, the UUID is always generated in `PowResetPassword.Plug.create_reset_token/2` whether the user exists or not.

--- a/lib/extensions/persistent_session/plug/base.ex
+++ b/lib/extensions/persistent_session/plug/base.ex
@@ -7,11 +7,13 @@ defmodule PowPersistentSession.Plug.Base do
   ## Configuration options
 
     * `:persistent_session_store` - the persistent session store. This value
-      defaults to `{PersistentSessionCache, backend: EtsCache}`. The `EtsCache`
-      backend store can be changed with the `:cache_store_backend` option.
+      defaults to
+      `{PowPersistentSession.Store.PersistentSessionCache, backend: Pow.Store.Backend.EtsCache}`.
+      The `Pow.Store.Backend.EtsCache` backend store can be changed with the
+      `:cache_store_backend` option.
 
     * `:cache_store_backend` - the backend cache store. This value defaults to
-      `EtsCache`.
+      `Pow.Store.Backend.EtsCache`.
 
     * `:persistent_session_ttl` - integer value in milliseconds for TTL of
       persistent session in the backend store. This defaults to 30 days in

--- a/lib/pow/plug/session.ex
+++ b/lib/pow/plug/session.ex
@@ -27,11 +27,12 @@ defmodule Pow.Plug.Session do
       used it'll automatically prepend the key with the `:otp_app` value.
 
     * `:session_store` - the credentials cache store. This value defaults to
-      `{CredentialsCache, backend: EtsCache}`. The `EtsCache` backend store
-      can be changed with the `:cache_store_backend` option.
+      `{Pow.Store.CredentialsCache, backend: Pow.Store.Backend.EtsCache}`. The
+      `Pow.Store.Backend.EtsCache` backend store can be changed with the
+      `:cache_store_backend` option.
 
     * `:cache_store_backend` - the backend cache store. This value defaults to
-      `EtsCache`.
+      `Pow.Store.Backend.EtsCache`.
 
     * `:session_ttl_renewal` - the ttl in milliseconds to trigger renewal of
       sessions. Defaults to 15 minutes in miliseconds.


### PR DESCRIPTION
This allows for using a custom `ResetTokenCache` module by setting the `:reset_password_token_store` config option the same way as with PowPersistentSession, and CredentialsCache.

Also cleaned up docs.