### PR TITLE
Refactor e-mail validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@
   * when `:email` is identical to the persisted `:email` value both `:email_confirmation_token` and `:unconfirmed_email` will be set to `nil`
   * when there is no `:email` value in the params nothing happens
 * Updated `PowEmailConfirmation.Ecto.Schema.confirm_email_changeset/1` so now `:email_confirmation_token` is set to `nil`
-* Fixed bug in `PowEmailConfirmation.Phoenix.ControllerCallbacks.send_confirmation_email/2` where the confirmation e-mail wasn't send to the updated e-mail address
+* Updated `Pow.Ecto.Schema.Changeset.user_id_field_changeset/3` so the e-mail validator now accepts unicode e-mails
 * Added `PowEmailConfirmation.Ecto.Context.current_email_unconfirmed?/2` and `PowEmailConfirmation.Plug.pending_email_change?/1`
 * Added `:email_validator` configuration option to `Pow.Ecto.Schema.Changeset`
 * Added `Pow.Ecto.Schema.Changeset.validate_email/1`
+* Fixed bug in `PowEmailConfirmation.Phoenix.ControllerCallbacks.send_confirmation_email/2` where the confirmation e-mail wasn't send to the updated e-mail address
 
 ## v1.0.12 (2019-08-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 * Updated `PowEmailConfirmation.Ecto.Schema.confirm_email_changeset/1` so now `:email_confirmation_token` is set to `nil`
 * Fixed bug in `PowEmailConfirmation.Phoenix.ControllerCallbacks.send_confirmation_email/2` where the confirmation e-mail wasn't send to the updated e-mail address
 * Added `PowEmailConfirmation.Ecto.Context.current_email_unconfirmed?/2` and `PowEmailConfirmation.Plug.pending_email_change?/1`
+* Added `:email_validator` configuration option to `Pow.Ecto.Schema.Changeset`
+* Added `Pow.Ecto.Schema.Changeset.validate_email/1`
 
 ## v1.0.12 (2019-08-16)
 

--- a/lib/pow/ecto/schema/changeset.ex
+++ b/lib/pow/ecto/schema/changeset.ex
@@ -307,7 +307,7 @@ defmodule Pow.Ecto.Schema.Changeset do
 
   defp validate_domain(domain) do
     cond do
-      String.first(domain) == "-"     -> {:error, "domain starts with hyphen"}
+      String.first(domain) == "-"     -> {:error, "domain begins with hyphen"}
       String.last(domain) == "-"      -> {:error, "domain ends with hyphen"}
       domain =~ ~r/^[\p{L}0-9-\.]+$/u -> :ok
       true                            -> {:error, "invalid characters in domain"}

--- a/lib/pow/ecto/schema/changeset.ex
+++ b/lib/pow/ecto/schema/changeset.ex
@@ -15,9 +15,12 @@ defmodule Pow.Ecto.Schema.Changeset do
 
           {&Pow.Ecto.Schema.Password.pbkdf2_hash/1,
           &Pow.Ecto.Schema.Password.pbkdf2_verify/2}
-    * `:email_validator`       - the email validation method, defaults to
-      `&Pow.Ecto.Schema.Changeset.validate_email/1`
+    * `:email_validator`       - the email validation method, defaults to:
 
+
+          &Pow.Ecto.Schema.Changeset.validate_email/1
+
+        The method should either return `:ok`, `:error`, or `{:error, reason}`.
   """
   alias Ecto.Changeset
   alias Pow.{Config, Ecto.Schema, Ecto.Schema.Password}
@@ -244,20 +247,25 @@ defmodule Pow.Ecto.Schema.Changeset do
   @doc """
   Validates an e-mail.
 
-  This implementation follows the following rules:
+  This implementation has the following rules:
 
-  - Split at last `@` occurance into local-part and domain
-  - Local-part may only be 64 octets
-  - Domain may only be 255 octets
-  - Non-quoted and quoted content in local-part has to be dot seperated
-  - No white spaces in local-part or domain
-  - Only letters, digits, and the following characters are allowed outside
-    quoted content in local-part: `!#$%&'*+-/=?^_`{|}~.`
-  - Consecutive dots are not allowed outside quoted content
-  - Only letters, digits, hyphen, and dots are allowed in domain
-  - Unicode characters allowed in both local-part and domain
+  - Split into local-part and domain at last `@` occurance
+  - Local-part should;
+    - be at most 64 octets
+    - separate quoted and unquoted content with a single dot
+    - only have letters, digits, and the following characters outside quoted
+      content:
+        ```text
+        !#$%&'*+-/=?^_`{|}~.
+        ```
+    - not have any consecutive dots outside quoted content
+  - Domain should;
+    - be at most 255 octets
+    - only have letters, digits, hyphen, and dots
+
+  Unicode characters are permitted in both local-part and domain.
   """
-  @spec validate_email(binary()) :: :ok | :error | {:error, any()}
+  @spec validate_email(binary()) :: :ok | {:error, any()}
   def validate_email(email) do
     [domain | rest] =
       email

--- a/test/extensions/email_confirmation/ecto/schema_test.exs
+++ b/test/extensions/email_confirmation/ecto/schema_test.exs
@@ -93,7 +93,7 @@ defmodule PowEmailConfirmation.Ecto.SchemaTest do
       changeset = User.changeset(user, Map.put(@valid_params, :email, "invalid"))
 
       refute changeset.valid?
-      assert changeset.errors[:email] == {"has invalid format", [validation: :format]}
+      assert changeset.errors[:email] == {"has invalid format", [validator: &Pow.Ecto.Schema.Changeset.validate_email/1]}
       refute Ecto.Changeset.get_change(changeset, :email_confirmation_token)
       refute Ecto.Changeset.get_change(changeset, :unconfirmed_email)
 
@@ -105,7 +105,7 @@ defmodule PowEmailConfirmation.Ecto.SchemaTest do
       changeset = User.changeset(user, Map.put(@valid_params, :email, "invalid"))
 
       refute changeset.valid?
-      assert changeset.errors[:email] == {"has invalid format", [validation: :format]}
+      assert changeset.errors[:email] == {"has invalid format", [validator: &Pow.Ecto.Schema.Changeset.validate_email/1]}
       assert Ecto.Changeset.get_field(changeset, :email_confirmation_token) == user.email_confirmation_token
       assert Ecto.Changeset.get_field(changeset, :unconfirmed_email) == user.unconfirmed_email
     end

--- a/test/extensions/email_confirmation/ecto/schema_test.exs
+++ b/test/extensions/email_confirmation/ecto/schema_test.exs
@@ -93,7 +93,7 @@ defmodule PowEmailConfirmation.Ecto.SchemaTest do
       changeset = User.changeset(user, Map.put(@valid_params, :email, "invalid"))
 
       refute changeset.valid?
-      assert changeset.errors[:email] == {"has invalid format", [validator: &Pow.Ecto.Schema.Changeset.validate_email/1]}
+      assert changeset.errors[:email] == {"has invalid format", [validator: &Pow.Ecto.Schema.Changeset.validate_email/1, reason: "invalid format"]}
       refute Ecto.Changeset.get_change(changeset, :email_confirmation_token)
       refute Ecto.Changeset.get_change(changeset, :unconfirmed_email)
 
@@ -105,7 +105,7 @@ defmodule PowEmailConfirmation.Ecto.SchemaTest do
       changeset = User.changeset(user, Map.put(@valid_params, :email, "invalid"))
 
       refute changeset.valid?
-      assert changeset.errors[:email] == {"has invalid format", [validator: &Pow.Ecto.Schema.Changeset.validate_email/1]}
+      assert changeset.errors[:email] == {"has invalid format", [validator: &Pow.Ecto.Schema.Changeset.validate_email/1, reason: "invalid format"]}
       assert Ecto.Changeset.get_field(changeset, :email_confirmation_token) == user.email_confirmation_token
       assert Ecto.Changeset.get_field(changeset, :unconfirmed_email) == user.unconfirmed_email
     end

--- a/test/pow/ecto/schema/changeset_test.exs
+++ b/test/pow/ecto/schema/changeset_test.exs
@@ -37,11 +37,7 @@ defmodule Pow.Ecto.Schema.ChangesetTest do
     test "validates user id as email" do
       changeset = User.changeset(%User{}, Map.put(@valid_params, "email", "invalid"))
       refute changeset.valid?
-      assert changeset.errors[:email] == {"has invalid format", [validator: &Pow.Ecto.Schema.Changeset.validate_email/1]}
-
-      changeset = User.changeset(%User{}, Map.put(@valid_params, "email", ".wooly@example.com"))
-      refute changeset.valid?
-      assert changeset.errors[:email] == {"has invalid format", [validator: &Pow.Ecto.Schema.Changeset.validate_email/1]}
+      assert changeset.errors[:email] == {"has invalid format", [validator: &Pow.Ecto.Schema.Changeset.validate_email/1, reason: "invalid format"]}
 
       changeset = User.changeset(%User{}, @valid_params)
       assert changeset.valid?
@@ -228,5 +224,35 @@ defmodule Pow.Ecto.Schema.ChangesetTest do
       refute Changeset.verify_password(%User{password_hash: "hash"}, "secret1234", config)
       assert_received {:password_verify, "secret1234", "hash"}
     end
+  end
+
+  test "validate_email/1" do
+    # Format
+    assert Changeset.validate_email("simple@example.com") == :ok
+    assert Changeset.validate_email("very.common@example.com") == :ok
+    assert Changeset.validate_email("disposable.style.email.with+symbol@example.com") == :ok
+    assert Changeset.validate_email("other.email-with-hyphen@example.com") == :ok
+    assert Changeset.validate_email("fully-qualified-domain@example.com") == :ok
+    assert Changeset.validate_email("x@example.com") == :ok
+    assert Changeset.validate_email("example-indeed@strange-example.com") == :ok
+    assert Changeset.validate_email("admin@mailserver1") == :ok
+    assert Changeset.validate_email("example@s.example") == :ok
+    assert Changeset.validate_email("\" \"@example.org") == :ok
+    assert Changeset.validate_email("\"john..doe\"@example.org") == :ok
+
+    assert Changeset.validate_email("Abc.example.com") == {:error, "invalid format"}
+    assert Changeset.validate_email("A@b@c@example.com") == {:error, "invalid characters in local-part"}
+    assert Changeset.validate_email("a\"b(c)d,e:f;g<h>i[j\\k]l@example.com") == {:error, "invalid characters in local-part"}
+    assert Changeset.validate_email("just\"not\"right@example.com") == {:error, "invalid characters in local-part"}
+    assert Changeset.validate_email("this is\"not\\allowed@example.com") == {:error, "invalid characters in local-part"}
+    assert Changeset.validate_email("this\\ still\\\"not\\\\allowed@example.com") == {:error, "invalid characters in local-part"}
+    assert Changeset.validate_email("1234567890123456789012345678901234567890123456789012345678901234+x@example.com") == {:error, "local-part too long"}
+
+    # Unicode
+    assert Changeset.validate_email("Pelé@example.com") == :ok
+    assert Changeset.validate_email("δοκιμή@παράδειγμα.δοκιμή") == :ok
+    assert Changeset.validate_email("我買@屋企.香港") == :ok
+    assert Changeset.validate_email("二ノ宮@黒川.日本") == :ok
+    assert Changeset.validate_email("медведь@с-балалайкой.рф") == :ok
   end
 end

--- a/test/pow/ecto/schema/changeset_test.exs
+++ b/test/pow/ecto/schema/changeset_test.exs
@@ -254,5 +254,12 @@ defmodule Pow.Ecto.Schema.ChangesetTest do
     assert Changeset.validate_email("我買@屋企.香港") == :ok
     assert Changeset.validate_email("二ノ宮@黒川.日本") == :ok
     assert Changeset.validate_email("медведь@с-балалайкой.рф") == :ok
+
+    # All error cases
+    assert Changeset.validate_email("john..doe@example.com") == {:error, "consective dots in local-part"}
+    assert Changeset.validate_email("john.doe@#{String.duplicate("x", 256)}") == {:error, "domain too long"}
+    assert Changeset.validate_email("john.doe@-example.com") == {:error, "domain begins with hyphen"}
+    assert Changeset.validate_email("john.doe@example-") == {:error, "domain ends with hyphen"}
+    assert Changeset.validate_email("john.doe@invaliddomain$") == {:error, "invalid characters in domain"}
   end
 end


### PR DESCRIPTION
Resolves #253 

Makes email validation configurable with `:email_validator` configuration option.