### PR TITLE
Update handling of e-mail confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## v1.0.13 (TBA)
 
-* Fixed bug in `PowEmailConfirmation.Phoenix.ControllerCallbacks.send_confirmation_email/2` where the confirmation e-mail wasn't send to the new e-mail when updating a user
+* Updated `PowEmailConfirmation.Ecto.Schema.changeset/3` so;
+  * when `:email` is identical to `:unconfirmed_email` it won't generate new `:email_confirmation_token`
+  * when `:email` is identical to the persisted `:email` value both `:email_confirmation_token` and `:unconfirmed_email` will be set to `nil`
+  * when there is no `:email` value in the params nothing happens
+* Updated `PowEmailConfirmation.Ecto.Schema.confirm_email_changeset/1` so now `:email_confirmation_token` is set to `nil`
+* Fixed bug in `PowEmailConfirmation.Phoenix.ControllerCallbacks.send_confirmation_email/2` where the confirmation e-mail wasn't send to the updated e-mail address
 * Added `PowEmailConfirmation.Ecto.Context.current_email_unconfirmed?/2` and `PowEmailConfirmation.Plug.pending_email_change?/1`
 
 ## v1.0.12 (2019-08-16)

--- a/lib/extensions/email_confirmation/ecto/context.ex
+++ b/lib/extensions/email_confirmation/ecto/context.ex
@@ -30,7 +30,7 @@ defmodule PowEmailConfirmation.Ecto.Context do
   def pending_email_change?(_user, _config), do: false
 
   @doc """
-  Confirms current e-mail, or e-mail change.
+  Confirms e-mail.
 
   See `PowEmailConfirmation.Ecto.Schema.confirm_email_changeset/1`.
   """

--- a/lib/extensions/email_confirmation/ecto/schema.ex
+++ b/lib/extensions/email_confirmation/ecto/schema.ex
@@ -32,34 +32,97 @@ defmodule PowEmailConfirmation.Ecto.Schema do
   @doc """
   Handles e-mail confirmation if e-mail is updated.
 
-  This will copy the `:email` value to `:unconfirmed_email` if `:email` change
-  value is different from the original `:email` data value. The `:email` will
-  then be reverted to its original value.
+  The `:email_confirmation_token` will always be set if the struct isn't
+  persisted to the database.
 
-  An `:email_confirmation_token` is generated if the `:email` has been changed,
-  or the struct isn't persisted to the database.
+  For structs persisted to the database, no changes will happen if there is no
+  `:email` in the params. Likewise, no changes will happen if the `:email`
+  change is the same as the persisted `:unconfirmed_email` value.
+
+  If the `:email` change is the same as the persisted `:email` value then both
+  `:email_confirmation_token` and `:unconfirmed_email` will be set to nil.
+
+  Otherwise the `:email` change will be copied over to `:unconfirmed_email` and
+  the `:email` change will be reverted back to the original persisted `:email`
+  value. A unique `:email_confirmation_token` will be generated.
   """
   @impl true
   @spec changeset(Changeset.t(), map(), Config.t()) :: Changeset.t()
-  def changeset(%{errors: []} = changeset, _attrs, _config) do
-    current_email = changeset.data.email
-    new_email     = Changeset.get_field(changeset, :email)
-    state         = Ecto.get_meta(changeset.data, :state)
+  def changeset(%{valid?: true} = changeset, attrs, _config) do
+    cond do
+      built?(changeset) ->
+        put_email_confirmation_token(changeset)
 
-    changeset
-    |> maybe_put_email_confirmation_token(state, current_email, new_email)
-    |> maybe_set_unconfirmed_email(state, current_email, new_email)
+      email_reverted?(changeset, attrs) ->
+        changeset
+        |> Changeset.put_change(:email_confirmation_token, nil)
+        |> Changeset.put_change(:unconfirmed_email, nil)
+
+      email_changed?(changeset) ->
+        current_email = changeset.data.email
+        changed_email = Changeset.get_field(changeset, :email)
+
+        changeset
+        |> put_email_confirmation_token()
+        |> set_unconfirmed_email(current_email, changed_email)
+
+      true ->
+        changeset
+    end
   end
   def changeset(changeset, _attrs, _config), do: changeset
+
+  defp built?(changeset), do: Ecto.get_meta(changeset.data, :state) == :built
+
+  defp email_reverted?(changeset, attrs) do
+    param   = Map.get(attrs, :email) || Map.get(attrs, "email")
+    current = changeset.data.email
+
+    param == current
+  end
+
+  defp email_changed?(changeset) do
+    changed_email     = Changeset.get_change(changeset, :email)
+    unconfirmed_email = changeset.data.unconfirmed_email
+
+    changed_email && changed_email != unconfirmed_email
+  end
+
+  defp put_email_confirmation_token(changeset) do
+    changeset
+    |> Changeset.put_change(:email_confirmation_token, UUID.generate())
+    |> Changeset.unique_constraint(:email_confirmation_token)
+  end
+
+  defp set_unconfirmed_email(changeset, current_email, new_email) do
+    changeset
+    |> Changeset.put_change(:email, current_email)
+    |> Changeset.put_change(:unconfirmed_email, new_email)
+    |> Changeset.prepare_changes(&validate_unique_email/1)
+  end
+
+  defp validate_unique_email(changeset) do
+    opts = Keyword.take(changeset.repo_opts, [:prefix])
+    unconfirmed_email = Changeset.get_change(changeset, :unconfirmed_email)
+    unique_email_changeset =
+      changeset
+      |> Changeset.put_change(:email, unconfirmed_email)
+      |> Changeset.unsafe_validate_unique(:email, changeset.repo, opts)
+
+    case unique_email_changeset.valid? do
+      true  -> changeset
+      false -> unique_email_changeset
+    end
+  end
 
   @doc """
   Sets the e-mail as confirmed.
 
-  This updates `:email_confirmed_at`, and sets `:email_confirmation_token` to
+  This updates `:email_confirmed_at` and sets `:email_confirmation_token` to
   nil.
 
-  If `:unconfirmed_email` is set, then the `:email` will be updated with
-  the `:unconfirmed_email` value, and `:unconfirmed_email` will be set to nil.
+  If the struct has a `:unconfirmed_email` value, then the `:email` will be
+  changed to this value, and `:unconfirmed_email` will be set to nil.
   """
   @spec confirm_email_changeset(Ecto.Schema.t() | Changeset.t()) :: Changeset.t()
   def confirm_email_changeset(%Changeset{data: %{unconfirmed_email: unconfirmed_email}} = changeset) when not is_nil(unconfirmed_email) do
@@ -77,39 +140,16 @@ defmodule PowEmailConfirmation.Ecto.Schema do
 
   defp confirm_email(changeset, email) do
     confirmed_at = Pow.Ecto.Schema.__timestamp_for__(changeset.data.__struct__, :email_confirmed_at)
-    changes      = [email_confirmed_at: confirmed_at, email: email, unconfirmed_email: nil]
+    changes      =
+      [
+        email_confirmed_at: confirmed_at,
+        email: email,
+        unconfirmed_email: nil,
+        email_confirmation_token: nil
+      ]
 
     changeset
     |> Changeset.change(changes)
     |> Changeset.unique_constraint(:email)
-  end
-
-  defp maybe_put_email_confirmation_token(changeset, state, current_email, new_email) when current_email != new_email or state == :built do
-    changeset
-    |> Changeset.put_change(:email_confirmation_token, UUID.generate())
-    |> Changeset.unique_constraint(:email_confirmation_token)
-  end
-  defp maybe_put_email_confirmation_token(changeset, _state, _current_email, _new_email), do: changeset
-
-  defp maybe_set_unconfirmed_email(changeset, :loaded, current_email, new_email) when current_email != new_email do
-    changeset
-    |> Changeset.put_change(:email, current_email)
-    |> Changeset.put_change(:unconfirmed_email, new_email)
-    |> Changeset.prepare_changes(&validate_unique_email/1)
-  end
-  defp maybe_set_unconfirmed_email(changeset, _state, _current_email, _new_email), do: changeset
-
-  defp validate_unique_email(changeset) do
-    opts = Keyword.take(changeset.repo_opts, [:prefix])
-    unconfirmed_email = Changeset.get_change(changeset, :unconfirmed_email)
-    unique_email_changeset =
-      changeset
-      |> Changeset.put_change(:email, unconfirmed_email)
-      |> Changeset.unsafe_validate_unique(:email, changeset.repo, opts)
-
-    case unique_email_changeset.valid? do
-      true  -> changeset
-      false -> unique_email_changeset
-    end
   end
 end

--- a/test/extensions/email_confirmation/ecto/context_test.exs
+++ b/test/extensions/email_confirmation/ecto/context_test.exs
@@ -26,13 +26,15 @@ defmodule PowEmailConfirmation.Ecto.ContextTest do
 
     test "changes :email to :unconfirmed_email" do
       user = %{@user | unconfirmed_email: "new@example.com"}
+
       assert {:ok, user} = Context.confirm_email(user, @config)
       assert user.email == "new@example.com"
       refute user.unconfirmed_email
     end
 
-    test "handles unique index" do
+    test "handles unique constraint" do
       user = %{@user | unconfirmed_email: "taken@example.com"}
+
       assert {:error, changeset} = Context.confirm_email(user, @config)
       assert changeset.errors[:email] == {"has already been taken", []}
     end

--- a/test/extensions/email_confirmation/phoenix/controllers/confirmation_controller_test.exs
+++ b/test/extensions/email_confirmation/phoenix/controllers/confirmation_controller_test.exs
@@ -18,7 +18,7 @@ defmodule PowEmailConfirmation.Phoenix.ConfirmationControllerTest do
     end
 
     test "confirms with valid token and :unconfirmed_email", %{conn: conn} do
-      conn = get conn, Routes.pow_email_confirmation_confirmation_path(conn, :show, "valid_unconfirmed_email")
+      conn = get conn, Routes.pow_email_confirmation_confirmation_path(conn, :show, "valid-with-unconfirmed-changed-email")
       assert redirected_to(conn) == Routes.pow_session_path(conn, :new)
       assert get_flash(conn, :info) == "The email address has been confirmed."
 


### PR DESCRIPTION
A bunch of refactoring after #255, made the tests and mocks more readable, and fixed the following logic:

> * Updated `PowEmailConfirmation.Ecto.Schema.changeset/3` so;
>    * when `:email` is identical to `:unconfirmed_email` it won't generate new `:email_confirmation_token`
>    * when `:email` is identical to the persisted `:email` value both `:email_confirmation_token` and `:unconfirmed_email` will be set to `nil`
>   * when there is no `:email` value in the params nothing happens
> * Updated `PowEmailConfirmation.Ecto.Schema.confirm_email_changeset/1` so now `:email_confirmation_token` is set to `nil`