### PR TITLE
Change minimum password length to 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.0.14 (TBA)
+
+* Changed minmum password length to 8 (OWASP/NIST recommendations)
+
 ## v1.0.13 (2019-08-25)
 
 * Updated `PowEmailConfirmation.Ecto.Schema.changeset/3` so;

--- a/README.md
+++ b/README.md
@@ -563,7 +563,7 @@ If you're currently using Coherence, you can migrate your app to use Pow instead
 
 * The `user_id_field` value is always treated as case insensitive
 * If the `user_id_field` is `:email`, it'll be validated based on RFC 5322 (excluding IP validation)
-* The `:password` has a minimum length of 10 characters
+* The `:password` has a minimum length of 8 characters
 * The `:password` has a maximum length of 4096 bytes [to prevent DOS attacks against Pbkdf2](https://github.com/riverrun/pbkdf2_elixir/blob/master/lib/pbkdf2.ex#L21)
 * The `:password_hash` is generated with `PBKDF2-SHA512` with 100,000 iterations
 * The session value contains a UUID token that is used to pull credentials through a GenServer
@@ -571,7 +571,7 @@ If you're currently using Coherence, you can migrate your app to use Pow instead
 * The credentials and session are renewed after 15 minutes if any activity is detected
 * The credentials and session are renewed when user updates
 
-Some of the above is based on [OWASP](https://www.owasp.org/) recommendations.
+Some of the above is based on [OWASP](https://www.owasp.org/) or [NIST SP800-63b](https://pages.nist.gov/800-63-3/sp800-63b.html) recommendations.
 
 ## Other libraries
 

--- a/lib/pow/ecto/schema.ex
+++ b/lib/pow/ecto/schema.ex
@@ -35,7 +35,7 @@ defmodule Pow.Ecto.Schema do
           user_id_field: :email,
           password_hash_methods: {&Pow.Ecto.Schema.Password.pbkdf2_hash/1,
                                   &Pow.Ecto.Schema.Password.pbkdf2_verify/2},
-          password_min_length: 10,
+          password_min_length: 8,
           password_max_length: 4096
 
         schema "users" do

--- a/lib/pow/ecto/schema/changeset.ex
+++ b/lib/pow/ecto/schema/changeset.ex
@@ -8,7 +8,7 @@ defmodule Pow.Ecto.Schema.Changeset do
 
   ## Configuration options
 
-    * `:password_min_length`   - minimum password length, defaults to 10
+    * `:password_min_length`   - minimum password length, defaults to 8
     * `:password_max_length`   - maximum password length, defaults to 4096
     * `:password_hash_methods` - the password hash and verify methods to use,
       defaults to:
@@ -25,7 +25,7 @@ defmodule Pow.Ecto.Schema.Changeset do
   alias Ecto.Changeset
   alias Pow.{Config, Ecto.Schema, Ecto.Schema.Password}
 
-  @password_min_length 10
+  @password_min_length 8
   @password_max_length 4096
 
   @doc """

--- a/test/pow/ecto/schema/changeset_test.exs
+++ b/test/pow/ecto/schema/changeset_test.exs
@@ -116,10 +116,10 @@ defmodule Pow.Ecto.Schema.ChangesetTest do
     end
 
     test "validates length of password" do
-      changeset = User.changeset(%User{}, Map.put(@valid_params, "password", Enum.join(1..9)))
+      changeset = User.changeset(%User{}, Map.put(@valid_params, "password", Enum.join(1..7)))
 
       refute changeset.valid?
-      assert changeset.errors[:password] == {"should be at least %{count} character(s)", [count: 10, validation: :length, kind: :min, type: :string]}
+      assert changeset.errors[:password] == {"should be at least %{count} character(s)", [count: 8, validation: :length, kind: :min, type: :string]}
 
       changeset = User.changeset(%User{}, Map.put(@valid_params, "password", Enum.join(1..4096)))
       refute changeset.valid?

--- a/test/pow/phoenix/controllers/registration_controller_test.exs
+++ b/test/pow/phoenix/controllers/registration_controller_test.exs
@@ -69,7 +69,7 @@ defmodule Pow.Phoenix.RegistrationControllerTest do
       assert html =~ "<input id=\"user_email\" name=\"user[email]\" type=\"text\" value=\"test@example.com\">"
       assert html =~ "<label for=\"user_password\">Password</label>"
       assert html =~ "<input id=\"user_password\" name=\"user[password]\" type=\"password\">"
-      assert html =~ "<span class=\"help-block\">should be at least 10 character(s)</span>"
+      assert html =~ "<span class=\"help-block\">should be at least 8 character(s)</span>"
       assert errors = conn.assigns[:changeset].errors
       assert errors[:password]
       refute Plug.current_user(conn)


### PR DESCRIPTION
OWASP have changed [their recommendations](https://github.com/OWASP/CheatSheetSeries/pull/129) to conform to NIST SP800-63b instead of NIST 800-132. Minimum recommended password length is now 8 instead of 10.