### PR TITLE
Update docs with how to override assocs or fields in extensions

### DIFF
--- a/lib/extensions/email_confirmation/ecto/schema.ex
+++ b/lib/extensions/email_confirmation/ecto/schema.ex
@@ -1,6 +1,29 @@
 defmodule PowEmailConfirmation.Ecto.Schema do
   @moduledoc """
   Handles the e-mail confirmation schema for user.
+
+  ## Customize PowEmailConfirmation fields
+
+  If you need to modify any of the fields that `PowEmailConfirmation` adds to
+  the user schema, you can override them by defining them before
+  `pow_user_fields/0`:
+
+      defmodule MyApp.Users.User do
+        use Ecto.Schema
+        use Pow.Ecto.Schema
+        use Pow.Extension.Ecto.Schema,
+          extensions: [PowEmailConfirmation]
+
+        schema "users" do
+          field :email_confirmation_token, :string
+          field :email_confirmed_at, :utc_datetime
+          field :unconfirmed_email, :string
+
+          pow_user_fields()
+
+          timestamps()
+        end
+      end
   """
 
   use Pow.Extension.Ecto.Schema.Base

--- a/lib/extensions/invitation/ecto/schema.ex
+++ b/lib/extensions/invitation/ecto/schema.ex
@@ -1,6 +1,31 @@
 defmodule PowInvitation.Ecto.Schema do
   @moduledoc """
   Handles the invitation schema for user.
+
+  ## Customize PowInvitation associations or fields
+
+  If you need to modify any of the associations or fields that `PowInvitation`
+  adds to the user schema, you can override them by defining them before
+  `pow_user_fields/0`:
+
+      defmodule MyApp.Users.User do
+        use Ecto.Schema
+        use Pow.Ecto.Schema
+        use Pow.Extension.Ecto.Schema,
+          extensions: [PowInvitation]
+
+        schema "users" do
+          belongs_to :invited_by, __MODULE__
+          has_many :invited_users __MODULE__, foreign_key: :invited_by_id, on_delete: delete_all
+
+          field :invitation_token, :string
+          field :invitation_accepted_at, :utc_datetime
+
+          pow_user_fields()
+
+          timestamps()
+        end
+      end
   """
 
   use Pow.Extension.Ecto.Schema.Base


### PR DESCRIPTION
This has a nice side effect of showing all fields/assocs that an extension adds to the user schema.