### PR TITLE
Make custom schema example in mix tasks clearer

### DIFF
--- a/lib/mix/tasks/ecto/pow.ecto.gen.migration.ex
+++ b/lib/mix/tasks/ecto/pow.ecto.gen.migration.ex
@@ -6,7 +6,7 @@ defmodule Mix.Tasks.Pow.Ecto.Gen.Migration do
 
       mix pow.ecto.gen.migration -r MyApp.Repo
 
-      mix pow.ecto.gen.migration -r MyApp.Repo Accounts.Organization organizations
+      mix pow.ecto.gen.migration -r MyApp.Repo Accounts.Account accounts
 
   This generator will add a migration file in `priv/repo/migrations` for the
   `users` table

--- a/lib/mix/tasks/ecto/pow.ecto.gen.schema.ex
+++ b/lib/mix/tasks/ecto/pow.ecto.gen.schema.ex
@@ -6,7 +6,7 @@ defmodule Mix.Tasks.Pow.Ecto.Gen.Schema do
 
       mix pow.ecto.gen.schema
 
-      mix pow.ecto.gen.schema --context-app my_app Accounts.Organization organizations
+      mix pow.ecto.gen.schema --context-app my_app Accounts.Account accounts
 
   This generator will add a schema module file in `lib/my_app/users/user.ex`.
 

--- a/lib/mix/tasks/ecto/pow.ecto.install.ex
+++ b/lib/mix/tasks/ecto/pow.ecto.install.ex
@@ -6,7 +6,7 @@ defmodule Mix.Tasks.Pow.Ecto.Install do
 
       mix pow.ecto.install -r MyApp.Repo
 
-      mix pow.ecto.install -r MyApp.Repo Accounts.Organization organizations
+      mix pow.ecto.install -r MyApp.Repo Accounts.Account accounts
 
   See `Mix.Tasks.Pow.Ecto.Gen.Schema`, `Mix.Tasks.Pow.Ecto.Gen.Migration`
   and `Mix.Tasks.Pow.Extension.Ecto.Gen.Migrations` for more.

--- a/lib/mix/tasks/extension/ecto/pow.extension.ecto.gen.migrations.ex
+++ b/lib/mix/tasks/extension/ecto/pow.extension.ecto.gen.migrations.ex
@@ -6,7 +6,7 @@ defmodule Mix.Tasks.Pow.Extension.Ecto.Gen.Migrations do
 
       mix pow.extension.ecto.gen.migrations -r MyApp.Repo --extension PowEmailConfirmation --extension PowResetPassword
 
-      mix pow.extension.ecto.gen.migrations -r MyApp.Repo --extension PowEmailConfirmation Accounts.Organization organizations
+      mix pow.extension.ecto.gen.migrations -r MyApp.Repo --extension PowEmailConfirmation Accounts.Account accounts
 
   ## Arguments
 

--- a/lib/mix/tasks/pow.install.ex
+++ b/lib/mix/tasks/pow.install.ex
@@ -6,7 +6,7 @@ defmodule Mix.Tasks.Pow.Install do
 
       mix pow.install -r MyApp.Repo
 
-      mix pow.install -r MyApp.Repo Accounts.Organization organizations
+      mix pow.install -r MyApp.Repo Accounts.Account accounts
 
   See `Mix.Tasks.Pow.Ecto.Install` and `Mix.Tasks.Pow.Phoenix.Install` for
   more.


### PR DESCRIPTION
Based on https://elixirforum.com/t/pow-robust-modular-extendable-user-authentication-and-management-system/15807/151?u=danschultzer I've made the custom schema examples clearer so instead of:

```bash
mix pow.ecto.gen.migration -r MyApp.Repo Accounts.Organization organizations
```

It's now:

```bash
mix pow.ecto.gen.migration -r MyApp.Repo Accounts.Account accounts
```