### PR TITLE
Add fingerprint to sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@
   * `Pow.Store.CredentialsCache` now adds a session key rather than appending to a list for the user key to prevent race condition
 * Fixed bug where `PowEmailConfirmation.Phoenix.ControllerCallbacks` couldn't deliver email
 * `Pow.Plug.Session` now adds a fingerprint for new sessions that will persist when sessions are renewed
+* `Pow.Plug.Session` assigns private key `:pow_session_fingerprint` in the conn with the session fingerprint value, or uses the private key value when creating sessions
+* `PowPersistentSession.Plug.Cookie` will record the value of `:pow_session_fingerprint` if it exists in conn private, and will assign it to the conn if `:session_fingerprint` exists for the persistent session metadata
 
 ## v1.0.13 (2019-08-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,8 @@
   * `Pow.Store.CredentialsCache` now adds a session key rather than appending to a list for the user key to prevent race condition
 * Fixed bug where `PowEmailConfirmation.Phoenix.ControllerCallbacks` couldn't deliver email
 * `Pow.Plug.Session` now adds a fingerprint for new sessions that will persist when sessions are renewed
-* `Pow.Plug.Session` assigns private key `:pow_session_fingerprint` in the conn with the session fingerprint value, or uses the private key value when creating sessions
-* `PowPersistentSession.Plug.Cookie` will record the value of `:pow_session_fingerprint` if it exists in conn private, and will assign it to the conn if `:session_fingerprint` exists for the persistent session metadata
+* `Pow.Plug.Session` assigns private key `:pow_session_metadata` in the conn as a keyword list with `:fingerprint` containing the session fingerprint value when fetching session, and fetches this value when creating sessions
+* `PowPersistentSession.Plug.Cookie` will record the value of `:fingerprint` in the `:pow_session_metadata` if it exists in conn private, and will assign it to the conn if `:session_fingerprint` exists for the persistent session metadata
 
 ## v1.0.13 (2019-08-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
   * Deprecated `Pow.Store.CredentialsCache.sessions/3`
   * `Pow.Store.CredentialsCache` now adds a session key rather than appending to a list for the user key to prevent race condition
 * Fixed bug where `PowEmailConfirmation.Phoenix.ControllerCallbacks` couldn't deliver email
+* `Pow.Plug.Session` now adds a fingerprint for new sessions that will persist when sessions are renewed
 
 ## v1.0.13 (2019-08-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 * Changed minmum password length to 8 (OWASP/NIST recommendations)
 * Fixed bug where `Pow.Store.CredentialsCache` wasn't used due to how `Pow.Store.Base` macro worked
-* `Pow.Plug.Session` now stores a keyword list with metadata for the session rather than just the timestamp
 * `Pow.Phoenix.Router` now only filters routes that has equal number of bindings
 * `Pow.Phoenix.Routes.user_not_authenticated_path/1` now only puts the `:request_path` param if the request is using "GET" method
 * The stores has been refactored so the command conforms with ETS store. This means that put commands now accept `{key, value}` record element(s), and keys may be list for easier lookup.
@@ -38,9 +37,11 @@
   * Deprecated `Pow.Store.CredentialsCache.sessions/3`
   * `Pow.Store.CredentialsCache` now adds a session key rather than appending to a list for the user key to prevent race condition
 * Fixed bug where `PowEmailConfirmation.Phoenix.ControllerCallbacks` couldn't deliver email
-* `Pow.Plug.Session` now adds a fingerprint for new sessions that will persist when sessions are renewed
-* `Pow.Plug.Session` assigns private key `:pow_session_metadata` in the conn as a keyword list with `:fingerprint` containing the session fingerprint value when fetching session, and fetches this value when creating sessions
-* `PowPersistentSession.Plug.Cookie` will record the value of `:fingerprint` in the `:pow_session_metadata` if it exists in conn private, and will assign it to the conn if `:session_fingerprint` exists for the persistent session metadata
+* `Pow.Plug.Session.create/3` now stores a keyword list with metadata for the session rather than just a timestamp
+* `Pow.Plug.Session.fetch/2` and `Pow.Plug.Session.create/3` now assigns `:pow_session_metadata` in `conn.private` with the session metadata
+* `Pow.Plug.Session.create/3` will use the metadata found in `conn.private[:pow_session_metadata]` if it exists and otherwise add a randomly unique id for `:fingerprint`
+* `PowPersistentSession.Plug.Cookie.create/3` will use the value of `conn.private[:pow_session_metadata][:fingerprint]` if it exists as `:session_fingerprint` in the persistent session metadata
+* `PowPersistentSession.Plug.Cookie.authenticate/2` will assign `:fingerprint` to `conn.private[:pow_session_metadata]` if it exists in the persistent session metadata
 
 ## v1.0.13 (2019-08-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * `Pow.Plug.Session.create/3` will use the metadata found in `conn.private[:pow_session_metadata]` if it exists and otherwise add a randomly unique id for `:fingerprint`
 * `PowPersistentSession.Plug.Cookie.create/3` will use the value of `conn.private[:pow_session_metadata][:fingerprint]` if it exists as `:session_fingerprint` in the persistent session metadata
 * `PowPersistentSession.Plug.Cookie.authenticate/2` will assign `:fingerprint` to `conn.private[:pow_session_metadata]` if it exists in the persistent session metadata
+* `Pow.Store.CredentialsCache.put/3` will invalidate any other sessions with the same `:fingerprint` if any is set in session metadata
 
 ## v1.0.13 (2019-08-25)
 

--- a/README.md
+++ b/README.md
@@ -508,9 +508,11 @@ The current user can also be fetched by using the template assigns set in the co
 
 ### Pow.Plug.Session
 
-Enables session-based authorization. The user struct will be collected from a cache store through a GenServer using a unique token generated for the session. The token will be reset every time the authorization level changes (handled by `Pow.Plug`).
+Enables session-based authorization. The user struct will be collected from a cache store through a GenServer using a unique token generated for the session. The token will be reset every time the authorization level changes (handled by `Pow.Plug`) or after a certain interval (default 15 minutes).
 
 The user struct fetched can be out of sync with the database if the row in the database is updated by actions outside Pow. In this case it's recommended to [add a plug](guides/sync_user.md) that reloads the user struct and reassigns it to the connection.
+
+Custom metadata can be set for the session by updating the `:pow_session_metadata` key in `conn.private`. Read the `Pow.Plug.Session` module docs for more details.
 
 #### Cache store
 

--- a/README.md
+++ b/README.md
@@ -512,7 +512,7 @@ Enables session-based authorization. The user struct will be collected from a ca
 
 The user struct fetched can be out of sync with the database if the row in the database is updated by actions outside Pow. In this case it's recommended to [add a plug](guides/sync_user.md) that reloads the user struct and reassigns it to the connection.
 
-Custom metadata can be set for the session by updating the `:pow_session_metadata` key in `conn.private`. Read the `Pow.Plug.Session` module docs for more details.
+Custom metadata can be set for the session by assigning a private `:pow_session_metadata` key in the conn. Read the `Pow.Plug.Session` module docs for more details.
 
 #### Cache store
 

--- a/lib/extensions/persistent_session/plug/cookie.ex
+++ b/lib/extensions/persistent_session/plug/cookie.ex
@@ -6,8 +6,8 @@ defmodule PowPersistentSession.Plug.Cookie do
   be renewed on every request. The token in the cookie can only be used once to
   create a session.
 
-  If a private `:pow_session_metadata` key is assigned to the conn with a
-  keyword list containing `:fingerprint` key, that fingerprint value will be
+  If an assigned private `:pow_session_metadata` key exists in the conn with a
+  keyword list containing a `:fingerprint` key, that fingerprint value will be
   set along with the user id as the persistent session value as
   `{user_id, session_fingerprint: fingerprint}`.
 
@@ -46,10 +46,13 @@ defmodule PowPersistentSession.Plug.Cookie do
   @doc """
   Sets a persistent session cookie with an auto generated token.
 
-  The token is set as a key in the persistent session cache with the user
-  struct id. If `:pow_session_metadata` has been assign as a private key in
-  the conn as a keyword list with a `:fingerprint` key, the value will be
-  `{user_id, session_fingerprint: fingerprint}` instead.
+  The token is set as a key in the persistent session cache with the id fetched
+  from the struct.
+
+  If an assigned private `:pow_session_metadata` key exists in the conn with a
+  keyword list containing a `:fingerprint` value, then that value will be set
+  as the `:session_fingerprint` in the metadata. The value will look like:
+  `{user_id, session_fingerprint: fingerprint}`
 
   The unique cookie id will be prepended by the `:otp_app` configuration
   value, if present.
@@ -110,8 +113,8 @@ defmodule PowPersistentSession.Plug.Cookie do
   be removed.
 
   If a `:session_fingerprint` is fetched from the persistent session metadata,
-  it'll be added as `:fingerprint` to the keyword list of the private key
-  `:pow_session_metadata` of the conn.
+  it'll be assigned to the private `:pow_session_metadata` key in the conn as
+  `:fingerprint`.
 
   The cookie expiration will automatically be renewed on every request.
   """

--- a/lib/pow/store/credentials_cache.ex
+++ b/lib/pow/store/credentials_cache.ex
@@ -62,6 +62,9 @@ defmodule Pow.Store.CredentialsCache do
     - `{session_id, {[user_struct, :user, user_id], metadata}}`
     - `{[user_struct, :user, user_id], user}`
     - `{[user_struct, :user, user_id, :session, session_id], inserted_at}`
+
+  If metadata has `:fingerprint` any active sessions for the user with the same
+  `:fingerprint` in metadata will be deleted.
   """
   @impl true
   def put(config, session_id, {user, metadata}) do
@@ -73,6 +76,8 @@ defmodule Pow.Store.CredentialsCache do
       {user_key, user},
       {session_key, :os.system_time(:millisecond)}
     ]
+
+    delete_user_sessions_with_fingerprint(config, user, metadata)
 
     Base.put(config, backend_config(config), records)
   end
@@ -154,6 +159,26 @@ defmodule Pow.Store.CredentialsCache do
       nil -> raise "Primary key value for key `#{inspect key}` in #{inspect struct} can't be `nil`"
       val -> val
     end
+  end
+
+  defp delete_user_sessions_with_fingerprint(config, user, metadata) do
+    case Keyword.get(metadata, :fingerprint) do
+      nil         -> :ok
+      fingerprint -> do_delete_user_sessions_with_fingerprint(config, user, fingerprint)
+    end
+  end
+
+  defp do_delete_user_sessions_with_fingerprint(config, user, fingerprint) do
+    backend_config = backend_config(config)
+
+    config
+    |> sessions(user)
+    |> Enum.each(fn session_id ->
+      with {_user_key, metadata} when is_list(metadata) <- Base.get(config, backend_config, session_id),
+           ^fingerprint <- Keyword.get(metadata, :fingerprint) do
+        delete(config, session_id)
+      end
+    end)
   end
 
   # TODO: Remove by 1.1.0

--- a/test/extensions/persistent_session/phoenix/controllers/controller_callbacks_test.exs
+++ b/test/extensions/persistent_session/phoenix/controllers/controller_callbacks_test.exs
@@ -10,7 +10,7 @@ defmodule PowPersistentSession.Phoenix.ControllerCallbacksTest do
   describe "Pow.Phoenix.SessionController.create/2" do
     test "generates cookie", %{conn: conn, ets: ets} do
       conn = post conn, Routes.pow_session_path(conn, :create, %{"user" => @valid_params})
-      assert session_fingerprint = conn.private[:pow_session_fingerprint]
+      assert session_fingerprint = conn.private[:pow_session_metadata][:fingerprint]
 
       assert %{max_age: @max_age, path: "/", value: id} = conn.resp_cookies[@cookie_key]
       assert PersistentSessionCache.get([backend: ets], id) == {1, session_fingerprint: session_fingerprint}
@@ -29,7 +29,6 @@ defmodule PowPersistentSession.Phoenix.ControllerCallbacksTest do
 
       assert conn.resp_cookies[@cookie_key]
     end
-
   end
 
   describe "Pow.Phoenix.SessionController.delete/2" do

--- a/test/extensions/persistent_session/phoenix/controllers/controller_callbacks_test.exs
+++ b/test/extensions/persistent_session/phoenix/controllers/controller_callbacks_test.exs
@@ -10,9 +10,10 @@ defmodule PowPersistentSession.Phoenix.ControllerCallbacksTest do
   describe "Pow.Phoenix.SessionController.create/2" do
     test "generates cookie", %{conn: conn, ets: ets} do
       conn = post conn, Routes.pow_session_path(conn, :create, %{"user" => @valid_params})
+      assert session_fingerprint = conn.private[:pow_session_fingerprint]
 
       assert %{max_age: @max_age, path: "/", value: id} = conn.resp_cookies[@cookie_key]
-      assert PersistentSessionCache.get([backend: ets], id) == 1
+      assert PersistentSessionCache.get([backend: ets], id) == {1, session_fingerprint: session_fingerprint}
     end
 
     test "with persistent_session param set to false", %{conn: conn} do

--- a/test/extensions/persistent_session/phoenix/controllers/controller_callbacks_test.exs
+++ b/test/extensions/persistent_session/phoenix/controllers/controller_callbacks_test.exs
@@ -13,7 +13,7 @@ defmodule PowPersistentSession.Phoenix.ControllerCallbacksTest do
       assert session_fingerprint = conn.private[:pow_session_metadata][:fingerprint]
 
       assert %{max_age: @max_age, path: "/", value: id} = conn.resp_cookies[@cookie_key]
-      assert PersistentSessionCache.get([backend: ets], id) == {1, session_fingerprint: session_fingerprint}
+      assert PersistentSessionCache.get([backend: ets], id) == {[id: 1], session_fingerprint: session_fingerprint}
     end
 
     test "with persistent_session param set to false", %{conn: conn} do

--- a/test/extensions/persistent_session/plug/cookie_test.exs
+++ b/test/extensions/persistent_session/plug/cookie_test.exs
@@ -58,7 +58,7 @@ defmodule PowPersistentSession.Plug.CookieTest do
     assert PersistentSessionCache.get([backend: ets], new_id) == 1
   end
 
-  test "call/2 assigns user from cookie with fingerprint value set", %{conn: conn, ets: ets} do
+  test "call/2 assigns user from cookie passing fingerprint to the session metadata", %{conn: conn, ets: ets} do
     user = %User{id: 1}
     id   = "test"
     conn =
@@ -71,6 +71,7 @@ defmodule PowPersistentSession.Plug.CookieTest do
     refute new_id == id
     assert PersistentSessionCache.get([backend: ets], id) == :not_found
     assert PersistentSessionCache.get([backend: ets], new_id) == {1, session_fingerprint: "fingerprint"}
+    assert conn.private[:pow_session_metadata][:fingerprint] == "fingerprint"
   end
 
   test "call/2 assigns user from cookie with prepended `:otp_app`", %{config: config, ets: ets} do
@@ -136,7 +137,7 @@ defmodule PowPersistentSession.Plug.CookieTest do
     assert %{max_age: 1, path: "/"} = conn.resp_cookies["persistent_session_cookie"]
   end
 
-  test "create/3 with `:pow_session_metadata` with `:fingerprint` defined in conn", %{conn: conn, config: config} do
+  test "create/3 with `[:pow_session_metadata][:fingerprint]` defined in conn.private", %{conn: conn, config: config} do
     conn
     |> Conn.put_private(:pow_session_metadata, fingerprint: "fingerprint")
     |> Cookie.create(%User{id: 1}, config)

--- a/test/extensions/persistent_session/plug/cookie_test.exs
+++ b/test/extensions/persistent_session/plug/cookie_test.exs
@@ -136,9 +136,9 @@ defmodule PowPersistentSession.Plug.CookieTest do
     assert %{max_age: 1, path: "/"} = conn.resp_cookies["persistent_session_cookie"]
   end
 
-  test "create/3 with `:pow_session_fingerprint` defined in conn", %{conn: conn, config: config} do
+  test "create/3 with `:pow_session_metadata` with `:fingerprint` defined in conn", %{conn: conn, config: config} do
     conn
-    |> Conn.put_private(:pow_session_fingerprint, "fingerprint")
+    |> Conn.put_private(:pow_session_metadata, fingerprint: "fingerprint")
     |> Cookie.create(%User{id: 1}, config)
 
     assert_received {:ets, :put, [{_key, {1, session_fingerprint: "fingerprint"}}], _config}

--- a/test/pow/store/credentials_cache_test.exs
+++ b/test/pow/store/credentials_cache_test.exs
@@ -60,6 +60,21 @@ defmodule Pow.Store.CredentialsCacheTest do
     assert EtsCacheMock.get(@backend_config, [User, :user, 1, :session, "key_1"]) == :not_found
   end
 
+  test "put/3 invalidates sessions with identical fingerprint" do
+    user = %User{id: 1}
+
+    CredentialsCache.put(@config, "key_1", {user, fingerprint: 1})
+    CredentialsCache.put(@config, "key_2", {user, fingerprint: 2})
+
+    assert CredentialsCache.get(@config, "key_1") == {user, fingerprint: 1}
+
+    CredentialsCache.put(@config, "key_3", {user, fingerprint: 1})
+
+    assert CredentialsCache.get(@config, "key_1") == :not_found
+    assert CredentialsCache.get(@config, "key_2") == {user, fingerprint: 2}
+    assert CredentialsCache.get(@config, "key_3") == {user, fingerprint: 1}
+  end
+
   test "raises for nil primary key value" do
     user_1 = %User{id: nil}
 


### PR DESCRIPTION
Resolves #282 

This adds fingerprint to the session that will stay the same throughout the life cycle. The current session will be fetched when `Pow.Plug.Session.create/3` is called and if a session with fingerprint value exists that value will be used for the new session. Otherwise a UUID is generated.

I've also made it customizable so you can easily add to it by populating the `:pow_session_metadata` private key. This would be particularly useful for #122 #210 #30