### PR TITLE
Only filter routes with same number of bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Changed minmum password length to 8 (OWASP/NIST recommendations)
 * Fixed bug where `Pow.Store.CredentialsCache` wasn't used due to how `Pow.Store.Base` macro worked
 * `Pow.Plug.Session` now stores a keyword list with metadata for the session rather than just the timestamp
+* `Pow.Phoenix.Router` now only filters routes that has equal number of bindings
 
 ## v1.0.13 (2019-08-25)
 

--- a/test/pow/phoenix/router_test.exs
+++ b/test/pow/phoenix/router_test.exs
@@ -25,6 +25,10 @@ defmodule Pow.Test.Phoenix.OverriddenRouteRouter do
     get "/registration/overidden", RegistrationController, :new
   end
 
+  scope "/:extra" do
+    pow_routes()
+  end
+
   scope "/" do
     pow_routes()
   end
@@ -48,6 +52,7 @@ defmodule Pow.Phoenix.RouterTest do
 
   test "can override routes" do
     assert unquote(OverriddenRoutes.pow_registration_path(@conn, :new)) == "/registration/overidden"
-    assert Enum.count(Pow.Test.Phoenix.OverriddenRouteRouter.phoenix_routes(), &(&1.plug == Pow.Phoenix.RegistrationController && &1.plug_opts == :new)) == 1
+    assert unquote(OverriddenRoutes.pow_registration_path(@conn, :new, "test")) == "/test/registration/new"
+    assert Enum.count(Pow.Test.Phoenix.OverriddenRouteRouter.phoenix_routes(), &(&1.plug == Pow.Phoenix.RegistrationController && &1.plug_opts == :new)) == 2
   end
 end


### PR DESCRIPTION
Resolves #291 

When a route exists with the same helper alias and controller action, the length of bindings will also be checked. This ensure that the following won't be filtered out:

```elixir
  scope "/" do
    pipe_through [:browser]

    pow_routes()
    pow_extension_routes()
    pow_assent_routes()
  end

  scope "/:locale" do
    pipe_through [:browser]

    pow_routes()
    pow_extension_routes()
    pow_assent_routes()
  end
```

The first set of helper aliases in the above is different from the second set so there are no conflicts.