### PR TITLE
Only permit GET method for request_path param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fixed bug where `Pow.Store.CredentialsCache` wasn't used due to how `Pow.Store.Base` macro worked
 * `Pow.Plug.Session` now stores a keyword list with metadata for the session rather than just the timestamp
 * `Pow.Phoenix.Router` now only filters routes that has equal number of bindings
+* `Pow.Phoenix.Routes.user_not_authenticated_path/1` now only puts the `:request_path` param if the request is using "GET" method
 
 ## v1.0.13 (2019-08-25)
 

--- a/lib/pow/phoenix/routes.ex
+++ b/lib/pow/phoenix/routes.ex
@@ -92,10 +92,15 @@ defmodule Pow.Phoenix.Routes do
   redirect users back the the page they first attempted to visit. See
   `after_sign_in_path/1` for how `:request_path` is handled.
 
+  The `:request_path` will only be added if the request uses "GET" method.
+
   See `Pow.Phoenix.SessionController` for more on how this value is handled.
   """
   def user_not_authenticated_path(conn) do
-    session_path(conn, :new, request_path: Phoenix.Controller.current_path(conn))
+    case conn.method do
+      "GET"   -> session_path(conn, :new, request_path: Phoenix.Controller.current_path(conn))
+      _method -> session_path(conn, :new)
+    end
   end
 
   @doc """

--- a/test/support/phoenix/controller_assertions.ex
+++ b/test/support/phoenix/controller_assertions.ex
@@ -15,11 +15,17 @@ defmodule Pow.Test.Phoenix.ControllerAssertions do
 
   @spec assert_not_authenticated_redirect(Plug.Conn.t()) :: no_return
   defmacro assert_not_authenticated_redirect(conn) do
-    quote do
-      router = Module.concat([unquote(conn).private.phoenix_router, Helpers])
+    quote bind_quoted: [conn: conn] do
+      router = Module.concat([conn.private.phoenix_router, Helpers])
 
-      assert ConnTest.redirected_to(unquote(conn)) == router.pow_session_path(unquote(conn), :new, request_path: Phoenix.Controller.current_path(unquote(conn)))
-      assert ConnTest.get_flash(unquote(conn), :error) == Messages.user_not_authenticated(unquote(conn))
+      expected_path =
+        case conn.method do
+          "GET" -> router.pow_session_path(conn, :new, request_path: Phoenix.Controller.current_path(conn))
+          _any  -> router.pow_session_path(conn, :new)
+        end
+
+      assert ConnTest.redirected_to(conn) == expected_path
+      assert ConnTest.get_flash(conn, :error) == Messages.user_not_authenticated(conn)
     end
   end
 end


### PR DESCRIPTION
This prevents paths that doesn't use GET method from being used such as POST and DELETE since the path is used for redirects which can only be handled with GET method.