### PR TITLE
Refactor cache stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,14 +23,19 @@
   * `Pow.Store.Backend.MnesiaCache` will delete all binary key records when initialized
   * `Pow.Store.Base` behaviour now requires to;
     * Accept erlang term value for keys in all methods
+    * Implement `put/3` instead of `put/4`
+    * Implement `delete/2` instead of `put/3`
+    * Implement `get/2` instead of `put/3`
     * Remove `keys/2`
-    * Remove `put/4`
   * `Pow.Store.Base.all/3` added
+  * `Pow.Store.Base.put/3` added
   * `Pow.Store.Base.keys/2` deprecated
   * `Pow.Store.Base.put/4` deprecated
   * `Pow.Store.Base` will use binary key rather than key list if `all/2` doesn't exist in the backend cache
-  * Added `Pow.Store.CredentialsCache.users/3`
+  * Added `Pow.Store.CredentialsCache.users/2`
+  * Added `Pow.Store.CredentialsCache.sessions/2`
   * Deprecated `Pow.Store.CredentialsCache.user_session_keys/3`
+  * Deprecated `Pow.Store.CredentialsCache.sessions/3`
   * `Pow.Store.CredentialsCache` now adds a session key rather than appending to a list for the user key to prevent race condition
 
 ## v1.0.13 (2019-08-25)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@
 * `Pow.Plug.Session` now stores a keyword list with metadata for the session rather than just the timestamp
 * `Pow.Phoenix.Router` now only filters routes that has equal number of bindings
 * `Pow.Phoenix.Routes.user_not_authenticated_path/1` now only puts the `:request_path` param if the request is using "GET" method
+* The stores has been refactored so the command conforms with ETS store. This means that put commands now accept `{key, value}` record element(s), and keys may be list for easier lookup.
+  * `Pow.Store.Backend.Base` behaviour now requires to;
+    * Accept `Pow.Store.Backend.Base.record/0` values for `put/2`
+    * Accept `Pow.Store.Backend.Base.key/0` for `delete/2` and `get/2`
+    * Implement `all/2`
+    * Remove `keys/1`
+    * Remove `put/3`
+  * `Pow.Store.Backend.EtsCache.keys/1` deprecated
+  * `Pow.Store.Backend.EtsCache.put/3` deprecated
+  * `Pow.Store.Backend.EtsCache` now uses `:ordered_set` instead of `:set` for efficiency
+  * `Pow.Store.Backend.MnesiaCache.keys/1` deprecated
+  * `Pow.Store.Backend.MnesiaCache.put/3` deprecated
+  * `Pow.Store.Backend.MnesiaCache` now uses `:ordered_set` instead of `:set` for efficiency
+  * `Pow.Store.Backend.MnesiaCache` will delete all binary key records when initialized
+  * `Pow.Store.Base` behaviour now requires to;
+    * Accept erlang term value for keys in all methods
+    * Remove `keys/2`
+    * Remove `put/4`
+  * `Pow.Store.Base.all/3` added
+  * `Pow.Store.Base.keys/2` deprecated
+  * `Pow.Store.Base.put/4` deprecated
+  * `Pow.Store.Base` will use binary key rather than key list if `all/2` doesn't exist in the backend cache
+  * Added `Pow.Store.CredentialsCache.users/3`
+  * Deprecated `Pow.Store.CredentialsCache.user_session_keys/3`
+  * `Pow.Store.CredentialsCache` now adds a session key rather than appending to a list for the user key to prevent race condition
 
 ## v1.0.13 (2019-08-25)
 

--- a/guides/redis_cache_store_backend.md
+++ b/guides/redis_cache_store_backend.md
@@ -23,26 +23,43 @@ defmodule MyAppWeb.PowRedisCache do
 
   @redix_instance_name :redix
 
-  def put(config, key, value) do
-    key     = redis_key(config, key)
-    ttl     = Config.get(config, :ttl)
-    value   = :erlang.term_to_binary(value)
-    command = put_command(key, value, ttl)
+  @impl true
+  def put(config, record_or_records) do
+    ttl      = Config.get(config, :ttl) || raise_ttl_error()
+    commands =
+      record_or_records
+      |> List.wrap()
+      |> Enum.map(fn {key, value} ->
+        config
+        |> binary_redis_key(key)
+        |> put_command(value, ttl)
+      end)
 
-    Redix.noreply_command(@redix_instance_name, command)
+    Redix.noreply_pipeline(@redix_instance_name, commands)
   end
 
-  defp put_command(key, value, ttl) when is_integer(ttl) and ttl > 0, do: ["SET", key, value, "PX", ttl]
-  defp put_command(key, value, _ttl), do: ["SET", key, value]
+  defp put_command(key, value, ttl) do
+    value = :erlang.term_to_binary(value)
 
+    ["SET", key, value, "PX", ttl]
+  end
+
+  @impl true
   def delete(config, key) do
-    key = redis_key(config, key)
+    key =
+      config
+      |> redis_key(key)
+      |> to_binary_redis_key()
 
     Redix.noreply_command(@redix_instance_name, ["DEL", key])
   end
 
+  @impl true
   def get(config, key) do
-    key = redis_key(config, key)
+    key =
+      config
+      |> redis_key(key)
+      |> to_binary_redis_key()
 
     case Redix.command(@redix_instance_name, ["GET", key]) do
       {:ok, nil}   -> :not_found
@@ -50,22 +67,102 @@ defmodule MyAppWeb.PowRedisCache do
     end
   end
 
-  def keys(config) do
-    namespace = redis_key(config, "")
-    length    = String.length(namespace)
+  @impl true
+  def all(config, match_spec) do
+    compiled_match_spec = :ets.match_spec_compile([{match_spec, [], [:"$_"]}])
 
-    {:ok, values} = Redix.command(@redix_instance_name, ["KEYS", "#{namespace}*"])
+    Stream.resource(
+      fn -> do_scan(config, compiled_match_spec, "0") end,
+      &stream_scan(config, compiled_match_spec, &1),
+      fn _ -> :ok end)
+    |> Enum.to_list()
+    |> case do
+      []   -> []
+      keys -> fetch_values_for_keys(keys, config)
+    end
+  end
 
-    Enum.map(values, &String.slice(&1, length..-1))
+  defp fetch_values_for_keys(keys, config) do
+    binary_keys = Enum.map(keys, &binary_redis_key(config, &1))
+
+    case Redix.command(@redix_instance_name, ["MGET"] ++ binary_keys) do
+      {:ok, values} ->
+        values = Enum.map(values, &:erlang.binary_to_term/1)
+
+        keys
+        |> Enum.zip(values)
+        |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+    end
+  end
+
+  defp stream_scan(_config, _compiled_match_spec, {[], "0"}), do: {:halt, nil}
+  defp stream_scan(config, compiled_match_spec, {[], iterator}), do: do_scan(config, compiled_match_spec, iterator)
+  defp stream_scan(_config, _compiled_match_spec, {keys, iterator}), do: {keys, {[], iterator}}
+
+  defp do_scan(config, compiled_match_spec, iterator) do
+    prefix = to_binary_redis_key([namespace(config)]) <> ":*"
+
+    case Redix.command(@redix_instance_name, ["SCAN", iterator, "MATCH", prefix]) do
+      {:ok, [iterator, res]} -> {filter_or_load_value(compiled_match_spec, res), iterator}
+    end
+  end
+
+  defp filter_or_load_value(compiled_match_spec, keys) do
+    keys
+    |> Enum.map(&convert_key/1)
+    |> Enum.sort()
+    |> :ets.match_spec_run(compiled_match_spec)
+  end
+
+  defp convert_key(key) do
+    key
+    |> from_binary_redis_key()
+    |> unwrap()
+  end
+
+  defp unwrap([_namespace, key]), do: key
+  defp unwrap([_namespace | key]), do: key
+
+  defp binary_redis_key(config, key) do
+    config
+    |> redis_key(key)
+    |> to_binary_redis_key()
   end
 
   defp redis_key(config, key) do
-    namespace = Config.get(config, :namespace, "cache")
-
-    "#{namespace}:#{key}"
+    [namespace(config) | List.wrap(key)]
   end
+
+  defp namespace(config), do: Config.get(config, :namespace, "cache")
+
+  defp to_binary_redis_key(key) do
+    key
+    |> Enum.map(fn part ->
+      part
+      |> :erlang.term_to_binary()
+      |> Base.url_encode64(padding: false)
+    end)
+    |> Enum.join(":")
+  end
+
+  defp from_binary_redis_key(key) do
+    key
+    |> String.split(":")
+    |> Enum.map(fn part ->
+      part
+      |> Base.url_decode64!(padding: false)
+      |> :erlang.binary_to_term()
+    end)
+  end
+
+  @spec raise_ttl_error :: no_return
+  defp raise_ttl_error,
+    do: Config.raise_error("`:ttl` configuration option is required for #{inspect(__MODULE__)}")
 end
+
 ```
+
+We are converting keys to binary keys since we can't directly use the Erlang terms as with ETS and Mnesia.
 
 We'll need to start the Redix application on our app startup, so in `application.ex` add `{Redix, name: :redix}` to your supervision tree:
 
@@ -107,10 +204,17 @@ defmodule MyAppWeb.PowRedisCacheTest do
 
   @default_config [namespace: "test", ttl: :timer.hours(1)]
 
+  setup do
+    start_supervised!({Redix, host: "localhost", port: 6379, name: :redix})
+    Redix.command!(:redix, ["FLUSHALL"])
+
+    :ok
+  end
+
   test "can put, get and delete records" do
     assert PowRedisCache.get(@default_config, "key") == :not_found
 
-    PowRedisCache.put(@default_config, "key", "value")
+    PowRedisCache.put(@default_config, {"key", "value"})
     :timer.sleep(100)
     assert PowRedisCache.get(@default_config, "key") == "value"
 
@@ -119,22 +223,39 @@ defmodule MyAppWeb.PowRedisCacheTest do
     assert PowRedisCache.get(@default_config, "key") == :not_found
   end
 
-  test "fetch keys" do
-    PowRedisCache.put(@default_config, "key1", "value")
-    PowRedisCache.put(@default_config, "key2", "value")
+  test "can put multiple records at once" do
+    PowRedisCache.put(@default_config, [{"key1", "1"}, {"key2", "2"}])
+    :timer.sleep(100)
+    assert PowRedisCache.get(@default_config, "key1") == "1"
+    assert PowRedisCache.get(@default_config, "key2") == "2"
+  end
+
+  test "can match fetch all" do
+    PowRedisCache.put(@default_config, {"key1", "value"})
+    PowRedisCache.put(@default_config, {"key2", "value"})
     :timer.sleep(100)
 
-    assert Enum.sort(PowRedisCache.keys(@default_config)) == ["key1", "key2"]
+    assert PowRedisCache.all(@default_config, :_) ==  [{"key1", "value"}, {"key2", "value"}]
+
+    PowRedisCache.put(@default_config, {["namespace", "key"], "value"})
+    :timer.sleep(100)
+
+    assert PowRedisCache.all(@default_config, ["namespace", :_]) ==  [{["namespace", "key"], "value"}]
   end
 
   test "records auto purge" do
     config = Keyword.put(@default_config, :ttl, 100)
 
-    PowRedisCache.put(config, "key", "value")
+    PowRedisCache.put(config, {"key", "value"})
+    PowRedisCache.put(config, [{"key1", "1"}, {"key2", "2"}])
     :timer.sleep(50)
     assert PowRedisCache.get(config, "key") == "value"
+    assert PowRedisCache.get(config, "key1") == "1"
+    assert PowRedisCache.get(config, "key2") == "2"
     :timer.sleep(100)
     assert PowRedisCache.get(config, "key") == :not_found
+    assert PowRedisCache.get(config, "key1") == :not_found
+    assert PowRedisCache.get(config, "key2") == :not_found
   end
 end
 ```

--- a/lib/pow/store/backend/base.ex
+++ b/lib/pow/store/backend/base.ex
@@ -12,8 +12,12 @@ defmodule Pow.Store.Backend.Base do
   """
   alias Pow.Config
 
-  @callback put(Config.t(), binary(), any()) :: :ok
-  @callback delete(Config.t(), binary()) :: :ok
-  @callback get(Config.t(), binary()) :: any() | :not_found
-  @callback keys(Config.t()) :: [any()]
+  @type key() :: [binary() | atom()] | binary()
+  @type record() :: {key(), any()}
+  @type key_match() :: [atom() | binary()]
+
+  @callback put(Config.t(), record() | [record()]) :: :ok
+  @callback delete(Config.t(), key()) :: :ok
+  @callback get(Config.t(), key()) :: any() | :not_found
+  @callback all(Config.t(), key_match()) :: [record()]
 end

--- a/lib/pow/store/base.ex
+++ b/lib/pow/store/base.ex
@@ -11,40 +11,42 @@ defmodule Pow.Store.Base do
 
         @impl true
         def put(config, backend_config, key, value) do
-          Pow.Store.Base.put(config, backend_config, key, value)
+          Pow.Store.Base.put(config, backend_config, {key, value})
         end
       end
   """
-  alias Pow.{Config, Store.Backend.EtsCache}
+  alias Pow.Config
+  alias Pow.Store.Backend.{EtsCache, MnesiaCache, Base}
 
-  @callback put(Config.t(), Config.t(), binary(), any()) :: :ok
-  @callback delete(Config.t(), Config.t(), binary()) :: :ok
-  @callback get(Config.t(), Config.t(), binary()) :: any() | :not_found
-  @callback keys(Config.t(), Config.t()) :: [any()]
+  @type key :: Base.key()
+  @type record :: Base.record()
+  @type key_match :: Base.key_match()
+
+  @callback put(Config.t(), Config.t(), key(), any()) :: :ok
+  @callback delete(Config.t(), Config.t(), key()) :: :ok
+  @callback get(Config.t(), Config.t(), key()) :: any() | :not_found
+  @callback all(Config.t(), Config.t(), key_match()) :: [record()]
 
   @doc false
   defmacro __using__(defaults) do
     quote do
       @behaviour unquote(__MODULE__)
 
-      # TODO: Remove by 1.1.0
-      @behaviour Pow.Store.Backend.Base
-
-      @spec put(Config.t(), binary(), any()) :: :ok
+      @spec put(Config.t(), unquote(__MODULE__).key(), any()) :: :ok
       def put(config, key, value),
         do: put(config, backend_config(config), key, value)
 
-      @spec delete(Config.t(), binary()) :: :ok
+      @spec delete(Config.t(), unquote(__MODULE__).key()) :: :ok
       def delete(config, key),
         do: delete(config, backend_config(config), key)
 
-      @spec get(Config.t(), binary()) :: any() | :not_found
+      @spec get(Config.t(), unquote(__MODULE__).key()) :: any() | :not_found
       def get(config, key),
         do: get(config, backend_config(config), key)
 
-      @spec keys(Config.t()) :: [any()]
-      def keys(config),
-        do: keys(config, backend_config(config))
+      @spec all(Config.t(), unquote(__MODULE__).key_match()) :: [unquote(__MODULE__).record()]
+      def all(config, key_match),
+        do: all(config, backend_config(config), key_match)
 
       defp backend_config(config) do
         [
@@ -53,43 +55,129 @@ defmodule Pow.Store.Base do
         ]
       end
 
-      defdelegate put(config, backend_config, key, value), to: unquote(__MODULE__)
+      @impl unquote(__MODULE__)
+      def put(config, backend_config, key, value), do: unquote(__MODULE__).put(config, backend_config, {key, value})
+
       defdelegate delete(config, backend_config, key), to: unquote(__MODULE__)
       defdelegate get(config, backend_config, key), to: unquote(__MODULE__)
-      defdelegate keys(config, backend_config), to: unquote(__MODULE__)
+      defdelegate all(config, backend_config, key_match), to: unquote(__MODULE__)
 
       defoverridable unquote(__MODULE__)
 
       # TODO: Remove by 1.1.0
-      defoverridable Pow.Store.Backend.Base
+      defoverridable put: 3, delete: 2, get: 2, all: 2
     end
   end
 
-  @doc false
-  @spec put(Config.t(), Config.t(), binary(), any()) :: :ok
-  def put(config, backend_config, key, value) do
-    store(config).put(backend_config, key, value)
+  @spec put(Config.t(), Config.t(), record() | [record()]) :: :ok
+  def put(config, backend_config, record_or_records) do
+    # TODO: Update by 1.1.0
+    backwards_compatible_call(store(config), :put, [backend_config, record_or_records])
   end
 
   @doc false
-  @spec delete(Config.t(), Config.t(), binary()) :: :ok
+  @spec delete(Config.t(), Config.t(), key()) :: :ok
   def delete(config, backend_config, key) do
-    store(config).delete(backend_config, key)
+    # TODO: Update by 1.1.0
+    backwards_compatible_call(store(config), :delete, [backend_config, key])
   end
 
   @doc false
-  @spec get(Config.t(), Config.t(), binary()) :: any() | :not_found
+  @spec get(Config.t(), Config.t(), key()) :: any() | :not_found
   def get(config, backend_config, key) do
-    store(config).get(backend_config, key)
+    # TODO: Update by 1.1.0
+    backwards_compatible_call(store(config), :get, [backend_config, key])
   end
 
   @doc false
-  @spec keys(Config.t(), Config.t()) :: [any()]
-  def keys(config, backend_config) do
-    store(config).keys(backend_config)
+  @spec all(Config.t(), Config.t(), key_match()) :: [record()]
+  def all(config, backend_config, key_match) do
+    # TODO: Update by 1.1.0
+    backwards_compatible_call(store(config), :all, [backend_config, key_match])
   end
 
   defp store(config) do
     Config.get(config, :backend, EtsCache)
+  end
+
+  # TODO: Remove by 1.1.0
+  defp backwards_compatible_call(store, method, args) do
+    store
+    |> has_binary_keys?()
+    |> case do
+      false ->
+        apply(store, method, args)
+
+      true ->
+        IO.warn("binary key for backend stores is depecated, update `#{store}` to accept erlang terms instead")
+
+        case method do
+          :put    -> binary_key_put(store, args)
+          :get    -> binary_key_get(store, args)
+          :delete -> binary_key_delete(store, args)
+          :all    -> binary_key_all(store, args)
+        end
+    end
+  end
+
+  # TODO: Remove by 1.1.0
+  defp has_binary_keys?(store) when store in [EtsCache, MnesiaCache], do: false
+  defp has_binary_keys?(store), do: not function_exported?(store, :all, 2)
+
+  # TODO: Remove by 1.1.0
+  defp binary_key_put(store, [backend_config, record_or_records]) do
+    record_or_records
+    |> List.wrap()
+    |> Enum.each(fn {key, value} ->
+      key = binary_key(key)
+
+      store.put(backend_config, key, value)
+    end)
+  end
+
+  # TODO: Remove by 1.1.0
+  defp binary_key_get(store, [backend_config, key]) do
+    key = binary_key(key)
+
+    store.get(backend_config, key)
+  end
+
+  # TODO: Remove by 1.1.0
+  defp binary_key_delete(store, [backend_config, key]) do
+    key = binary_key(key)
+
+    store.delete(backend_config, key)
+  end
+
+  # TODO: Remove by 1.1.0
+  defp binary_key_all(store, [backend_config, match_spec]) do
+    match_spec = :ets.match_spec_compile([{match_spec, [], [:"$_"]}])
+
+    backend_config
+    |> store.keys()
+    |> Enum.map(&:erlang.binary_to_term/1)
+    |> :ets.match_spec_run(match_spec)
+    |> Enum.map(&{&1, binary_key_get(store, [backend_config, &1])})
+  end
+
+  # TODO: Remove by 1.1.0
+  defp binary_key(key) do
+    key
+    |> List.wrap()
+    |> :erlang.term_to_binary()
+  end
+
+  # TODO: Remove by 1.1.0
+  @doc false
+  @deprecated "Use `put/3` instead"
+  def put(config, backend_config, key, value) do
+    put(config, backend_config, {key, value})
+  end
+
+  # TODO: Remove by 1.1.0
+  @doc false
+  @deprecated "Use `all/2` instead"
+  def keys(config, backend_config) do
+    store(config).keys(backend_config)
   end
 end

--- a/test/extensions/persistent_session/plug/cookie_test.exs
+++ b/test/extensions/persistent_session/plug/cookie_test.exs
@@ -114,7 +114,7 @@ defmodule PowPersistentSession.Plug.CookieTest do
     config = Keyword.put(config, :persistent_session_ttl, 1000)
     conn   = Cookie.create(conn, %User{id: 1}, config)
 
-    assert_received {:ets, :put, _key, _value, config}
+    assert_received {:ets, :put, [{_key, _value} | _rest], config}
     assert config[:ttl] == 1000
 
     assert %{max_age: 1, path: "/"} = conn.resp_cookies["persistent_session_cookie"]

--- a/test/extensions/reset_password/phoenix/controllers/reset_password_controller_test.exs
+++ b/test/extensions/reset_password/phoenix/controllers/reset_password_controller_test.exs
@@ -41,7 +41,7 @@ defmodule PowResetPassword.Phoenix.ResetPasswordControllerTest do
 
     test "with valid params", %{conn: conn, ets: ets} do
       conn    = post conn, Routes.pow_reset_password_reset_password_path(conn, :create, @valid_params)
-      [token] = ResetTokenCache.keys([backend: ets])
+      [{token, _}] = ResetTokenCache.all([backend: ets], [:_])
 
       assert_received {:mail_mock, mail}
 

--- a/test/pow/phoenix/controllers/registration_controller_test.exs
+++ b/test/pow/phoenix/controllers/registration_controller_test.exs
@@ -187,7 +187,7 @@ defmodule Pow.Phoenix.RegistrationControllerTest do
     conn = post conn, Routes.pow_registration_path(conn, :create, @valid_params)
     assert %{id: 1} = Plug.current_user(conn)
     assert conn.private[:plug_session]["auth"]
-    assert_receive {:ets, :put, _key, _value, _opts}
+    assert_receive {:ets, :put, [{_key, _value} | _rest], _opts}
 
     conn
   end

--- a/test/pow/phoenix/controllers/session_controller_test.exs
+++ b/test/pow/phoenix/controllers/session_controller_test.exs
@@ -107,7 +107,7 @@ defmodule Pow.Phoenix.SessionControllerTest do
       conn = post conn, Routes.pow_session_path(conn, :create, @valid_params)
       assert %{id: 1} = Plug.current_user(conn)
       assert conn.private[:plug_session]["auth"]
-      assert_receive {:ets, :put, _key, _value, _opts}
+      assert_receive {:ets, :put, [{_key, _value} | _rest], _opts}
 
       conn = delete(conn, Routes.pow_session_path(conn, :delete))
       assert redirected_to(conn) == "/signed_out"

--- a/test/pow/plug_test.exs
+++ b/test/pow/plug_test.exs
@@ -100,7 +100,7 @@ defmodule Pow.PlugTest do
     assert user = Plug.current_user(conn)
     assert session_id = conn.private[:plug_session]["auth"]
     assert {key, _metadata} = EtsCacheMock.get([namespace: "credentials"], session_id)
-    assert %{user: ^user} = EtsCacheMock.get([namespace: "credentials"], key)
+    assert EtsCacheMock.get([namespace: "credentials"], key) == user
 
     {:ok, conn} = Plug.clear_authenticated_user(conn)
     refute Plug.current_user(conn)

--- a/test/pow/store/backend/ets_cache_test.exs
+++ b/test/pow/store/backend/ets_cache_test.exs
@@ -6,10 +6,16 @@ defmodule Pow.Store.Backend.EtsCacheTest do
 
   @default_config [namespace: "pow:test", ttl: :timer.hours(1)]
 
+  setup do
+    start_supervised!({EtsCache, []})
+
+    :ok
+  end
+
   test "can put, get and delete records" do
     assert EtsCache.get(@default_config, "key") == :not_found
 
-    EtsCache.put(@default_config, "key", "value")
+    EtsCache.put(@default_config, {"key", "value"})
     :timer.sleep(100)
     assert EtsCache.get(@default_config, "key") == "value"
 
@@ -18,10 +24,17 @@ defmodule Pow.Store.Backend.EtsCacheTest do
     assert EtsCache.get(@default_config, "key") == :not_found
   end
 
+  test "can put multiple records at once" do
+    EtsCache.put(@default_config, [{"key1", "1"}, {"key2", "2"}])
+    :timer.sleep(100)
+    assert EtsCache.get(@default_config, "key1") == "1"
+    assert EtsCache.get(@default_config, "key2") == "2"
+  end
+
   test "with no `:ttl` option" do
     config = [namespace: "pow:test"]
 
-    EtsCache.put(config, "key", "value")
+    EtsCache.put(config, {"key", "value"})
     :timer.sleep(100)
     assert EtsCache.get(config, "key") == "value"
 
@@ -29,21 +42,35 @@ defmodule Pow.Store.Backend.EtsCacheTest do
     :timer.sleep(100)
   end
 
-  test "fetch keys" do
-    EtsCache.put(@default_config, "key1", "value")
-    EtsCache.put(@default_config, "key2", "value")
+  test "can match fetch all" do
+    EtsCache.put(@default_config, {"key1", "value"})
+    EtsCache.put(@default_config, {"key2", "value"})
+    EtsCache.put(@default_config, {["namespace", "key"], "value"})
     :timer.sleep(100)
 
-    assert Enum.sort(EtsCache.keys(@default_config)) == ["key1", "key2"]
+    assert EtsCache.all(@default_config, :_) ==  [{"key1", "value"}, {"key2", "value"}]
+    assert EtsCache.all(@default_config, ["namespace", :_]) ==  [{["namespace", "key"], "value"}]
   end
 
   test "records auto purge" do
     config = Config.put(@default_config, :ttl, 100)
 
-    EtsCache.put(config, "key", "value")
+    EtsCache.put(config, {"key", "value"})
+    EtsCache.put(config, [{"key1", "1"}, {"key2", "2"}])
     :timer.sleep(50)
     assert EtsCache.get(config, "key") == "value"
+    assert EtsCache.get(config, "key1") == "1"
+    assert EtsCache.get(config, "key2") == "2"
     :timer.sleep(100)
     assert EtsCache.get(config, "key") == :not_found
+    assert EtsCache.get(config, "key1") == :not_found
+    assert EtsCache.get(config, "key2") == :not_found
+  end
+
+  # TODO: Remove by 1.1.0
+  test "backwards compatible" do
+    assert EtsCache.put(@default_config, "key", "value") == :ok
+    :timer.sleep(50)
+    assert EtsCache.keys(@default_config) == [{"key", "value"}]
   end
 end

--- a/test/pow/store/base_test.exs
+++ b/test/pow/store/base_test.exs
@@ -2,17 +2,25 @@ defmodule Pow.Store.BaseTest do
   use ExUnit.Case
   doctest Pow.Store.Base
 
-  alias Pow.Store.Base
+  alias Pow.Store.{Backend.EtsCache, Base}
 
   defmodule BackendCacheMock do
     def get(_config, :backend), do: :mock_backend
     def get(config, :config), do: config
+
+    def all(_config, _match_spec), do: []
   end
 
   defmodule BaseMock do
     use Base,
       namespace: "default_namespace",
       ttl: :timer.seconds(10)
+  end
+
+  setup do
+    start_supervised!({EtsCache, []})
+
+    :ok
   end
 
   test "fetches from custom backend" do
@@ -39,5 +47,50 @@ defmodule Pow.Store.BaseTest do
 
     assert BaseMock.get(default_config, :test) == :value
     assert BaseMock.get(override_config, :test) == :not_found
+  end
+
+  defmodule BackwardsCompabilityMock do
+    def put(config, key, value) do
+      send(self(), {:put, key(config, key), value})
+    end
+
+    def get(config, key) do
+      send(self(), {:get, key(config, key)})
+
+      :value
+    end
+
+    def delete(config, key) do
+      send(self(), {:delete, key(config, key)})
+
+      :ok
+    end
+
+    def keys(_config) do
+      [:erlang.term_to_binary([BackwardsCompabilityMock, :id, 2])]
+    end
+
+    defp key(config, key) do
+      "#{Pow.Config.get(config, :namespace, "cache")}:#{key}"
+    end
+  end
+
+  # TODO: Remove by 1.1.0
+  test "backwards compatible with binary keys support" do
+    config = [backend: BackwardsCompabilityMock]
+
+    assert BaseMock.put(config, [BackwardsCompabilityMock, :id, 2], :value) == :ok
+    binary_key = "default_namespace:#{:erlang.term_to_binary([BackwardsCompabilityMock, :id, 2])}"
+    assert_received {:put, ^binary_key, :value}
+
+    assert BaseMock.get(config, [BackwardsCompabilityMock, :id, 2]) == :value
+    assert_received {:get, ^binary_key}
+
+    assert BaseMock.delete(config, [BackwardsCompabilityMock, :id, 2]) == :ok
+    assert_received {:delete, ^binary_key}
+
+    assert BaseMock.all(config, [BackwardsCompabilityMock | :_]) == [{[BackwardsCompabilityMock, :id, 2], :value}]
+    assert BaseMock.all(config, [BackwardsCompabilityMock, :id, :_]) == [{[BackwardsCompabilityMock, :id, 2], :value}]
+    assert BaseMock.all(config, [BackwardsCompabilityMock, :id, 3]) == []
   end
 end

--- a/test/pow/store/credentials_cache_test.exs
+++ b/test/pow/store/credentials_cache_test.exs
@@ -30,15 +30,16 @@ defmodule Pow.Store.CredentialsCacheTest do
     assert CredentialsCache.get(@config, @backend_config, "key_3") == {user_2, a: 3}
     assert CredentialsCache.get(@config, @backend_config, "key_4") == {user_3, a: 4}
 
-    assert Enum.sort(CredentialsCache.user_session_keys(@config, @backend_config, User)) == ["pow/test/ecto/users/user_sessions_1", "pow/test/ecto/users/user_sessions_2"]
-    assert CredentialsCache.user_session_keys(@config, @backend_config, UsernameUser) == ["pow/test/ecto/users/username_user_sessions_1"]
+    assert Enum.sort(CredentialsCache.users(@config, @backend_config, User)) == [user_1, user_2]
+    assert CredentialsCache.users(@config, @backend_config, UsernameUser) == [user_3]
 
     assert CredentialsCache.sessions(@config, @backend_config, user_1) == ["key_1", "key_2"]
     assert CredentialsCache.sessions(@config, @backend_config, user_2) == ["key_3"]
     assert CredentialsCache.sessions(@config, @backend_config, user_3) == ["key_4"]
 
-    assert EtsCacheMock.get(@backend_config, "key_1") == {"#{Macro.underscore(User)}_sessions_1", a: 1}
-    assert EtsCacheMock.get(@backend_config, "#{Macro.underscore(User)}_sessions_1") == %{user: user_1, sessions: ["key_1", "key_2"]}
+    assert EtsCacheMock.get(@backend_config, "key_1") == {[User, :user, 1], a: 1}
+    assert EtsCacheMock.get(@backend_config, [User, :user, 1]) == user_1
+    assert EtsCacheMock.get(@backend_config, [User, :user, 1, :session, "key_1"])
 
     CredentialsCache.put(@config, @backend_config, "key_2", {%{user_1 | email: :updated}, a: 5})
     assert CredentialsCache.get(@config, @backend_config, "key_1") == {%{user_1 | email: :updated}, a: 1}
@@ -47,10 +48,16 @@ defmodule Pow.Store.CredentialsCacheTest do
     assert CredentialsCache.get(@config, @backend_config, "key_1") == :not_found
     assert CredentialsCache.sessions(@config, @backend_config, user_1) == ["key_2"]
 
+    assert EtsCacheMock.get(@backend_config, "key_1") == :not_found
+    assert EtsCacheMock.get(@backend_config, [User, :user, 1]) == %{user_1 | email: :updated}
+    assert EtsCacheMock.get(@backend_config, [User, :user, 1, :session, "key_1"]) == :not_found
+
     assert CredentialsCache.delete(@config, @backend_config, "key_2") == :ok
     assert CredentialsCache.sessions(@config, @backend_config, user_1) == []
 
-    assert EtsCacheMock.get(@backend_config, "#{Macro.underscore(User)}_sessions_1") == :not_found
+    assert EtsCacheMock.get(@backend_config, "key_1") == :not_found
+    assert EtsCacheMock.get(@backend_config, [User, :user, 1]) == %{user_1 | email: :updated}
+    assert EtsCacheMock.get(@backend_config, [User, :user, 1, :session, "key_1"]) == :not_found
   end
 
   test "raises for nil primary key value" do
@@ -91,9 +98,11 @@ defmodule Pow.Store.CredentialsCacheTest do
       CredentialsCache.put(@config, @backend_config, "key_1", {%CompositePrimaryFieldsUser{}, a: 1})
     end
 
-    CredentialsCache.put(@config, @backend_config, "key_1", {%CompositePrimaryFieldsUser{some_id: 1, another_id: 2}, a: 1})
+    user = %CompositePrimaryFieldsUser{some_id: 1, another_id: 2}
 
-    assert CredentialsCache.user_session_keys(@config, @backend_config, CompositePrimaryFieldsUser) == ["pow/store/credentials_cache_test/composite_primary_fields_user_sessions_another_id:2_some_id:1"]
+    CredentialsCache.put(@config, @backend_config, "key_1", {user, a: 1})
+
+    assert CredentialsCache.users(@config, @backend_config, CompositePrimaryFieldsUser) == [user]
   end
 
   defmodule NonEctoUser do
@@ -105,9 +114,11 @@ defmodule Pow.Store.CredentialsCacheTest do
       CredentialsCache.put(@config, @backend_config, "key_1", {%NonEctoUser{}, a: 1})
     end
 
-    assert CredentialsCache.put(@config, @backend_config, "key_1", {%NonEctoUser{id: 1}, a: 1})
+    user = %NonEctoUser{id: 1}
 
-    assert CredentialsCache.user_session_keys(@config, @backend_config, NonEctoUser) == ["pow/store/credentials_cache_test/non_ecto_user_sessions_1"]
+    assert CredentialsCache.put(@config, @backend_config, "key_1", {user, a: 1})
+
+    assert CredentialsCache.users(@config, @backend_config, NonEctoUser) == [user]
   end
 
   # TODO: Remove by 1.1.0
@@ -115,14 +126,31 @@ defmodule Pow.Store.CredentialsCacheTest do
     user_1 = %User{id: 1}
     timestamp = :os.system_time(:millisecond)
 
-    EtsCacheMock.put(@backend_config, "key_1", {user_1, inserted_at: timestamp})
+    EtsCacheMock.put(@backend_config, {"key_1", {user_1, inserted_at: timestamp}})
 
     assert CredentialsCache.get(@config, @backend_config, "key_1") == {user_1, inserted_at: timestamp}
     assert CredentialsCache.delete(@config, @backend_config, "key_1") == :ok
     assert CredentialsCache.get(@config, @backend_config, "key_1") == :not_found
+
+    assert CredentialsCache.user_session_keys(@config, @backend_config, User) == []
+
+    user_2 = %UsernameUser{id: 1}
+
+    CredentialsCache.put(@config, @backend_config, "key_1", {user_1, a: 1})
+    CredentialsCache.put(@config, @backend_config, "key_2", {user_1, a: 1})
+    CredentialsCache.put(@config, @backend_config, "key_3", {user_2, a: 1})
+
+    assert CredentialsCache.user_session_keys(@config, @backend_config, User) == [[Pow.Test.Ecto.Users.User, :user, 1, :session, "key_1"], [Pow.Test.Ecto.Users.User, :user, 1, :session, "key_2"]]
+    assert CredentialsCache.user_session_keys(@config, @backend_config, UsernameUser) == [[Pow.Test.Ecto.Users.UsernameUser, :user, 1, :session, "key_3"]]
   end
 
   describe "with EtsCache backend" do
+    setup do
+      start_supervised!({EtsCache, []})
+
+      :ok
+    end
+
     test "handles purged values" do
       user_1 = %User{id: 1}
       config = [backend: EtsCache]
@@ -140,7 +168,7 @@ defmodule Pow.Store.CredentialsCacheTest do
       :timer.sleep(50)
       assert CredentialsCache.get(config, backend_config, "key_1") == :not_found
       assert CredentialsCache.get(config, backend_config, "key_2") == {user_1, a: 2}
-      assert CredentialsCache.sessions(config, backend_config, user_1) == ["key_1", "key_2"]
+      assert CredentialsCache.sessions(config, backend_config, user_1) == ["key_2"]
 
       CredentialsCache.put(config, backend_config ++ [ttl: 100], "key_2", {user_1, a: 3})
       :timer.sleep(50)

--- a/test/pow/store/credentials_cache_test.exs
+++ b/test/pow/store/credentials_cache_test.exs
@@ -20,40 +20,40 @@ defmodule Pow.Store.CredentialsCacheTest do
     user_2 = %User{id: 2}
     user_3 = %UsernameUser{id: 1}
 
-    CredentialsCache.put(@config, @backend_config, "key_1", {user_1, a: 1})
-    CredentialsCache.put(@config, @backend_config, "key_2", {user_1, a: 2})
-    CredentialsCache.put(@config, @backend_config, "key_3", {user_2, a: 3})
-    CredentialsCache.put(@config, @backend_config, "key_4", {user_3, a: 4})
+    CredentialsCache.put(@config, "key_1", {user_1, a: 1})
+    CredentialsCache.put(@config, "key_2", {user_1, a: 2})
+    CredentialsCache.put(@config, "key_3", {user_2, a: 3})
+    CredentialsCache.put(@config, "key_4", {user_3, a: 4})
 
-    assert CredentialsCache.get(@config, @backend_config, "key_1") == {user_1, a: 1}
-    assert CredentialsCache.get(@config, @backend_config, "key_2") == {user_1, a: 2}
-    assert CredentialsCache.get(@config, @backend_config, "key_3") == {user_2, a: 3}
-    assert CredentialsCache.get(@config, @backend_config, "key_4") == {user_3, a: 4}
+    assert CredentialsCache.get(@config, "key_1") == {user_1, a: 1}
+    assert CredentialsCache.get(@config, "key_2") == {user_1, a: 2}
+    assert CredentialsCache.get(@config, "key_3") == {user_2, a: 3}
+    assert CredentialsCache.get(@config, "key_4") == {user_3, a: 4}
 
-    assert Enum.sort(CredentialsCache.users(@config, @backend_config, User)) == [user_1, user_2]
-    assert CredentialsCache.users(@config, @backend_config, UsernameUser) == [user_3]
+    assert Enum.sort(CredentialsCache.users(@config, User)) == [user_1, user_2]
+    assert CredentialsCache.users(@config, UsernameUser) == [user_3]
 
-    assert CredentialsCache.sessions(@config, @backend_config, user_1) == ["key_1", "key_2"]
-    assert CredentialsCache.sessions(@config, @backend_config, user_2) == ["key_3"]
-    assert CredentialsCache.sessions(@config, @backend_config, user_3) == ["key_4"]
+    assert CredentialsCache.sessions(@config, user_1) == ["key_1", "key_2"]
+    assert CredentialsCache.sessions(@config, user_2) == ["key_3"]
+    assert CredentialsCache.sessions(@config, user_3) == ["key_4"]
 
     assert EtsCacheMock.get(@backend_config, "key_1") == {[User, :user, 1], a: 1}
     assert EtsCacheMock.get(@backend_config, [User, :user, 1]) == user_1
     assert EtsCacheMock.get(@backend_config, [User, :user, 1, :session, "key_1"])
 
-    CredentialsCache.put(@config, @backend_config, "key_2", {%{user_1 | email: :updated}, a: 5})
-    assert CredentialsCache.get(@config, @backend_config, "key_1") == {%{user_1 | email: :updated}, a: 1}
+    CredentialsCache.put(@config, "key_2", {%{user_1 | email: :updated}, a: 5})
+    assert CredentialsCache.get(@config, "key_1") == {%{user_1 | email: :updated}, a: 1}
 
-    assert CredentialsCache.delete(@config, @backend_config, "key_1") == :ok
-    assert CredentialsCache.get(@config, @backend_config, "key_1") == :not_found
-    assert CredentialsCache.sessions(@config, @backend_config, user_1) == ["key_2"]
+    assert CredentialsCache.delete(@config, "key_1") == :ok
+    assert CredentialsCache.get(@config, "key_1") == :not_found
+    assert CredentialsCache.sessions(@config, user_1) == ["key_2"]
 
     assert EtsCacheMock.get(@backend_config, "key_1") == :not_found
     assert EtsCacheMock.get(@backend_config, [User, :user, 1]) == %{user_1 | email: :updated}
     assert EtsCacheMock.get(@backend_config, [User, :user, 1, :session, "key_1"]) == :not_found
 
-    assert CredentialsCache.delete(@config, @backend_config, "key_2") == :ok
-    assert CredentialsCache.sessions(@config, @backend_config, user_1) == []
+    assert CredentialsCache.delete(@config, "key_2") == :ok
+    assert CredentialsCache.sessions(@config, user_1) == []
 
     assert EtsCacheMock.get(@backend_config, "key_1") == :not_found
     assert EtsCacheMock.get(@backend_config, [User, :user, 1]) == %{user_1 | email: :updated}
@@ -64,7 +64,7 @@ defmodule Pow.Store.CredentialsCacheTest do
     user_1 = %User{id: nil}
 
     assert_raise RuntimeError, "Primary key value for key `:id` in Pow.Test.Ecto.Users.User can't be `nil`", fn ->
-      CredentialsCache.put(@config, @backend_config, "key_1", {user_1, a: 1})
+      CredentialsCache.put(@config, "key_1", {user_1, a: 1})
     end
   end
 
@@ -91,18 +91,18 @@ defmodule Pow.Store.CredentialsCacheTest do
 
   test "handles custom primary fields" do
     assert_raise RuntimeError, "No primary keys found for Pow.Store.CredentialsCacheTest.NoPrimaryFieldUser", fn ->
-      CredentialsCache.put(@config, @backend_config, "key_1", {%NoPrimaryFieldUser{}, a: 1})
+      CredentialsCache.put(@config, "key_1", {%NoPrimaryFieldUser{}, a: 1})
     end
 
     assert_raise RuntimeError, "Primary key value for key `:another_id` in Pow.Store.CredentialsCacheTest.CompositePrimaryFieldsUser can't be `nil`", fn ->
-      CredentialsCache.put(@config, @backend_config, "key_1", {%CompositePrimaryFieldsUser{}, a: 1})
+      CredentialsCache.put(@config, "key_1", {%CompositePrimaryFieldsUser{}, a: 1})
     end
 
     user = %CompositePrimaryFieldsUser{some_id: 1, another_id: 2}
 
-    CredentialsCache.put(@config, @backend_config, "key_1", {user, a: 1})
+    CredentialsCache.put(@config, "key_1", {user, a: 1})
 
-    assert CredentialsCache.users(@config, @backend_config, CompositePrimaryFieldsUser) == [user]
+    assert CredentialsCache.users(@config, CompositePrimaryFieldsUser) == [user]
   end
 
   defmodule NonEctoUser do
@@ -111,14 +111,14 @@ defmodule Pow.Store.CredentialsCacheTest do
 
   test "handles non-ecto user struct" do
     assert_raise RuntimeError, "Primary key value for key `:id` in Pow.Store.CredentialsCacheTest.NonEctoUser can't be `nil`", fn ->
-      CredentialsCache.put(@config, @backend_config, "key_1", {%NonEctoUser{}, a: 1})
+      CredentialsCache.put(@config, "key_1", {%NonEctoUser{}, a: 1})
     end
 
     user = %NonEctoUser{id: 1}
 
-    assert CredentialsCache.put(@config, @backend_config, "key_1", {user, a: 1})
+    assert CredentialsCache.put(@config, "key_1", {user, a: 1})
 
-    assert CredentialsCache.users(@config, @backend_config, NonEctoUser) == [user]
+    assert CredentialsCache.users(@config, NonEctoUser) == [user]
   end
 
   # TODO: Remove by 1.1.0
@@ -154,30 +154,29 @@ defmodule Pow.Store.CredentialsCacheTest do
     test "handles purged values" do
       user_1 = %User{id: 1}
       config = [backend: EtsCache]
-      backend_config = [namespace: "credentials_cache:test"]
 
-      CredentialsCache.put(config, backend_config ++ [ttl: 150], "key_1", {user_1, a: 1})
+      CredentialsCache.put(config ++ [ttl: 150], "key_1", {user_1, a: 1})
       :timer.sleep(50)
-      CredentialsCache.put(config, backend_config ++ [ttl: 200], "key_2", {user_1, a: 2})
+      CredentialsCache.put(config ++ [ttl: 200], "key_2", {user_1, a: 2})
       :timer.sleep(50)
 
-      assert CredentialsCache.get(config, backend_config, "key_1") == {user_1, a: 1}
-      assert CredentialsCache.get(config, backend_config, "key_2") == {user_1, a: 2}
-      assert CredentialsCache.sessions(config, backend_config, user_1) == ["key_1", "key_2"]
-
-      :timer.sleep(50)
-      assert CredentialsCache.get(config, backend_config, "key_1") == :not_found
-      assert CredentialsCache.get(config, backend_config, "key_2") == {user_1, a: 2}
-      assert CredentialsCache.sessions(config, backend_config, user_1) == ["key_2"]
-
-      CredentialsCache.put(config, backend_config ++ [ttl: 100], "key_2", {user_1, a: 3})
-      :timer.sleep(50)
-      assert CredentialsCache.sessions(config, backend_config, user_1) == ["key_2"]
+      assert CredentialsCache.get(config, "key_1") == {user_1, a: 1}
+      assert CredentialsCache.get(config, "key_2") == {user_1, a: 2}
+      assert CredentialsCache.sessions(config, user_1) == ["key_1", "key_2"]
 
       :timer.sleep(50)
-      assert CredentialsCache.get(config, backend_config, "key_1") == :not_found
-      assert CredentialsCache.get(config, backend_config, "key_2") == :not_found
-      assert CredentialsCache.sessions(config, backend_config, user_1) == []
+      assert CredentialsCache.get(config, "key_1") == :not_found
+      assert CredentialsCache.get(config, "key_2") == {user_1, a: 2}
+      assert CredentialsCache.sessions(config, user_1) == ["key_2"]
+
+      CredentialsCache.put(config ++ [ttl: 100], "key_2", {user_1, a: 3})
+      :timer.sleep(50)
+      assert CredentialsCache.sessions(config, user_1) == ["key_2"]
+
+      :timer.sleep(50)
+      assert CredentialsCache.get(config, "key_1") == :not_found
+      assert CredentialsCache.get(config, "key_2") == :not_found
+      assert CredentialsCache.sessions(config, user_1) == []
       assert EtsCache.get(config, "#{Macro.underscore(User)}_sessions_1") == :not_found
     end
   end

--- a/test/support/ets_cache_mock.ex
+++ b/test/support/ets_cache_mock.ex
@@ -2,7 +2,7 @@ defmodule Pow.Test.EtsCacheMock do
   @moduledoc false
   @tab __MODULE__
 
-  def init, do: :ets.new(@tab, [:set, :protected, :named_table])
+  def init, do: :ets.new(@tab, [:ordered_set, :protected, :named_table])
 
   def get(config, key) do
     ets_key = ets_key(config, key)
@@ -21,28 +21,25 @@ defmodule Pow.Test.EtsCacheMock do
     :ok
   end
 
-  def put(config, key, value) do
-    send(self(), {:ets, :put, key, value, config})
-    :ets.insert(@tab, {ets_key(config, key), value})
+  def put(config, record_or_records) do
+    records     = List.wrap(record_or_records)
+    ets_records = Enum.map(records, fn {key, value} ->
+      {ets_key(config, key), value}
+    end)
+
+    send(self(), {:ets, :put, records, config})
+    :ets.insert(@tab, ets_records)
   end
 
-  def keys(config) do
-    namespace = ets_key(config, "")
-    length    = String.length(namespace)
+  def all(config, match) do
+    ets_key_match = ets_key(config, match)
 
-    Stream.resource(
-      fn -> :ets.first(@tab) end,
-      fn :"$end_of_table" -> {:halt, nil}
-        previous_key -> {[previous_key], :ets.next(@tab, previous_key)} end,
-      fn _ -> :ok
-    end)
-    |> Enum.filter(&String.starts_with?(&1, namespace))
-    |> Enum.map(&String.slice(&1, length..-1))
+    @tab
+    |> :ets.select([{{ets_key_match, :_}, [], [:"$_"]}])
+    |> Enum.map(fn {[_namespace | keys], value} -> {keys, value} end)
   end
 
   defp ets_key(config, key) do
-    namespace = Pow.Config.get(config, :namespace, "cache")
-
-    "#{namespace}:#{key}"
+    [Keyword.get(config, :namespace, "cache")] ++ List.wrap(key)
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,5 +1,7 @@
 Logger.configure(level: :warn)
 
+:ok = Supervisor.terminate_child(Pow.Supervisor, Pow.Store.Backend.EtsCache)
+
 ExUnit.start()
 
 # Ensure that symlink to custom ecto priv directory exists


### PR DESCRIPTION
While working on #287 I came [to realize](https://github.com/danschultzer/pow/pull/287#issuecomment-539762999) that the credentials cache shouldn't override the user key with a list of sessions, but instead should add another key that can be looked up with the namespace. There is potential race condition issue when overriding the key, and it may only happen when updating the user cache key (since we never guarantee that the user is the most recent updated, but do have to guarantee that all sessions are listed).

This can still be done with a binary keys with namespace, but to improve efficiency I've moved over to Erlang terms for keys for namespace so [match spec](http://erlang.org/doc/apps/erts/match_spec.html) can be used. In Pow either a binary key or a list consisting of binary, integer or atom is used as key and will always in the cache backend be wrapped in a list with a prepending namespace.

`Pow.Store.CredentialsCache` now inserts three keys at once, which in ETS and Mnesia is guaranteed to be atomic:

```
{session_id, {[user_struct, :user, user_id], metadata}}
{[user_struct, :user, user_id}, user}
{{user_struct, :user, user_id, :session, session_id}, inserted_at}
```

Instead of the previous:

```
{session_id, {"USER_STUCT_sessions_USER_ID", metadata}}
{"USER_STUCT_sessions_USER_ID", %{user: user, session: [session_id, ...]}}
```

I've also refactored the code so the cache store and cache backend has separate behaviours.

The Redis guide has be updated, and I've added a bunch of backwards compatibility logic since there are many who uses Redis with binary key in production at the moment.

Any extra :eyes: or hands to test this out would be much appreciated!

Resolves #302 