### PR TITLE
dialyzer fix for guides/api::SessionController example

### DIFF
--- a/guides/api.md
+++ b/guides/api.md
@@ -213,6 +213,7 @@ defmodule MyAppWeb.API.V1.SessionController do
   use MyAppWeb, :controller
 
   alias MyAppWeb.APIAuthPlug
+  alias Plug.Conn
 
   @spec create(Conn.t(), map()) :: Conn.t()
   def create(conn, %{"user" => user_params}) do


### PR DESCRIPTION
For Dialyzer users

Before:
```
:0: Unknown type 'Elixir.Conn':t/0
done (warnings were emitted)
```

After:
```
done (passed successfully)
```