### PR TITLE
Fix confirmation email delivery issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
   * Deprecated `Pow.Store.CredentialsCache.user_session_keys/3`
   * Deprecated `Pow.Store.CredentialsCache.sessions/3`
   * `Pow.Store.CredentialsCache` now adds a session key rather than appending to a list for the user key to prevent race condition
+* Fixed bug where `PowEmailConfirmation.Phoenix.ControllerCallbacks` couldn't deliver email
 
 ## v1.0.13 (2019-08-25)
 

--- a/lib/extensions/email_confirmation/phoenix/controllers/controller_callbacks.ex
+++ b/lib/extensions/email_confirmation/phoenix/controllers/controller_callbacks.ex
@@ -61,12 +61,13 @@ defmodule PowEmailConfirmation.Phoenix.ControllerCallbacks do
     user        = Plug.current_user(conn)
     {:ok, conn} = Plug.clear_authenticated_user(conn)
     error       = extension_messages(conn).email_confirmation_required(conn)
-    conn        =
+
+    send_confirmation_email(user, conn)
+
+    conn =
       conn
       |> Phoenix.Controller.put_flash(:error, error)
       |> Phoenix.Controller.redirect(to: return_path)
-
-    send_confirmation_email(user, conn)
 
     {:halt, conn}
   end


### PR DESCRIPTION
Resolves #266

In some environments, email delivery gets interrupted if `Plug.Conn.send_resp/2` is called first.