### PR TITLE
Always success response only if registration disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@
 * `PowPersistentSession.Plug.Cookie.create/3` will use the value of `conn.private[:pow_session_metadata][:fingerprint]` if it exists as `:session_fingerprint` in the persistent session metadata
 * `PowPersistentSession.Plug.Cookie.authenticate/2` will assign `:fingerprint` to `conn.private[:pow_session_metadata]` if it exists in the persistent session metadata
 * `Pow.Store.CredentialsCache.put/3` will invalidate any other sessions with the same `:fingerprint` if any is set in session metadata
+* `PowResetPassword.Phoenix.ResetPasswordController.create/2` when a user doesn't exist will now only return success message if the registration routes has been disabled, otherwise the form with an error message will be returned
+* Added `PowResetPassword.Phoenix.Messages.user_not_found/1`
 
 ### Bug fixes
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -18,7 +18,7 @@ config :pow, Pow.Ecto.Schema.Password, iterations: 1
 
 config :phoenix, :json_library, Jason
 
-extension_test_modules = [PowEmailConfirmation, PowInvitation, PowEmailConfirmation.PowInvitation, PowPersistentSession, PowResetPassword]
+extension_test_modules = [PowEmailConfirmation, PowInvitation, PowEmailConfirmation.PowInvitation, PowPersistentSession, PowResetPassword, PowResetPassword.NoRegistration]
 
 for extension <- extension_test_modules do
   endpoint_module = Module.concat([extension, TestWeb.Phoenix.Endpoint])

--- a/lib/extensions/reset_password/README.md
+++ b/lib/extensions/reset_password/README.md
@@ -2,6 +2,8 @@
 
 This extension will allow users to reset the password by sending an e-mail with a reset password link. It requires that the user schema has an `:email` field.
 
+A success message will always be returned during reset request if registration routes has been disabled to prevent information leak.
+
 ## Installation
 
 Follow the instructions for extensions in [README.md](../../../README.md#add-extensions-support), and set `PowResetPassword` in the `:extensions` list.

--- a/lib/extensions/reset_password/phoenix/messages.ex
+++ b/lib/extensions/reset_password/phoenix/messages.ex
@@ -7,6 +7,11 @@ defmodule PowResetPassword.Phoenix.Messages do
   def email_has_been_sent(_conn), do: "An email with reset instructions has been sent to you. Please check your inbox."
 
   @doc """
+  Flash message to show when no user exists for the provided e-mail.
+  """
+  def user_not_found(_conn), do: "No account exists for the provided email. Please try again."
+
+  @doc """
   Flash message to show when a an invalid or expired reset password link is
   used.
   """

--- a/test/extensions/reset_password/phoenix/controllers/reset_password_controller_test.exs
+++ b/test/extensions/reset_password/phoenix/controllers/reset_password_controller_test.exs
@@ -55,6 +55,18 @@ defmodule PowResetPassword.Phoenix.ResetPasswordControllerTest do
 
     test "with invalid params", %{conn: conn} do
       conn = post conn, Routes.pow_reset_password_reset_password_path(conn, :create, @invalid_params)
+
+      assert html = html_response(conn, 200)
+      assert get_flash(conn, :error) == "No account exists for the provided email. Please try again."
+      assert html =~ "<input id=\"user_email\" name=\"user[email]\" type=\"text\" value=\"invalid@example.com\">"
+    end
+  end
+
+  alias PowResetPassword.NoRegistration.TestWeb.Phoenix.Endpoint, as: NoRegistrationEndpoint
+  describe "create/2 with no registration routes" do
+    test "with invalid params", %{conn: conn} do
+      conn = Phoenix.ConnTest.dispatch(conn, NoRegistrationEndpoint, :post, Routes.pow_reset_password_reset_password_path(conn, :create, @invalid_params))
+
       assert redirected_to(conn) == Routes.pow_session_path(conn, :new)
       assert get_flash(conn, :info) == "An email with reset instructions has been sent to you. Please check your inbox."
     end

--- a/test/support/extensions/reset_password/no_registration/endpoint.ex
+++ b/test/support/extensions/reset_password/no_registration/endpoint.ex
@@ -1,0 +1,24 @@
+defmodule PowResetPassword.NoRegistration.TestWeb.Phoenix.Endpoint do
+  @moduledoc false
+  use Phoenix.Endpoint, otp_app: :pow
+
+  plug Plug.RequestId
+  plug Plug.Logger
+
+  plug Plug.Parsers,
+    parsers: [:urlencoded, :multipart, :json],
+    pass: ["*/*"],
+    json_decoder: Phoenix.json_library()
+
+  plug Plug.MethodOverride
+  plug Plug.Head
+
+  plug Plug.Session,
+    store: :cookie,
+    key: "_binaryid_key",
+    signing_salt: "secret"
+
+  plug Pow.Plug.Session, PowResetPassword.Test.pow_config()
+
+  plug PowResetPassword.NoRegistration.TestWeb.Phoenix.Router
+end

--- a/test/support/extensions/reset_password/no_registration/router.ex
+++ b/test/support/extensions/reset_password/no_registration/router.ex
@@ -1,0 +1,22 @@
+defmodule PowResetPassword.NoRegistration.TestWeb.Phoenix.Router do
+  @moduledoc false
+  use Phoenix.Router
+  use Pow.Phoenix.Router
+  use Pow.Extension.Phoenix.Router,
+    extensions: [PowResetPassword]
+
+  pipeline :browser do
+    plug :accepts, ["html"]
+    plug :fetch_session
+    plug :fetch_flash
+    plug :protect_from_forgery
+    plug :put_secure_browser_headers
+  end
+
+  scope "/" do
+    pipe_through :browser
+
+    pow_session_routes()
+    pow_extension_routes()
+  end
+end


### PR DESCRIPTION
Resolves #313 

There is no point in always returning success response if registration also is permitted since info leakage can happen on registration page.