### PR TITLE
Adds test module to user role guide - #230

### DIFF
--- a/guides/user_roles.md
+++ b/guides/user_roles.md
@@ -130,44 +130,58 @@ defmodule MyAppWeb.EnsureRolePlugTest do
 
   alias MyAppWeb.EnsureRolePlug
 
-  @user %{id: 1, role: "admin"}
+  @opts ~w(admin)a
+  @user %{id: 1, role: "user"}
+  @admin %{id: 2, role: "admin"}
 
   setup do
     conn =
       build_conn()
+      |> Plug.Conn.put_private(:plug_session, %{})
+      |> Plug.Conn.put_private(:plug_session_fetch, :done)
       |> Pow.Plug.put_config(otp_app: :my_app)
-      |> Pow.Plug.assign_current_user(@user, otp_app: :my_app)
+      |> fetch_flash()
 
     {:ok, conn: conn}
   end
 
-  test "does not halt and redirect when the user roles match as an atom", %{conn: conn} do
-    opts = EnsureRolePlug.init(:admin)
-    conn = EnsureRolePlug.call(conn, opts)
-
-    refute conn.halted
-  end
-
-  test "does not halt and redirect when the user roles match as a string", %{conn: conn} do
-    opts = EnsureRolePlug.init("admin")
-    conn = EnsureRolePlug.call(conn, opts)
-
-    refute conn.halted
-  end
-
-  test "does not halt and redirect when the user role is included in a list of roles", %{conn: conn} do
-    opts = EnsureRolePlug.init([:admin])
-    conn = EnsureRolePlug.call(conn, opts)
-
-    refute conn.halted
-  end
-
-  test "halts and redirects when the user role is not among the listed", %{conn: conn} do
-    opts = EnsureRolePlug.init(:user)
+  test "call/2 with no user", %{conn: conn} do
+    opts = EnsureRolePlug.init(@opts)
     conn = EnsureRolePlug.call(conn, opts)
 
     assert conn.halted
     assert Phoenix.ConnTest.redirected_to(conn) == Routes.page_path(conn, :index)
+  end
+
+  test "call/2 with non-admin user", %{conn: conn} do
+    opts = EnsureRolePlug.init(@opts)
+    conn =
+      conn
+      |> Pow.Plug.assign_current_user(@user, otp_app: :my_app)
+      |> EnsureRolePlug.call(opts)
+
+    assert conn.halted
+    assert Phoenix.ConnTest.redirected_to(conn) == Routes.page_path(conn, :index)
+  end
+
+  test "call/2 with non-admin user and multiple roles", %{conn: conn} do
+    opts = EnsureRolePlug.init(~w(user admin)a)
+    conn =
+      conn
+      |> Pow.Plug.assign_current_user(@user, otp_app: :my_app)
+      |> EnsureRolePlug.call(opts)
+
+    refute conn.halted
+  end
+
+  test "call/2 with admin user", %{conn: conn} do
+    opts = EnsureRolePlug.init(@opts)
+    conn =
+      conn
+      |> Pow.Plug.assign_current_user(@admin, otp_app: :my_app)
+      |> EnsureRolePlug.call(opts)
+
+    refute conn.halted
   end
 end
 ```

--- a/guides/user_roles.md
+++ b/guides/user_roles.md
@@ -42,13 +42,17 @@ This is all the work you'll need to control access:
 defmodule MyAppWeb.EnsureRolePlug do
   @moduledoc """
   This plug ensures that a user has a particular role.
+
   ## Example
+
       plug MyAppWeb.EnsureRolePlug, [:user, :admin]
+
       plug MyAppWeb.EnsureRolePlug, :admin
+
       plug MyAppWeb.EnsureRolePlug, ~w(user admin)a
   """
-
   import Plug.Conn, only: [halt: 1]
+
   alias MyAppWeb.Router.Helpers, as: Routes
   alias Phoenix.Controller
   alias Plug.Conn
@@ -59,7 +63,7 @@ defmodule MyAppWeb.EnsureRolePlug do
   def init(config), do: config
 
   @doc false
-  @spec call(Conn.t(), atom() | list(atom() | String.t())) :: Conn.t()
+  @spec call(Conn.t(), atom() | binary() | [atom()] | [binary()]) :: Conn.t()
   def call(conn, roles) do
     conn
     |> Plug.current_user()
@@ -72,8 +76,8 @@ defmodule MyAppWeb.EnsureRolePlug do
   defp has_role?(user, role) when is_atom(role), do: has_role?(user, Atom.to_string(role))
   defp has_role?(%{role: role}, role), do: true
   defp has_role?(_user, _role), do: false
-  defp maybe_halt(true, conn), do: conn
 
+  defp maybe_halt(true, conn), do: conn
   defp maybe_halt(_any, conn) do
     conn
     |> Controller.put_flash(:error, "Unauthorized access")
@@ -124,37 +128,44 @@ end
 defmodule MyAppWeb.EnsureRolePlugTest do
   use MyAppWeb.ConnCase
 
-  @user %MyApp.User{id: 1, email: "test@example.com", role: "admin"}
+  alias MyAppWeb.EnsureRolePlug
+
+  @user %{id: 1, role: "admin"}
 
   setup do
     conn =
       build_conn()
-      |> bypass_through(MyAppWeb.Router, [:browser])
-      |> Pow.Plug.assign_current_user(@user, [])
-      |> get("/")
+      |> Pow.Plug.put_config(otp_app: :my_app)
+      |> Pow.Plug.assign_current_user(@user, otp_app: :my_app)
 
     {:ok, conn: conn}
   end
 
   test "does not halt and redirect when the user roles match as an atom", %{conn: conn} do
-    conn = MyAppWeb.EnsureRolePlug.call(conn, :admin)
+    opts = EnsureRolePlug.init(:admin)
+    conn = EnsureRolePlug.call(conn, opts)
+
     refute conn.halted
   end
 
   test "does not halt and redirect when the user roles match as a string", %{conn: conn} do
-    conn = MyAppWeb.EnsureRolePlug.call(conn, "admin")
+    opts = EnsureRolePlug.init("admin")
+    conn = EnsureRolePlug.call(conn, opts)
+
     refute conn.halted
   end
 
-  test "does not halt and redirect when the user role is included in a list of roles", %{
-    conn: conn
-  } do
-    conn = MyAppWeb.EnsureRolePlug.call(conn, [:admin])
+  test "does not halt and redirect when the user role is included in a list of roles", %{conn: conn} do
+    opts = EnsureRolePlug.init([:admin])
+    conn = EnsureRolePlug.call(conn, opts)
+
     refute conn.halted
   end
 
   test "halts and redirects when the user role is not among the listed", %{conn: conn} do
-    conn = MyAppWeb.EnsureRolePlug.call(conn, :user)
+    opts = EnsureRolePlug.init(:user)
+    conn = EnsureRolePlug.call(conn, opts)
+
     assert conn.halted
     assert Phoenix.ConnTest.redirected_to(conn) == Routes.page_path(conn, :index)
   end


### PR DESCRIPTION
Adds a test module to the guide for user role plug per #230 that can be used as a base for users working to understand one way to implement roles in Pow.

It may also be worth mentioning other authorization libraries or strategies, such as [bodyguard](https://github.com/schrockwell/bodyguard).