### PR TITLE
Fix issue with resource routes filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.0.15 (TBA)
+
+* Fixed bug in `Router.Phoenix.Router` where resource routes were not filtered correctly according to the path bindings
+
 ## v1.0.14 (2019-10-29)
 
 ### Changes

--- a/test/pow/extension/phoenix/router_test.exs
+++ b/test/pow/extension/phoenix/router_test.exs
@@ -5,7 +5,7 @@ defmodule Pow.Test.Extension.Phoenix.Router.Phoenix.Router do
 
   defmacro routes(_config) do
     quote location: :keep do
-      Router.pow_resources "/test", TestController, only: [:new, :create, :edit, :update]
+      Router.pow_resources "/test", TestController, only: [:new, :create, :edit, :update, :delete]
     end
   end
 end
@@ -17,7 +17,8 @@ defmodule Pow.Test.Extension.Phoenix.Router do
     extensions: [Pow.Test.Extension.Phoenix.Router]
 
   scope "/", as: "pow_test_extension_phoenix_router" do
-    get "/test/:id/overidden", TestController, :edit
+    get "/test/:id/overridden", TestController, :edit
+    resources "/overridden/test", TestController, only: [:delete]
   end
 
   scope "/" do
@@ -67,7 +68,10 @@ defmodule Pow.Extension.Phoenix.RouterTest do
   end
 
   test "can override routes" do
-    assert unquote(Routes.pow_test_extension_phoenix_router_test_path(@conn, :edit, 1)) == "/test/1/overidden"
+    assert unquote(Routes.pow_test_extension_phoenix_router_test_path(@conn, :edit, 1)) == "/test/1/overridden"
     assert Enum.count(Pow.Test.Extension.Phoenix.Router.phoenix_routes(), &(&1.plug == TestController && &1.plug_opts == :edit)) == 1
+
+    assert unquote(Routes.pow_test_extension_phoenix_router_test_path(@conn, :delete, 1)) == "/overridden/test/1"
+    assert Enum.count(Pow.Test.Extension.Phoenix.Router.phoenix_routes(), &(&1.plug == TestController && &1.plug_opts == :delete)) == 1
   end
 end

--- a/test/pow/phoenix/router_test.exs
+++ b/test/pow/phoenix/router_test.exs
@@ -22,7 +22,8 @@ defmodule Pow.Test.Phoenix.OverriddenRouteRouter do
   use Pow.Phoenix.Router
 
   scope "/", Pow.Phoenix, as: "pow" do
-    get "/registration/overidden", RegistrationController, :new
+    get "/registration/overridden", RegistrationController, :new
+    resources "/registration/overridden", RegistrationController, only: [:edit], singleton: true
   end
 
   scope "/:extra" do
@@ -51,8 +52,12 @@ defmodule Pow.Phoenix.RouterTest do
   end
 
   test "can override routes" do
-    assert unquote(OverriddenRoutes.pow_registration_path(@conn, :new)) == "/registration/overidden"
+    assert unquote(OverriddenRoutes.pow_registration_path(@conn, :new)) == "/registration/overridden"
     assert unquote(OverriddenRoutes.pow_registration_path(@conn, :new, "test")) == "/test/registration/new"
     assert Enum.count(Pow.Test.Phoenix.OverriddenRouteRouter.phoenix_routes(), &(&1.plug == Pow.Phoenix.RegistrationController && &1.plug_opts == :new)) == 2
+
+    assert unquote(OverriddenRoutes.pow_registration_path(@conn, :edit)) == "/registration/overridden/edit"
+    assert unquote(OverriddenRoutes.pow_registration_path(@conn, :edit, "test")) == "/test/registration/edit"
+    assert Enum.count(Pow.Test.Phoenix.OverriddenRouteRouter.phoenix_routes(), &(&1.plug == Pow.Phoenix.RegistrationController && &1.plug_opts == :edit)) == 2
   end
 end


### PR DESCRIPTION
Resolves #326 

#292 didn't account for `singleton: false` handling of resource routes, and thus didn't filter resource routes because the number of bindings would not be equal.