### PR TITLE
Refactor extension module discovery

### DIFF
--- a/lib/extensions/reset_password/ecto/schema.ex
+++ b/lib/extensions/reset_password/ecto/schema.ex
@@ -7,7 +7,7 @@ defmodule PowResetPassword.Ecto.Schema do
 
   @impl true
   def validate!(_config, module) do
-    Schema.require_schema_field!(module, :email, PowEmailConfirmation)
+    Schema.require_schema_field!(module, :email, PowResetPassword)
   end
 
   @spec reset_password_changeset(map(), map()) :: Changeset.t()

--- a/lib/pow/extension/config.ex
+++ b/lib/pow/extension/config.ex
@@ -12,6 +12,21 @@ defmodule Pow.Extension.Config do
     Config.get(config, :extensions, [])
   end
 
+  # This speeds up compile since we won't depend on `Code.ensure_compiled?/1`
+  @compiled_modules [
+    PowEmailConfirmation.Ecto.Schema,
+    PowEmailConfirmation.Phoenix.ControllerCallbacks,
+    PowEmailConfirmation.Phoenix.Messages,
+    PowEmailConfirmation.Phoenix.Router,
+    PowInvitation.Ecto.Schema,
+    PowInvitation.Phoenix.Messages,
+    PowInvitation.Phoenix.Router,
+    PowPersistentSession.Phoenix.ControllerCallbacks,
+    PowResetPassword.Ecto.Schema,
+    PowResetPassword.Phoenix.Messages,
+    PowResetPassword.Phoenix.Router,
+  ]
+
   @doc """
   Finds all existing extension modules that matches the extensions and module
   list.
@@ -23,7 +38,10 @@ defmodule Pow.Extension.Config do
   def extension_modules(extensions, module_list) do
     extensions
     |> Enum.map(&Module.concat([&1] ++ module_list))
-    |> Enum.filter(&Code.ensure_compiled?/1)
+    |> Enum.filter(fn
+      module when module in @compiled_modules -> true
+      module -> Code.ensure_compiled?(module)
+    end)
   end
 
   # TODO: Remove by 1.1.0

--- a/lib/pow/extension/ecto/schema.ex
+++ b/lib/pow/extension/ecto/schema.ex
@@ -57,6 +57,7 @@ defmodule Pow.Extension.Ecto.Schema do
   def __use_extensions__(config) do
     config
     |> schema_modules()
+    |> Enum.filter(&Code.ensure_compiled?/1)
     |> Enum.filter(&Kernel.macro_exported?(&1, :__using__, 1))
     |> Enum.map(fn module ->
       quote do


### PR DESCRIPTION
While this is not a complete solution to #329, it will reduce `Code.ensure_compiled?/1` calls significantly since most devs are only using the built-in extensions.

In short I just provide a list of modules that are expected to exist, so we won't call `Code.ensure_compiled?/1` unnecessarily. The issues:

- For any third-party extensions, `Code.ensure_compiled?/1` will still be used.
- Any changes to this library may not account for updating `@compiled_modules`. This could maybe be solved by maybe adding some step to the test that checks this, not sure though.
- `Pow.Extension.Ecto.Schema` still has a `Code.ensure_compiled?/1` call since I need to know if a macro method exists. I would like to see if this can be removed.

I'll be working on a more complete fix, but if it doesn't work out, or takes too long, I'll go with this one.