### PR TITLE
Refactor extension discovery and add base module for all extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
   * `PowPersistentSession.Plug.Cookie.create/3` will now, instead of adding `:session_fingerprint` to the metadata, populate the `:session_metadata` keyword list with `:fingerprint`
   * `PowPersistentSession.Plug.Cookie.authenticate/2` will now populate session metadata with what exists in `:session_metadata` key for the persistent session metadata
 * `PowPersistentSession.Plug.Cookie.create/3` now ensures to delete the previous persistent session first, if one is found in cookies
+* Extensions are now expected to have a base module with compile-time information whether certain modules are available to prevent unnecessary `Code.ensure_compiled?/1` calls:
+  * Added `Pow.Extension.Base` module
+  * Added `PowEmailConfirmation` module
+  * Added `PowInvitation` module
+  * Added `PowPersistentSession` module
+  * Added `PowResetPassword` module
 
 ## v1.0.14 (2019-10-29)
 

--- a/README.md
+++ b/README.md
@@ -180,13 +180,14 @@ defmodule MyApp.Users.User do
 end
 ```
 
-Add Pow extension routes to `WEB_PATH/router.ex` (note the `:otp_app` configuration that will pull the extensions defined in the app environment):
+Add Pow extension routes to `WEB_PATH/router.ex`:
 
 ```elixir
 defmodule MyAppWeb.Router do
   use MyAppWeb, :router
   use Pow.Phoenix.Router
-  use Pow.Extension.Phoenix.Router, otp_app: :my_app
+  use Pow.Extension.Phoenix.Router,
+    extensions: [PowResetPassword, PowEmailConfirmation]
 
   # ...
 

--- a/lib/extensions/email_confirmation/email_confirmation.ex
+++ b/lib/extensions/email_confirmation/email_confirmation.ex
@@ -1,0 +1,16 @@
+defmodule PowEmailConfirmation do
+  @moduledoc false
+  use Pow.Extension.Base
+
+  @impl true
+  def ecto_schema?(), do: true
+
+  @impl true
+  def phoenix_controller_callbacks?(), do: true
+
+  @impl true
+  def phoenix_router?(), do: true
+
+  @impl true
+  def phoenix_messages?(), do: true
+end

--- a/lib/extensions/invitation/ecto/schema.ex
+++ b/lib/extensions/invitation/ecto/schema.ex
@@ -57,6 +57,7 @@ defmodule PowInvitation.Ecto.Schema do
   end
 
   @doc false
+  @impl true
   defmacro __using__(_config) do
     quote do
       def invite_changeset(changeset, invited_by, attrs), do: pow_invite_changeset(changeset, invited_by, attrs)

--- a/lib/extensions/invitation/invitation.ex
+++ b/lib/extensions/invitation/invitation.ex
@@ -1,0 +1,16 @@
+defmodule PowInvitation do
+  @moduledoc false
+  use Pow.Extension.Base
+
+  @impl true
+  def ecto_schema?(), do: true
+
+  @impl true
+  def use_ecto_schema?(), do: true
+
+  @impl true
+  def phoenix_router?(), do: true
+
+  @impl true
+  def phoenix_messages?(), do: true
+end

--- a/lib/extensions/persistent_session/pow_persistent_session.ex
+++ b/lib/extensions/persistent_session/pow_persistent_session.ex
@@ -1,0 +1,7 @@
+defmodule PowPersistentSession do
+  @moduledoc false
+  use Pow.Extension.Base
+
+  @impl true
+  def phoenix_controller_callbacks?(), do: true
+end

--- a/lib/extensions/reset_password/ecto/schema.ex
+++ b/lib/extensions/reset_password/ecto/schema.ex
@@ -7,7 +7,7 @@ defmodule PowResetPassword.Ecto.Schema do
 
   @impl true
   def validate!(_config, module) do
-    Schema.require_schema_field!(module, :email, PowEmailConfirmation)
+    Schema.require_schema_field!(module, :email, PowResetPassword)
   end
 
   @spec reset_password_changeset(map(), map()) :: Changeset.t()

--- a/lib/extensions/reset_password/reset_password.ex
+++ b/lib/extensions/reset_password/reset_password.ex
@@ -1,0 +1,13 @@
+defmodule PowResetPassword do
+  @moduledoc false
+  use Pow.Extension.Base
+
+  @impl true
+  def ecto_schema?(), do: true
+
+  @impl true
+  def phoenix_messages?(), do: true
+
+  @impl true
+  def phoenix_router?(), do: true
+end

--- a/lib/pow/extension/base.ex
+++ b/lib/pow/extension/base.ex
@@ -1,0 +1,111 @@
+defmodule Pow.Extension.Base do
+  @moduledoc """
+  Used to set up extensions to enable parts of extension for auto-discovery.
+
+  This exists to prevent unnecessary `Code.ensure_compiled?/1` calls, and will
+  let the extension define what modules it has.
+
+  ## Usage
+
+      defmodule MyCustomExtension do
+        use Pow.Extension.Base
+
+        @impl true
+        def ecto_schema?(), do: true
+      end
+  """
+  @callback ecto_schema?() :: boolean()
+  @callback use_ecto_schema?() :: boolean()
+  @callback phoenix_controller_callbacks?() :: boolean()
+  @callback phoenix_messages?() :: boolean()
+  @callback phoenix_router?() :: boolean()
+
+  @doc false
+  defmacro __using__(_opts) do
+    quote do
+      @behaviour unquote(__MODULE__)
+
+      @doc false
+      @impl true
+      def ecto_schema?(), do: false
+
+      @doc false
+      @impl true
+      def use_ecto_schema?(), do: false
+
+      @doc false
+      @impl true
+      def phoenix_controller_callbacks?(), do: false
+
+      @doc false
+      @impl true
+      def phoenix_messages?(), do: false
+
+      @doc false
+      @impl true
+      def phoenix_router?(), do: false
+
+      defoverridable unquote(__MODULE__)
+    end
+  end
+
+  @doc """
+  Checks whether an extension has a certain module.
+
+  If a base extension module doesn't exist, or is configured improperly,
+  `Code.ensure_compiled?/1` will be used instead to see whether the module
+  exists for the extension.
+  """
+  @spec has?(atom(), [any()]) :: boolean()
+  def has?(extension, module_list) do
+    try do
+      has_extension_module?(extension, module_list)
+    rescue
+      # TODO: Remove or refactor by 1.1.0
+      _e in UndefinedFunctionError ->
+        IO.warn("no #{inspect extension} base module to check for #{inspect module_list} support found, please use #{inspect __MODULE__} to implement it")
+
+        [extension]
+        |> Kernel.++(module_list)
+        |> Module.concat()
+        |> Code.ensure_compiled?()
+    end
+  end
+
+  defp has_extension_module?(extension, ["Ecto", "Schema"]), do: extension.ecto_schema?()
+  defp has_extension_module?(extension, ["Phoenix", "ControllerCallbacks"]), do: extension.phoenix_controller_callbacks?()
+  defp has_extension_module?(extension, ["Phoenix", "Messages"]), do: extension.phoenix_messages?()
+  defp has_extension_module?(extension, ["Phoenix", "Router"]), do: extension.phoenix_router?()
+
+  @doc """
+  Checks whether an extension has a certain module that has a `__using__/1`
+  macro.
+
+  This calls `has?/2` first, If a base extension module doesn't exist, or is
+  configured improperly, `Kernel.macro_exported?/3` will be used instead to
+  check if the module has a `__using__/1` macro.
+  """
+  @spec use?(atom(), [any()]) :: boolean()
+  def use?(extension, module_list) do
+    case has?(extension, module_list) do
+      true  ->
+        try do
+          use_extension_module?(extension, module_list)
+        rescue
+          # TODO: Remove or refactor by 1.1.0
+          _e in UndefinedFunctionError ->
+            IO.warn("#{inspect extension} has been configured improperly")
+
+            [extension]
+            |> Kernel.++(module_list)
+            |> Module.concat()
+            |> Kernel.macro_exported?(:__using__, 1)
+        end
+
+      false ->
+        false
+    end
+  end
+
+  defp use_extension_module?(extension, ["Ecto", "Schema"]), do: extension.use_ecto_schema?()
+end

--- a/lib/pow/extension/config.ex
+++ b/lib/pow/extension/config.ex
@@ -2,7 +2,7 @@ defmodule Pow.Extension.Config do
   @moduledoc """
   Configuration helpers for extensions.
   """
-  alias Pow.Config
+  alias Pow.{Config, Extension.Base}
 
   @doc """
   Fetches the `:extensions` key from the configuration.
@@ -22,8 +22,8 @@ defmodule Pow.Extension.Config do
   @spec extension_modules([atom()], [any()]) :: [atom()]
   def extension_modules(extensions, module_list) do
     extensions
+    |> Enum.filter(&Base.has?(&1, module_list))
     |> Enum.map(&Module.concat([&1] ++ module_list))
-    |> Enum.filter(&Code.ensure_compiled?/1)
   end
 
   # TODO: Remove by 1.1.0

--- a/lib/pow/extension/ecto/schema.ex
+++ b/lib/pow/extension/ecto/schema.ex
@@ -32,7 +32,7 @@ defmodule Pow.Extension.Ecto.Schema do
       end
   """
   alias Ecto.Changeset
-  alias Pow.{Config, Extension}
+  alias Pow.{Config, Extension, Extension.Base}
 
   defmodule SchemaError do
     @moduledoc false
@@ -56,8 +56,7 @@ defmodule Pow.Extension.Ecto.Schema do
   @doc false
   def __use_extensions__(config) do
     config
-    |> schema_modules()
-    |> Enum.filter(&Kernel.macro_exported?(&1, :__using__, 1))
+    |> schema_modules_with_use()
     |> Enum.map(fn module ->
       quote do
         use unquote(module), unquote(config)
@@ -198,6 +197,13 @@ defmodule Pow.Extension.Ecto.Schema do
     config
     |> Extension.Config.extensions()
     |> Extension.Config.extension_modules(["Ecto", "Schema"])
+  end
+
+  defp schema_modules_with_use(config) do
+    config
+    |> Extension.Config.extensions()
+    |> Enum.filter(&Base.use?(&1, ["Ecto", "Schema"]))
+    |> Enum.map(&Module.concat([&1] ++ ["Ecto", "Schema"]))
   end
 
   @doc """

--- a/lib/pow/extension/ecto/schema/base.ex
+++ b/lib/pow/extension/ecto/schema/base.ex
@@ -28,6 +28,8 @@ defmodule Pow.Extension.Ecto.Schema.Base do
   @callback assocs(Config.t()) :: [tuple()]
   @callback indexes(Config.t()) :: [tuple()]
   @callback changeset(Changeset.t(), map(), Config.t()) :: Changeset.t()
+  @macrocallback __using__(Config.t()) :: Macro.t()
+  @optional_callbacks __using__: 1
 
   @doc false
   defmacro __using__(_opts) do

--- a/test/mix/tasks/extension/ecto/pow.extension.ecto.gen.migrations_test.exs
+++ b/test/mix/tasks/extension/ecto/pow.extension.ecto.gen.migrations_test.exs
@@ -1,4 +1,12 @@
 defmodule Mix.Tasks.Pow.Extension.Ecto.Gen.MigrationsTest do
+  # Implementation needed for `Pow.Extension.Base.has?/2` check
+  defmodule ExtensionMock do
+    use Pow.Extension.Base
+
+    @impl true
+    def ecto_schema?(), do: true
+  end
+
   defmodule ExtensionMock.Ecto.Schema do
     use Pow.Extension.Ecto.Schema.Base
 

--- a/test/pow/extension/ecto/schema/migration_test.exs
+++ b/test/pow/extension/ecto/schema/migration_test.exs
@@ -1,4 +1,12 @@
 defmodule Pow.Extension.Ecto.Schema.MigrationTest do
+  # Implementation needed for `Pow.Extension.Base.has?/2` check
+  defmodule ExtensionMock do
+    use Pow.Extension.Base
+
+    @impl true
+    def ecto_schema?(), do: true
+  end
+
   defmodule ExtensionMock.Ecto.Schema do
     use Pow.Extension.Ecto.Schema.Base
 

--- a/test/pow/extension/ecto/schema_test.exs
+++ b/test/pow/extension/ecto/schema_test.exs
@@ -1,4 +1,15 @@
 defmodule Pow.Extension.Ecto.SchemaTest do
+  # Implementation needed for `Pow.Extension.Base.has?/2` check
+  defmodule ExtensionMock do
+    use Pow.Extension.Base
+
+    @impl true
+    def ecto_schema?(), do: true
+
+    @impl true
+    def use_ecto_schema?(), do: true
+  end
+
   defmodule ExtensionMock.Ecto.Schema do
     use Pow.Extension.Ecto.Schema.Base
     alias Ecto.Changeset
@@ -34,6 +45,7 @@ defmodule Pow.Extension.Ecto.SchemaTest do
       end
     end
 
+    @impl true
     defmacro __using__(_config) do
       quote do
         def custom_method, do: true

--- a/test/pow/extension/phoenix/messages_test.exs
+++ b/test/pow/extension/phoenix/messages_test.exs
@@ -1,4 +1,12 @@
 defmodule Pow.Extension.Phoenix.MessagesTest do
+  # Implementation needed for `Pow.Extension.Base.has?/2` check
+  defmodule ExtensionMock do
+    use Pow.Extension.Base
+
+    @impl true
+    def phoenix_messages?(), do: true
+  end
+
   defmodule ExtensionMock.Phoenix.Messages do
     def a(_conn), do: "First"
     def b(_conn), do: "Second"

--- a/test/pow/extension/phoenix/router_test.exs
+++ b/test/pow/extension/phoenix/router_test.exs
@@ -1,4 +1,12 @@
 defmodule Pow.Extension.Phoenix.RouterTest do
+  # Implementation needed for `Pow.Extension.Base.has?/2` check
+  defmodule ExtensionMock do
+    use Pow.Extension.Base
+
+    @impl true
+    def phoenix_router?(), do: true
+  end
+
   defmodule ExtensionMock.Phoenix.Router do
     use Pow.Extension.Phoenix.Router.Base
 


### PR DESCRIPTION
Resolves #329

This may supersede #333

With this PR a base module is now expected in an extension that will clearly describe what the extension supports. This should prevent pretty much all `Code.ensure_compiled?/1` calls, but is still backwards compatible.

For extensions missing the base module a warning will be printed with `no MyCustomModule base module to check for ["Ecto", "Schema"] support found, please use Pow.Extension.Base to implement it`).

A base module would look like this:

```elixir
defmodule PowEmailConfirmation do
  @moduledoc false
  use Pow.Extension.Base

  @impl true
  def ecto_schema?(), do: true

  @impl true
  def phoenix_controller_callbacks?(), do: true

  @impl true
  def phoenix_router?(), do: true

  @impl true
  def phoenix_messages?(), do: true
end
```