### PR TITLE
Call custom `get_by/2` context method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v1.0.17 (TBA)
+
+### Enhancements
+
+* [`Pow.Ecto.Context`] Calls to `Pow.Ecto.Context.get_by/2` replaced with `Pow.Operations.get_by/2` so custom users context module can be used. The following methods has been updated
+  * `Pow.Ecto.Context.authenticate/2`
+  * `PowEmailConfirmation.Ecto.Context.get_by_confirmation_token/2`
+  * `PowInvitation.Ecto.Context.get_by_invitation_token/2`
+  * `PowResetPassword.Ecto.Context.get_by_email/2`
+
 ## v1.0.16 (2020-01-07)
 
 **Note:** This release contains an important security fix.

--- a/guides/lock_users.md
+++ b/guides/lock_users.md
@@ -70,7 +70,7 @@ defmodule MyAppWeb.Admin.UserController do
   defp load_user(%{params: %{"id" => user_id}} = conn, _opts) do
     config = Pow.Plug.fetch_config(conn)
 
-    case Pow.Ecto.Context.get_by([id: user_id], config) do
+    case Pow.Operations.get_by([id: user_id], config) do
       nil -> # Invalid user id
       user -> Plug.Conn.assign(conn, :user, user)
     end

--- a/lib/extensions/email_confirmation/ecto/context.ex
+++ b/lib/extensions/email_confirmation/ecto/context.ex
@@ -2,7 +2,7 @@ defmodule PowEmailConfirmation.Ecto.Context do
   @moduledoc """
   Handles e-mail confirmation context for user.
   """
-  alias Pow.{Config, Ecto.Context}
+  alias Pow.{Config, Ecto.Context, Operations}
   alias PowEmailConfirmation.Ecto.Schema
 
   @doc """
@@ -10,7 +10,7 @@ defmodule PowEmailConfirmation.Ecto.Context do
   """
   @spec get_by_confirmation_token(binary(), Config.t()) :: Context.user() | nil
   def get_by_confirmation_token(token, config),
-    do: Context.get_by([email_confirmation_token: token], config)
+    do: Operations.get_by([email_confirmation_token: token], config)
 
   @doc """
   Checks if the users current e-mail is unconfirmed.

--- a/lib/extensions/invitation/ecto/context.ex
+++ b/lib/extensions/invitation/ecto/context.ex
@@ -2,7 +2,7 @@ defmodule PowInvitation.Ecto.Context do
   @moduledoc """
   Handles invitation context for user.
   """
-  alias Pow.{Config, Ecto.Context}
+  alias Pow.{Config, Ecto.Context, Operations}
   alias PowInvitation.Ecto.Schema
 
   @doc """
@@ -40,7 +40,7 @@ defmodule PowInvitation.Ecto.Context do
   @spec get_by_invitation_token(binary(), Config.t()) :: Context.user() | nil
   def get_by_invitation_token(token, config) do
     [invitation_token: token]
-    |> Context.get_by(config)
+    |> Operations.get_by(config)
     |> case do
       %{invitation_accepted_at: nil} = user -> user
       _ -> nil

--- a/lib/extensions/persistent_session/plug/cookie.ex
+++ b/lib/extensions/persistent_session/plug/cookie.ex
@@ -72,7 +72,7 @@ defmodule PowPersistentSession.Plug.Cookie do
   use PowPersistentSession.Plug.Base
 
   alias Plug.Conn
-  alias Pow.{Config, Plug, UUID}
+  alias Pow.{Config, Operations, Plug, UUID}
 
   @cookie_key "persistent_session_cookie"
   @cookie_expiration_timeout 10
@@ -247,7 +247,7 @@ defmodule PowPersistentSession.Plug.Cookie do
   defp fetch_and_auth_user(conn, {clauses, metadata}, plug, config) do
     clauses
     |> filter_invalid!()
-    |> Pow.Operations.get_by(config)
+    |> Operations.get_by(config)
     |> case do
       nil ->
         conn

--- a/lib/extensions/reset_password/ecto/context.ex
+++ b/lib/extensions/reset_password/ecto/context.ex
@@ -1,10 +1,10 @@
 defmodule PowResetPassword.Ecto.Context do
   @moduledoc false
-  alias Pow.{Config, Ecto.Context}
+  alias Pow.{Config, Ecto.Context, Operations}
   alias PowResetPassword.Ecto.Schema
 
   @spec get_by_email(binary(), Config.t()) :: Context.user() | nil
-  def get_by_email(email, config), do: Context.get_by([email: email], config)
+  def get_by_email(email, config), do: Operations.get_by([email: email], config)
 
   @spec update_password(Context.user(), map(), Config.t()) :: {:ok, Context.user()} | {:error, Context.changeset()}
   def update_password(user, params, config) do

--- a/lib/pow/ecto/context.ex
+++ b/lib/pow/ecto/context.ex
@@ -35,8 +35,7 @@ defmodule Pow.Ecto.Context do
     * `:user` - the user schema module (required)
     * `:repo_opts` - keyword list options for the repo, `:prefix` can be set here
   """
-  alias Pow.Config
-  alias Pow.Ecto.Schema
+  alias Pow.{Config, Ecto.Schema, Operations}
 
   @type user :: map()
   @type changeset :: map()
@@ -109,7 +108,7 @@ defmodule Pow.Ecto.Context do
   defp do_authenticate(_user_id_field, nil, _password, _config), do: nil
   defp do_authenticate(user_id_field, user_id_value, password, config) do
     [{user_id_field, user_id_value}]
-    |> get_by(config)
+    |> Operations.get_by(config)
     |> verify_password(password, config)
   end
 

--- a/test/extensions/email_confirmation/ecto/context_test.exs
+++ b/test/extensions/email_confirmation/ecto/context_test.exs
@@ -9,6 +9,16 @@ defmodule PowEmailConfirmation.Ecto.ContextTest do
   @config [repo: RepoMock, user: User]
   @user   %User{id: 1, email: "test@example.com"}
 
+  defmodule CustomUsers do
+    def get_by([email_confirmation_token: :test]), do: %User{email: :ok}
+  end
+
+  describe "get_by_confirmation_token/2" do
+    test "with `:users_context`" do
+      assert %User{email: :ok} = Context.get_by_confirmation_token(:test, @config ++ [users_context: CustomUsers])
+    end
+  end
+
   describe "confirm_email/2" do
     test "confirms with no :unconfirmed_email" do
       assert {:ok, user} = Context.confirm_email(@user, @config)

--- a/test/extensions/invitation/ecto/context_test.exs
+++ b/test/extensions/invitation/ecto/context_test.exs
@@ -7,6 +7,10 @@ defmodule PowInvitation.Ecto.ContextTest do
 
   @config [repo: RepoMock, user: User]
 
+  defmodule CustomUsers do
+    def get_by([invitation_token: :test]), do: %User{email: :ok}
+  end
+
   describe "get_by_invitation_token/2" do
     test "gets when :invitation_accepted_at is nil" do
       assert Context.get_by_invitation_token("valid", @config)
@@ -14,6 +18,10 @@ defmodule PowInvitation.Ecto.ContextTest do
 
     test "nil when :invitation_accepted_at is not nil" do
       refute Context.get_by_invitation_token("valid_but_accepted", @config)
+    end
+
+    test "with `:users_context`" do
+      assert %User{email: :ok} = Context.get_by_invitation_token(:test, @config ++ [users_context: CustomUsers])
     end
   end
 end

--- a/test/extensions/reset_password/ecto/context_test.exs
+++ b/test/extensions/reset_password/ecto/context_test.exs
@@ -10,6 +10,10 @@ defmodule PowResetPassword.Ecto.ContextTest do
   @password "secret1234"
   @user %User{id: 1, password_hash: :set}
 
+  defmodule CustomUsers do
+    def get_by([email: :test]), do: %User{email: :ok}
+  end
+
   describe "get_by_email/2" do
     test "email is case insensitive when it's the user id field" do
       assert Context.get_by_email("test@example.com", @config)
@@ -18,6 +22,10 @@ defmodule PowResetPassword.Ecto.ContextTest do
 
     test "email is trimmed when it's the user id field" do
       assert Context.get_by_email(" test@example.com ", @config)
+    end
+
+    test "with `:users_context`" do
+      assert %User{email: :ok} = Context.get_by_email(:test, @config ++ [users_context: CustomUsers])
     end
   end
 

--- a/test/pow/ecto/context_test.exs
+++ b/test/pow/ecto/context_test.exs
@@ -33,6 +33,10 @@ defmodule Pow.Ecto.ContextTest do
   @config [repo: Repo, user: User]
   @username_config [repo: Repo, user: UsernameUser]
 
+  defmodule CustomUsers do
+    def get_by([email: :test]), do: %User{email: :ok, password_hash: Password.pbkdf2_hash("secret1234")}
+  end
+
   describe "authenticate/2" do
     @password "secret1234"
     @valid_params %{"email" => "test@example.com", "password" => @password}
@@ -94,6 +98,12 @@ defmodule Pow.Ecto.ContextTest do
     test "as `use Pow.Ecto.Context`", %{user: user} do
       assert Users.authenticate(@valid_params) == user
       assert Users.authenticate(:test_macro) == :ok
+    end
+
+    test "with `:users_context`" do
+      params = Map.put(@valid_params, "email", :test)
+
+      assert %User{email: :ok} = Context.authenticate(params, @config ++ [users_context: CustomUsers])
     end
 
     test "prevents timing attack" do


### PR DESCRIPTION
https://github.com/danschultzer/pow/issues/308#issuecomment-545475332 is not possible with how Pow currently handles custom context. This is a potential solution, but I'll work a bit more on it as I'm not sure if it makes sense to call Operations module rather than handle custom context in the context module itself.

Resolves #371