### PR TITLE
Generic response for reset password message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Enhancements
 
 * [`PowPersistentSession.Plug.Cookie`] Now supports `:persistent_session_cookie_opts` to customize any options that will be passed on to `Plug.Conn.put_resp_cookie/4`
+* [`PowResetPassword.Phoenix.ResetPasswordController`] Now uses `PowResetPassword.Phoenix.Messages.maybe_email_has_been_sent/1` with a generic response that tells the user the email has been sent only if an account was found
+* [`PowResetPassword.Phoenix.Messages`] Added `PowResetPassword.Phoenix.Messages.maybe_email_has_been_sent/1` and let `PowResetPassword.Phoenix.Messages.email_has_been_sent/1` fall back to it
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [`PowPersistentSession.Plug.Cookie`] Now supports `:persistent_session_cookie_opts` to customize any options that will be passed on to `Plug.Conn.put_resp_cookie/4`
 * [`PowResetPassword.Phoenix.ResetPasswordController`] Now uses `PowResetPassword.Phoenix.Messages.maybe_email_has_been_sent/1` with a generic response that tells the user the email has been sent only if an account was found
+* [`PowResetPassword.Phoenix.ResetPasswordController`] When a user doesn't exist will now return success message if `PowEmailConfirmation` extension is enabled
 * [`PowResetPassword.Phoenix.Messages`] Added `PowResetPassword.Phoenix.Messages.maybe_email_has_been_sent/1` and let `PowResetPassword.Phoenix.Messages.email_has_been_sent/1` fall back to it
 
 ### Bug fixes

--- a/lib/extensions/reset_password/README.md
+++ b/lib/extensions/reset_password/README.md
@@ -2,7 +2,7 @@
 
 This extension will allow users to reset the password by sending an e-mail with a reset password link. It requires that the user schema has an `:email` field.
 
-A success message will always be returned during reset request if registration routes has been disabled to prevent information leak.
+A success message will always be returned during reset request if registration routes has been disabled or `PowEmailConfirmation` is included in the extension list to prevent information leak.
 
 ## Installation
 

--- a/lib/extensions/reset_password/phoenix/controllers/reset_password_controller.ex
+++ b/lib/extensions/reset_password/phoenix/controllers/reset_password_controller.ex
@@ -32,7 +32,9 @@ defmodule PowResetPassword.Phoenix.ResetPasswordController do
     url = routes(conn).url_for(conn, __MODULE__, :edit, [token])
     deliver_email(conn, user, url)
 
-    default_respond_create(conn)
+    conn
+    |> put_flash(:info, extension_messages(conn).email_has_been_sent(conn))
+    |> redirect(to: routes(conn).session_path(conn, :new))
   end
   def respond_create({:error, _any, conn}) do
     case registration_path?(conn) do
@@ -43,14 +45,10 @@ defmodule PowResetPassword.Phoenix.ResetPasswordController do
         |> render("new.html")
 
       false ->
-        default_respond_create(conn)
+        conn
+        |> put_flash(:info, extension_messages(conn).maybe_email_has_been_sent(conn))
+        |> redirect(to: routes(conn).session_path(conn, :new))
     end
-  end
-
-  defp default_respond_create(conn) do
-    conn
-    |> put_flash(:info, extension_messages(conn).email_has_been_sent(conn))
-    |> redirect(to: routes(conn).session_path(conn, :new))
   end
 
   @spec process_edit(Conn.t(), map()) :: {:ok, map(), Conn.t()}

--- a/lib/extensions/reset_password/phoenix/messages.ex
+++ b/lib/extensions/reset_password/phoenix/messages.ex
@@ -2,9 +2,15 @@ defmodule PowResetPassword.Phoenix.Messages do
   @moduledoc false
 
   @doc """
-  Flash message to show when a reset password e-mail has been sent.
+  Flash message to show generic response for reset password request.
   """
-  def email_has_been_sent(_conn), do: "An email with reset instructions has been sent to you. Please check your inbox."
+  def maybe_email_has_been_sent(_conn), do: "If an account for the provided email exists, an email with reset instructions will be send to you. Please check your inbox."
+
+  @doc """
+  Flash message to show when a reset password e-mail has been sent. Falls back
+  to `maybe_email_has_been_sent/1`
+  """
+  def email_has_been_sent(conn), do: maybe_email_has_been_sent(conn)
 
   @doc """
   Flash message to show when no user exists for the provided e-mail.

--- a/test/extensions/reset_password/phoenix/controllers/reset_password_controller_test.exs
+++ b/test/extensions/reset_password/phoenix/controllers/reset_password_controller_test.exs
@@ -50,7 +50,7 @@ defmodule PowResetPassword.Phoenix.ResetPasswordControllerTest do
       assert mail.html =~ "<a href=\"http://localhost/reset-password/#{token}\">"
 
       assert redirected_to(conn) == Routes.pow_session_path(conn, :new)
-      assert get_flash(conn, :info) == "An email with reset instructions has been sent to you. Please check your inbox."
+      assert get_flash(conn, :info) == "If an account for the provided email exists, an email with reset instructions will be send to you. Please check your inbox."
     end
 
     test "with invalid params", %{conn: conn} do
@@ -68,7 +68,7 @@ defmodule PowResetPassword.Phoenix.ResetPasswordControllerTest do
       conn = Phoenix.ConnTest.dispatch(conn, NoRegistrationEndpoint, :post, Routes.pow_reset_password_reset_password_path(conn, :create, @invalid_params))
 
       assert redirected_to(conn) == Routes.pow_session_path(conn, :new)
-      assert get_flash(conn, :info) == "An email with reset instructions has been sent to you. Please check your inbox."
+      assert get_flash(conn, :info) == "If an account for the provided email exists, an email with reset instructions will be send to you. Please check your inbox."
     end
   end
 

--- a/test/extensions/reset_password/phoenix/controllers/reset_password_controller_test.exs
+++ b/test/extensions/reset_password/phoenix/controllers/reset_password_controller_test.exs
@@ -60,6 +60,16 @@ defmodule PowResetPassword.Phoenix.ResetPasswordControllerTest do
       assert get_flash(conn, :error) == "No account exists for the provided email. Please try again."
       assert html =~ "<input id=\"user_email\" name=\"user[email]\" type=\"text\" value=\"invalid@example.com\">"
     end
+
+    test "with invalid params and PowEmailConfirmation enabled", %{conn: conn} do
+      conn =
+        conn
+        |> Plug.Conn.put_private(:pow_test_config, extensions: [PowResetPassword, PowEmailConfirmation])
+        |> post(Routes.pow_reset_password_reset_password_path(conn, :create, @invalid_params))
+
+      assert redirected_to(conn) == Routes.pow_session_path(conn, :new)
+      assert get_flash(conn, :info) == "If an account for the provided email exists, an email with reset instructions will be send to you. Please check your inbox."
+    end
   end
 
   alias PowResetPassword.NoRegistration.TestWeb.Phoenix.Endpoint, as: NoRegistrationEndpoint


### PR DESCRIPTION
This will conform the success message during password reset to [the OWASP recommendations](https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html#incorrect-and-correct-response-examples), so that the user will know that they may not receive the email if they entered in a wrong email address.

I'm thinking that maybe the `email_has_been_sent/1` should be deprecated, and instead `maybe_email_has_been_sent/1` should be used so it's clear what the message is about. I don't know if it will be possible to fall back on custom `email_has_been_sent/1` with the current extension messages structure.

Edit: Added `maybe_email_has_been_sent/1` and also keeps `email_has_been_sent/1`.