### PR TITLE
Prevent information leakage on registration when using PowEmailConfirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [`PowResetPassword.Phoenix.ResetPasswordController`] Now uses `PowResetPassword.Phoenix.Messages.maybe_email_has_been_sent/1` with a generic response that tells the user the email has been sent only if an account was found
 * [`PowResetPassword.Phoenix.ResetPasswordController`] When a user doesn't exist will now return success message if `PowEmailConfirmation` extension is enabled
 * [`PowResetPassword.Phoenix.Messages`] Added `PowResetPassword.Phoenix.Messages.maybe_email_has_been_sent/1` and let `PowResetPassword.Phoenix.Messages.email_has_been_sent/1` fall back to it
+* [`PowEmailConfirmation.Phoenix.ControllerCallbacks`] When a user tries to sign up and the email has already been taken the default e-mail confirmation required message will be shown
 
 ### Bug fixes
 

--- a/lib/extensions/email_confirmation/README.md
+++ b/lib/extensions/email_confirmation/README.md
@@ -4,6 +4,8 @@ This extension will send an e-mail confirmation link when the user registers, an
 
 Users won't be signed in when they register, and can't sign in until the e-mail has been confirmed. The confirmation e-mail will be sent every time the sign in fails. The user will be redirected to `after_registration_path/1` and `after_sign_in_path/1` accordingly.
 
+To prevent information leak, the user will see the same confirmation required message with no e-mail sent if a user attempts to register with an already taken email.
+
 When users updates their e-mail, it won't be changed until the user has confirmed the new e-mail by clicking the e-mail confirmation link.
 
 ## Installation

--- a/test/support/extensions/email_confirmation/repo_mock.ex
+++ b/test/support/extensions/email_confirmation/repo_mock.ex
@@ -32,7 +32,7 @@ defmodule PowEmailConfirmation.Test.RepoMock do
     %{user() | unconfirmed_email: "new@example.com", email_confirmed_at: DateTime.utc_now()}
   end
 
-  def update(%{changes: %{email: "taken@example.com"}} = changeset, _opts) do
+  def update(%{changes: %{email: "taken@example.com"}, valid?: true} = changeset, _opts) do
     changeset = Ecto.Changeset.add_error(changeset, :email, "has already been taken")
 
     {:error, changeset}
@@ -57,6 +57,12 @@ defmodule PowEmailConfirmation.Test.RepoMock do
     |> Enum.reduce(changeset, & &1.(&2))
   end
 
+  def insert(%{valid?: false} = changeset, _opts), do: {:error, %{changeset | action: :insert}}
+  def insert(%{changes: %{email: "taken@example.com"}, valid?: true} = changeset, _opts) do
+    changeset = Ecto.Changeset.add_error(changeset, :email, "has already been taken")
+
+    {:error, %{changeset | action: :insert}}
+  end
   def insert(%{valid?: true} = changeset, _opts) do
     user =
       changeset


### PR DESCRIPTION
This adheres to [OWASP recommendation](https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html#incorrect-and-correct-response-examples) to show the default confirmation required message when a user attempts to register with an already taken e-mail, but otherwise has valid params.

This to some degree prevents information leakage about an accounts existence as discussed in https://github.com/danschultzer/pow/issues/238#issuecomment-512860697. I will also implement the same logic for authentication with invalid credentials for existing user to fully prevent fully any information leakage.

I'm not completely convinced that the controller callbacks should have this expectation of the changeset map since I try to make any Phoenix modules just pass along whatever is sent to them without caring what it is to have clear separation of responsibility. I kind of wish I could handle it at the Ecto level, but it really only makes sense to have this logic in the controller callbacks to figure out the correct response based on error type. In PowAssent I've let the [context method](https://github.com/pow-auth/pow_assent/blob/v0.4.5/lib/pow_assent/ecto/user_identities/context.ex#L201) return an error that could be acted upon. It might be difficult to implement this with how the Pow context works though, since there is only extension callback in the changeset, not for context methods.

One doubt I have about the logic is that this only checks the email taken. What if you have both email and username? In that case it should probably check both the user id and email. But what if there is an additional unique field defined by the user? I'll think about this and figure out what is appropriate.

Edit: I've changed the logic so the success message is always shown when email has been taken disregarding any other errors there may be.