### PR TITLE
Fix bug with nil user id change exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [`PowPersistentSession.Plug.Cookie`] Now supports `:persistent_session_cookie_opts` to customize any options that will be passed on to `Plug.Conn.put_resp_cookie/4`
 
+### Bug fixes
+
+* [`Pow.Ecto.Schema.Changeset`] Fixed bug where `Pow.Ecto.Schema.Changeset.user_id_field_changeset/3` update with `nil` value caused an exception to be raised
+
 ## v1.0.15 (2019-11-20)
 
 ### Enhancements

--- a/lib/pow/ecto/schema/changeset.ex
+++ b/lib/pow/ecto/schema/changeset.ex
@@ -45,11 +45,14 @@ defmodule Pow.Ecto.Schema.Changeset do
 
     user_or_changeset
     |> Changeset.cast(params, [user_id_field])
-    |> Changeset.update_change(user_id_field, &Schema.normalize_user_id_field_value/1)
+    |> Changeset.update_change(user_id_field, &maybe_normalize_user_id_field_value/1)
     |> maybe_validate_email_format(user_id_field, config)
     |> Changeset.validate_required([user_id_field])
     |> Changeset.unique_constraint(user_id_field)
   end
+
+  defp maybe_normalize_user_id_field_value(value) when is_binary(value), do: Schema.normalize_user_id_field_value(value)
+  defp maybe_normalize_user_id_field_value(any), do: any
 
   @doc """
   Validates the password field.

--- a/test/pow/ecto/schema/changeset_test.exs
+++ b/test/pow/ecto/schema/changeset_test.exs
@@ -26,6 +26,10 @@ defmodule Pow.Ecto.Schema.ChangesetTest do
       refute changeset.valid?
       assert changeset.errors[:email] == {"can't be blank", [validation: :required]}
 
+      changeset = User.changeset(%User{email: "john.doe@example.com"}, %{email: nil})
+      refute changeset.valid?
+      assert changeset.errors[:email] == {"can't be blank", [validation: :required]}
+
       changeset = UsernameUser.changeset(%UsernameUser{}, Map.delete(@valid_params_username, "username"))
       refute changeset.valid?
       assert changeset.errors[:username] == {"can't be blank", [validation: :required]}


### PR DESCRIPTION
Resolves #358 

When the user id value was changed to nil when a user id value already exists, an exception was raised instead of an error set in the changeset, like this:

```elixir
User.pow_user_id_field_changeset(%User{email: "test"}, %{email: nil})
```

```
** (FunctionClauseError) no function clause matching in String.Break.trim_leading/1

The following arguments were given to String.Break.trim_leading/1:

    # 1
    nil

Attempted function clauses (showing 1 out of 1):

    def trim_leading(string) when is_binary(string)

code: changeset = User.changeset(%User{email: "john.doe@example.com"}, %{email: nil})
stacktrace:
  (elixir) lib/elixir/unicode/properties.ex:288: String.Break.trim_leading/1
  (elixir) lib/string.ex:1108: String.trim/1
  (pow) lib/pow/ecto/schema.ex:307: Pow.Ecto.Schema.normalize_user_id_field_value/1
  (ecto) lib/ecto/changeset.ex:1133: Ecto.Changeset.update_change/3
  (pow) lib/pow/ecto/schema/changeset.ex:48: Pow.Ecto.Schema.Changeset.user_id_field_changeset/3
```