### PR TITLE
Support custom cookie opts for PowPersistentSession.Plug.Cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.0.16 (TBA)
+
+### Enhancements
+
+* [`PowPersistentSession.Plug.Cookie`] Now supports `:persistent_session_cookie_opts` to customize any options that will be passed on to `Plug.Conn.put_resp_cookie/4`
+
 ## v1.0.15 (2019-11-20)
 
 ### Enhancements

--- a/test/extensions/persistent_session/plug/cookie_test.exs
+++ b/test/extensions/persistent_session/plug/cookie_test.exs
@@ -196,6 +196,20 @@ defmodule PowPersistentSession.Plug.CookieTest do
     assert %{max_age: 1, path: "/"} = conn.resp_cookies["persistent_session_cookie"]
   end
 
+  test "create/3 with custom cookie options", %{conn: conn, config: config} do
+    config = Keyword.put(config, :persistent_session_cookie_opts, [domain: "domain.com", max_age: 1, path: "/path", http_only: false, secure: true, extra: "SameSite=Lax"])
+    conn   = Cookie.create(conn, %User{id: 1}, config)
+
+    assert %{
+      domain: "domain.com",
+      extra: "SameSite=Lax",
+      http_only: false,
+      max_age: 1,
+      path: "/path",
+      secure: true
+    } = conn.resp_cookies["persistent_session_cookie"]
+  end
+
   test "create/3 deletes previous persistent session", %{conn: conn, config: config, ets: ets} do
     conn = store_persistent(conn, ets, "previous_persistent_session", {[id: 1], []})
 


### PR DESCRIPTION
Resolves #362 

`:persistent_session_cookie_opts` can be used to add or override any cookie options such as:

```elixir
plug PowPersistentSession.Plug.Cookie,
  persistent_session_cookie_opts: [extra: "SameSite=Lax", path: "/path"]
```