### PR TITLE
Prevent eager deletion of invalid persistent session cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Bug fixes
 
 * [`Pow.Ecto.Schema.Changeset`] Fixed bug where `Pow.Ecto.Schema.Changeset.user_id_field_changeset/3` update with `nil` value caused an exception to be raised
-* [`PowPersistentSession.Plug.Cookie`] Now expires the cookie after 10 seconds after the last request when authenticating to prevent multiple simultaneous requests deletes the cookie immediately
+* [`PowPersistentSession.Plug.Cookie`] Now expires the cookie 10 seconds after the last request when authenticating to prevent multiple simultaneous requests deletes the cookie immediately
 
 ## v1.0.15 (2019-11-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug fixes
 
 * [`Pow.Ecto.Schema.Changeset`] Fixed bug where `Pow.Ecto.Schema.Changeset.user_id_field_changeset/3` update with `nil` value caused an exception to be raised
+* [`PowPersistentSession.Plug.Cookie`] Now expires the cookie after 10 seconds after the last request when authenticating to prevent multiple simultaneous requests deletes the cookie immediately
 
 ## v1.0.15 (2019-11-20)
 

--- a/test/extensions/persistent_session/plug/cookie_test.exs
+++ b/test/extensions/persistent_session/plug/cookie_test.exs
@@ -144,7 +144,7 @@ defmodule PowPersistentSession.Plug.CookieTest do
   end
 
   test "call/2 when persistent session cache doesn't have credentials with custom cookie options", %{conn: conn, config: config} do
-    config = Keyword.merge(config, persistent_session_cookie_opts: @custom_cookie_opts, persistent_session_cookie_expiration_drift: 20)
+    config = Keyword.merge(config, persistent_session_cookie_opts: @custom_cookie_opts, persistent_session_cookie_expiration_timeout: 20)
     conn   =
       conn
       |> persistent_cookie("persistent_session_cookie", "test")

--- a/test/extensions/persistent_session/plug/cookie_test.exs
+++ b/test/extensions/persistent_session/plug/cookie_test.exs
@@ -144,7 +144,7 @@ defmodule PowPersistentSession.Plug.CookieTest do
   end
 
   test "call/2 when persistent session cache doesn't have credentials with custom cookie options", %{conn: conn, config: config} do
-    config = Keyword.put(config, :persistent_session_cookie_opts, @custom_cookie_opts)
+    config = Keyword.merge(config, persistent_session_cookie_opts: @custom_cookie_opts, persistent_session_cookie_expiration_drift: 20)
     conn   =
       conn
       |> persistent_cookie("persistent_session_cookie", "test")
@@ -155,7 +155,7 @@ defmodule PowPersistentSession.Plug.CookieTest do
       domain: "domain.com",
       extra: "SameSite=Lax",
       http_only: false,
-      max_age: 10,
+      max_age: 20,
       path: "/path",
       secure: true,
       value: "test"


### PR DESCRIPTION
Resolves #356 

This prevent eager deletion of cookie. The cookie expiration date is set to 10 seconds in the future rather than 1 second in the past, so the cookie will automatically expires 10 seconds after the last request. This should give enough time in case there are a multitude of requests as described in #356 while rolling the persistent session.

I've also added the `:persistent_session_cookie_opts` to the cookie deletion and expiration.