### PR TITLE
Improve docs on session expiration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [`PowPersistentSession.Plug.Cookie`] Now supports `:persistent_session_cookie_opts` to customize any options that will be passed on to `Plug.Conn.put_resp_cookie/4`
 * Added mailer rate limitation section to [production checklist guide](guides/production_checklist.md)
+* [`Pow.Plug.Session`] Added section on session expiration to the docs
 
 ### Bug fixes
 

--- a/lib/pow/plug/session.ex
+++ b/lib/pow/plug/session.ex
@@ -78,6 +78,32 @@ defmodule Pow.Plug.Session do
 
   The method should be called after `Pow.Plug.Session.call/2` has been called
   to ensure that the metadata, if any, has been fetched.
+
+  ## Session expiration
+
+  `Pow.Store.CredentialsCache` will, by default, invalidate any session token
+  30 minutes after it has been generated. To keep sessions alive the
+  `:session_ttl_renewal` option is used to determine when a session token
+  becomes stale and a new session ID has to be generated for the user (deleting
+  the previous one in the process).
+
+  If `:session_ttl_renewal` is set to zero, a new session token will be
+  generated on every request.
+
+  To change the amount of time a session can be alive, both the TTL for
+  `Pow.Store.CredentialsCache` and `:session_ttl_renewal` option should be
+  changed:
+
+      plug Pow.Plug.Session, otp_app: :my_app,
+        session_ttl_renewal: :timer.minutes(1),
+        session_store: {Pow.Store.CredentialsCache, ttl: :timer.minutes(15)}
+
+  In the above, a new session token will be generated when a request occurs
+  more than a minute after the current session token was generated. The
+  session is invalidated if there is no request for the next 14 minutes.
+
+  There are no absolute session timeout; sessions can be kept alive
+  indefinitely.
   """
   use Pow.Plug.Base
 


### PR DESCRIPTION
This resolves #360 

I wonder if Pow should support absolute timeout. Right now a session can be kept alive indefinitely, if requests are constantly made. The session token is rolled every 15 minutes, but if someone highjacks the session, they can keep the session alive indefinitely instead of being forced to sign in again after the absolute limit is reached.

If implemented, sane default would most likely be a few hours for the session, and 30 days for the persistent session.