### PR TITLE
Add after compile validation check to ensure all fields and assocs have been defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [`Pow.Ecto.Schema.Changeset`] `Pow.Ecto.Schema.Changeset.confirm_password_changeset/3` now adds the default `Ecto.Changeset.validate_confirmation/3` error instead of the previous `not same as password` error
 * [`Pow.Ecto.Changeset`] `Pow.Ecto.Schema.Changeset.confirm_password_changeset/3` now uses the `Ecto.Changeset.validate_confirmation/3` for validation and expects `:password_confirmation` instead of `:confirm_password` in params
 * [`Pow.Ecto.Schema`] No longer adds `:confirm_password` virtual field
+* [`Pow.Ecto.Schema`] Now has an `@after_compile` callback that ensures all required fields has been defined
 * [`PowInvitation.Phoenix.InvitationView`] Now renders `:password_confirmation` field instead of `:confirm_password`
 * [`PowResetPassword.Phoenix.ResetPasswordView`] Now renders `:password_confirmation` field instead of `:confirm_password`
 * [`Pow.Phoenix.RegistrationView`] Now renders `:password_confirmation` field instead of `:confirm_password`

--- a/lib/pow/extension/ecto/schema.ex
+++ b/lib/pow/extension/ecto/schema.ex
@@ -99,11 +99,11 @@ defmodule Pow.Extension.Ecto.Schema do
   @doc false
   defmacro __register_after_compile_validation__ do
     quote do
-      def validate_after_compilation!(env, _bytecode) do
+      def pow_extension_validate_after_compilation!(env, _bytecode) do
         unquote(__MODULE__).validate!(@pow_extension_config, __MODULE__)
       end
 
-      @after_compile {__MODULE__, :validate_after_compilation!}
+      @after_compile {__MODULE__, :pow_extension_validate_after_compilation!}
     end
   end
 


### PR DESCRIPTION
Based on suggestion by @josevalim.

This adds an `@after_compile` validation check to ensure all assocs and fields used by Pow and its extensions has been defined. This way devs are no longer dependent on using `pow_user_fields/0`, as `Pow.Ecto.Schema` will raise an error on compile-time to ensure all fields are defined.

This paves the road to get rid of `pow_user_fields/0` and let devs explicitly list all assocs and fields. The thing that holds me back is to still keep Pow super easy to set up. If the assocs and fields have to be explicitly listed, then adding extensions would require additional steps to get working.