### PR TITLE
Use `Ecto.Changeset.validate_confirmation/3`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@
   * `PowInvitation.Ecto.Context.get_by_invitation_token/2`
   * `PowResetPassword.Ecto.Context.get_by_email/2`
 * [`Pow.Ecto.Schema.Changeset`] `Pow.Ecto.Schema.Changeset.confirm_password_changeset/3` now adds the default `Ecto.Changeset.validate_confirmation/3` error instead of the previous `not same as password` error
+* [`Pow.Ecto.Changeset`] `Pow.Ecto.Schema.Changeset.confirm_password_changeset/3` now uses the `Ecto.Changeset.validate_confirmation/3` for validation and expects `:password_confirmation` instead of `:confirm_password` in params
+* [`Pow.Ecto.Schema`] No longer adds `:confirm_password` virtual field
+* [`PowInvitation.Phoenix.InvitationView`] Now renders `:password_confirmation` field instead of `:confirm_password`
+* [`PowResetPassword.Phoenix.ResetPasswordView`] Now renders `:password_confirmation` field instead of `:confirm_password`
+* [`Pow.Phoenix.RegistrationView`] Now renders `:password_confirmation` field instead of `:confirm_password`
+
+### Deprecations
+
+* [`Pow.Ecto.Changeset`] `Pow.Ecto.Schema.Changeset.confirm_password_changeset/3` has deprecated use of `:confirm_password` in params in favor of `:password_confirmation`
 
 ## v1.0.16 (2020-01-07)
 

--- a/guides/api.md
+++ b/guides/api.md
@@ -265,7 +265,7 @@ You can now set up your client to connect to your API and generate session token
 You can run the following curl methods to test it out:
 
 ```bash
-$ curl -X POST -d "user[email]=test@example.com&user[password]=secret1234&user[confirm_password]=secret1234" http://localhost:4000/api/v1/registration
+$ curl -X POST -d "user[email]=test@example.com&user[password]=secret1234&user[password_confirmation]=secret1234" http://localhost:4000/api/v1/registration
 {"data":{"renew_token":"RENEW_TOKEN","token":"AUTH_TOKEN"}}
 
 $ curl -X POST -d "user[email]=test@example.com&user[password]=secret1234" http://localhost:4000/api/v1/session
@@ -333,8 +333,8 @@ defmodule MyAppWeb.API.V1.RegistrationControllerTest do
   use MyAppWeb.ConnCase
 
   describe "create/2" do
-    @valid_params %{"user" => %{"email" => "test@example.com", "password" => "secret1234", "confirm_password" => "secret1234"}}
-    @invalid_params %{"user" => %{"email" => "invalid", "password" => "secret1234", "confirm_password" => ""}}
+    @valid_params %{"user" => %{"email" => "test@example.com", "password" => "secret1234", "password_confirmation" => "secret1234"}}
+    @invalid_params %{"user" => %{"email" => "invalid", "password" => "secret1234", "password_confirmation" => ""}}
 
     test "with valid params", %{conn: conn} do
       conn = post conn, Routes.api_v1_registration_path(conn, :create, @valid_params)
@@ -351,7 +351,7 @@ defmodule MyAppWeb.API.V1.RegistrationControllerTest do
 
       assert json["error"]["message"] == "Couldn't create user"
       assert json["error"]["status"] == 500
-      assert json["error"]["errors"]["confirm_password"] == ["does not match confirmation"]
+      assert json["error"]["errors"]["password_confirmation"] == ["does not match confirmation"]
       assert json["error"]["errors"]["email"] == ["has invalid format"]
     end
   end

--- a/guides/custom_controllers.md
+++ b/guides/custom_controllers.md
@@ -155,15 +155,15 @@ Create `lib/my_app_web/templates/registration/new.html.eex`:
 
 ```elixir
 <%= form_for @changeset, Routes.signup_path(@conn, :create), fn f -> %>
-  <%= label f, :email, "email" %>
+  <%= label f, :email %>
   <%= email_input f, :email %>
   <%= error_tag f, :email %>
 
-  <%= label f, :password, "password" %>
+  <%= label f, :password %>
   <%= password_input f, :password %>
   <%= error_tag f, :password %>
 
-  <%= label f, :password_confirmation, "password_confirmation" %>
+  <%= label f, :password_confirmation %>
   <%= password_input f, :password_confirmation %>
   <%= error_tag f, :password_confirmation %>
 

--- a/guides/custom_controllers.md
+++ b/guides/custom_controllers.md
@@ -163,9 +163,9 @@ Create `lib/my_app_web/templates/registration/new.html.eex`:
   <%= password_input f, :password %>
   <%= error_tag f, :password %>
 
-  <%= label f, :confirm_password, "confirm_password" %>
-  <%= password_input f, :confirm_password %>
-  <%= error_tag f, :confirm_password %>
+  <%= label f, :password_confirmation, "password_confirmation" %>
+  <%= password_input f, :password_confirmation %>
+  <%= error_tag f, :password_confirmation %>
 
   <%= submit "Register" %>
 <% end %>

--- a/guides/user_roles.md
+++ b/guides/user_roles.md
@@ -178,7 +178,7 @@ defmodule MyApp.UsersTest do
 
   alias MyApp.{Repo, Users, Users.User}
 
-  @valid_params %{email: "test@example.com", password: "secret1234", confirm_password: "secret1234"}
+  @valid_params %{email: "test@example.com", password: "secret1234", password_confirmation: "secret1234"}
 
   test "create_admin/2" do
     assert {:ok, user} = Users.create_admin(@valid_params)

--- a/lib/extensions/invitation/phoenix/templates/invitation_template.ex
+++ b/lib/extensions/invitation/phoenix/templates/invitation_template.ex
@@ -18,7 +18,7 @@ defmodule PowInvitation.Phoenix.InvitationTemplate do
   <%= Pow.Phoenix.HTML.FormTemplate.render([
     {:text, {:changeset, :pow_user_id_field}},
     {:password, :password},
-    {:password, :confirm_password}
+    {:password, :password_confirmation}
   ]) %>
 
   <span><%%= link "Sign in", to: Routes.<%= Pow.Phoenix.Controller.route_helper(Pow.Phoenix.SessionController) %>_path(@conn, :new) %></span>

--- a/lib/extensions/reset_password/phoenix/templates/reset_password_template.ex
+++ b/lib/extensions/reset_password/phoenix/templates/reset_password_template.ex
@@ -17,7 +17,7 @@ defmodule PowResetPassword.Phoenix.ResetPasswordTemplate do
 
   <%= Pow.Phoenix.HTML.FormTemplate.render([
     {:password, :password},
-    {:password, :confirm_password}
+    {:password, :password_confirmation}
   ]) %>
 
   <span><%%= link "Sign in", to: Routes.<%= Pow.Phoenix.Controller.route_helper(Pow.Phoenix.SessionController) %>_path(@conn, :new) %></span>

--- a/lib/pow/ecto/schema.ex
+++ b/lib/pow/ecto/schema.ex
@@ -195,7 +195,6 @@ defmodule Pow.Ecto.Schema do
     * `:password_hash`
     * `:current_password` (virtual)
     * `:password` (virtual)
-    * `:confirm_password` (virtual)
   """
   defmacro pow_user_fields do
     quote do

--- a/lib/pow/ecto/schema/changeset.ex
+++ b/lib/pow/ecto/schema/changeset.ex
@@ -87,6 +87,7 @@ defmodule Pow.Ecto.Schema.Changeset do
     |> Changeset.validate_required([:password_hash])
   end
 
+  # TODO: Remove `confirm_password` support by 1.1.0
   @doc """
   Validates the confirm password field.
 
@@ -95,14 +96,46 @@ defmodule Pow.Ecto.Schema.Changeset do
   `nil`.
   """
   @spec confirm_password_changeset(Ecto.Schema.t() | Changeset.t(), map(), Config.t()) :: Changeset.t()
-  def confirm_password_changeset(user_or_changeset, params, _config) do
-    changeset = Changeset.cast(user_or_changeset, params, [:password, :confirm_password])
+  def confirm_password_changeset(user_or_changeset, %{confirm_password: password_confirmation} = params, _config) do
+    params =
+      params
+      |> Map.delete(:confirm_password)
+      |> Map.put(:password_confirmation, password_confirmation)
+
+    do_confirm_password_changeset(user_or_changeset, params)
+  end
+  def confirm_password_changeset(user_or_changeset, %{"confirm_password" => password_confirmation} = params, _config) do
+    params =
+      params
+      |> Map.delete("confirm_password")
+      |> Map.put("password_confirmation", password_confirmation)
+
+    convert_confirm_password_param(user_or_changeset, params)
+  end
+  def confirm_password_changeset(user_or_changeset, params, _config),
+    do: do_confirm_password_changeset(user_or_changeset, params)
+
+  # TODO: Remove by 1.1.0
+  defp convert_confirm_password_param(user_or_changeset, params) do
+    IO.warn("warning: passing `confirm_password` value to `#{inspect unquote(__MODULE__)}.confirm_password_changeset/3` has been deprecated, please use `password_confirmation` instead")
+
+    changeset = do_confirm_password_changeset(user_or_changeset, params)
+    errors    = Enum.map(changeset.errors, fn
+      {:password_confirmation, error} -> {:confirm_password, error}
+      error                           -> error
+    end)
+
+    %{changeset | errors: errors}
+  end
+
+  defp do_confirm_password_changeset(user_or_changeset, params) do
+    changeset = Changeset.cast(user_or_changeset, params, [:password])
 
     changeset
     |> Changeset.get_change(:password)
     |> case do
-      nil      -> changeset
-      password -> validate_confirm_password(changeset, password)
+      nil       -> changeset
+      _password -> Changeset.validate_confirmation(changeset, :password, required: true)
     end
   end
 
@@ -208,15 +241,6 @@ defmodule Pow.Ecto.Schema.Changeset do
     password_max_length = Config.get(config, :password_max_length, @password_max_length)
 
     Changeset.validate_length(changeset, :password, min: password_min_length, max: password_max_length)
-  end
-
-  defp validate_confirm_password(changeset, password) do
-    confirm_password = Changeset.get_change(changeset, :confirm_password)
-
-    case password do
-      ^confirm_password -> changeset
-      _                 -> Changeset.add_error(changeset, :confirm_password, "does not match confirmation", validation: :confirmation)
-    end
   end
 
   defp maybe_put_password_hash(%Changeset{valid?: true, changes: %{password: password}} = changeset, config) do

--- a/lib/pow/ecto/schema/fields.ex
+++ b/lib/pow/ecto/schema/fields.ex
@@ -7,8 +7,7 @@ defmodule Pow.Ecto.Schema.Fields do
   @attrs [
     {:password_hash, :string},
     {:current_password, :string, virtual: true},
-    {:password, :string, virtual: true},
-    {:confirm_password, :string, virtual: true}
+    {:password, :string, virtual: true}
   ]
 
   @doc """

--- a/lib/pow/phoenix/templates/registration_template.ex
+++ b/lib/pow/phoenix/templates/registration_template.ex
@@ -9,7 +9,7 @@ defmodule Pow.Phoenix.RegistrationTemplate do
   <%= Pow.Phoenix.HTML.FormTemplate.render([
     {:text, {:changeset, :pow_user_id_field}},
     {:password, :password},
-    {:password, :confirm_password}
+    {:password, :password_confirmation}
   ],
   button_label: "Register") %>
 
@@ -24,7 +24,7 @@ defmodule Pow.Phoenix.RegistrationTemplate do
     {:password, :current_password},
     {:text, {:changeset, :pow_user_id_field}},
     {:password, :password},
-    {:password, :confirm_password}
+    {:password, :password_confirmation}
   ],
   button_label: "Update") %>
   """

--- a/test/extensions/email_confirmation/ecto/context_test.exs
+++ b/test/extensions/email_confirmation/ecto/context_test.exs
@@ -50,7 +50,7 @@ defmodule PowEmailConfirmation.Ecto.ContextTest do
     end
   end
 
-  @valid_params %{email: "test@example.com", password: "secret1234", confirm_password: "secret1234"}
+  @valid_params %{email: "test@example.com", password: "secret1234", password_confirmation: "secret1234"}
 
   test "current_email_unconfirmed?/2" do
     new_user =

--- a/test/extensions/email_confirmation/ecto/schema_test.exs
+++ b/test/extensions/email_confirmation/ecto/schema_test.exs
@@ -6,7 +6,7 @@ defmodule PowEmailConfirmation.Ecto.SchemaTest do
   alias PowEmailConfirmation.Test.{RepoMock, Users.User}
 
   @password          "secret1234"
-  @valid_params     %{email: "test@example.com", password: @password, confirm_password: @password, current_password: @password}
+  @valid_params     %{email: "test@example.com", password: @password, password_confirmation: @password, current_password: @password}
 
   test "user_schema/1" do
     user = %User{}

--- a/test/extensions/email_confirmation/phoenix/controllers/controller_callbacks_test.exs
+++ b/test/extensions/email_confirmation/phoenix/controllers/controller_callbacks_test.exs
@@ -41,7 +41,7 @@ defmodule PowEmailConfirmation.Phoenix.ControllerCallbacksTest do
   end
 
   describe "Pow.Phoenix.RegistrationController.create/2" do
-    @valid_params %{"user" => %{"email" => "test@example.com", "password" => @password, "confirm_password" => @password}}
+    @valid_params %{"user" => %{"email" => "test@example.com", "password" => @password, "password_confirmation" => @password}}
 
     test "with valid params", %{conn: conn} do
       conn = post conn, Routes.pow_registration_path(conn, :create, @valid_params)
@@ -58,7 +58,7 @@ defmodule PowEmailConfirmation.Phoenix.ControllerCallbacksTest do
       assert mail.user.email == "test@example.com"
     end
 
-    @email_taken_invalid_params %{"user" => %{"email" => "taken@example.com", "password" => @password, "confirm_password" => "s"}}
+    @email_taken_invalid_params %{"user" => %{"email" => "taken@example.com", "password" => @password, "password_confirmation" => "s"}}
     test "with invalid params and email taken", %{conn: conn} do
       conn = post conn, Routes.pow_registration_path(conn, :create, @email_taken_invalid_params)
 
@@ -67,7 +67,7 @@ defmodule PowEmailConfirmation.Phoenix.ControllerCallbacksTest do
       assert html =~ "<span class=\"help-block\">does not match confirmation</span>"
     end
 
-    @email_taken_valid_params %{"user" => %{"email" => "taken@example.com", "password" => @password, "confirm_password" => @password}}
+    @email_taken_valid_params %{"user" => %{"email" => "taken@example.com", "password" => @password, "password_confirmation" => @password}}
     test "with valid params and email taken", %{conn: conn} do
       conn = post conn, Routes.pow_registration_path(conn, :create, @email_taken_valid_params)
 
@@ -127,8 +127,8 @@ defmodule PowEmailConfirmation.Phoenix.ControllerCallbacksTest do
 
   describe "PowInvitation.Phoenix.InvitationController.update/2" do
     @token               "token"
-    @params              %{"email" => "test@example.com", "password" => @password, "confirm_password" => @password}
-    @change_email_params %{"email" => "new@example.com", "password" => @password, "confirm_password" => @password}
+    @params              %{"email" => "test@example.com", "password" => @password, "password_confirmation" => @password}
+    @change_email_params %{"email" => "new@example.com", "password" => @password, "password_confirmation" => @password}
 
     test "when email changes", %{conn: conn} do
       conn = put_invitation conn, PowInvitationRoutes.pow_invitation_invitation_path(conn, :update, @token, %{"user" => @change_email_params})

--- a/test/extensions/invitation/ecto/schema_test.exs
+++ b/test/extensions/invitation/ecto/schema_test.exs
@@ -68,7 +68,7 @@ defmodule PowInvitation.Ecto.SchemaTest do
 
   describe "accept_invitation_changeset/2" do
     @password "password12"
-    @valid_params %{email: "test@example.com", password: @password, confirm_password: @password}
+    @valid_params %{email: "test@example.com", password: @password, password_confirmation: @password}
     @invalid_params %{email: "foo"}
 
     test "with valid params" do

--- a/test/extensions/invitation/phoenix/controllers/invitation_controller_test.exs
+++ b/test/extensions/invitation/phoenix/controllers/invitation_controller_test.exs
@@ -136,16 +136,16 @@ defmodule PowInvitation.Phoenix.InvitationControllerTest do
       assert html =~ "<input id=\"user_email\" name=\"user[email]\" type=\"text\" value=\"test@example.com\">"
       assert html =~ "<label for=\"user_password\">Password</label>"
       assert html =~ "<input id=\"user_password\" name=\"user[password]\" type=\"password\">"
-      assert html =~ "<label for=\"user_confirm_password\">Confirm password</label>"
-      assert html =~ "<input id=\"user_confirm_password\" name=\"user[confirm_password]\" type=\"password\">"
+      assert html =~ "<label for=\"user_password_confirmation\">Password confirmation</label>"
+      assert html =~ "<input id=\"user_password_confirmation\" name=\"user[password_confirmation]\" type=\"password\">"
       assert html =~ "<button type=\"submit\">Submit</button>"
     end
   end
 
   describe "update/2" do
     @password "password1234"
-    @valid_params %{"user" => %{"email" => "test@example.com", "password" => @password, "confirm_password" => @password}}
-    @invalid_params %{"user" => %{"email" => "invalid", "password" => @password, "confirm_password" => "invalid"}}
+    @valid_params %{"user" => %{"email" => "test@example.com", "password" => @password, "password_confirmation" => @password}}
+    @invalid_params %{"user" => %{"email" => "invalid", "password" => @password, "password_confirmation" => "invalid"}}
 
     test "already signed in", %{conn: conn} do
       conn =

--- a/test/extensions/reset_password/ecto/context_test.exs
+++ b/test/extensions/reset_password/ecto/context_test.exs
@@ -31,7 +31,7 @@ defmodule PowResetPassword.Ecto.ContextTest do
 
   describe "update_password/2" do
     test "updates with compiled password hash methods" do
-      assert {:ok, user} = Context.update_password(@user, %{password: @password, confirm_password: @password}, @config)
+      assert {:ok, user} = Context.update_password(@user, %{password: @password, password_confirmation: @password}, @config)
       assert Password.pbkdf2_verify(@password, user.password_hash)
     end
 
@@ -39,7 +39,7 @@ defmodule PowResetPassword.Ecto.ContextTest do
       assert {:error, changeset} = Context.update_password(@user, %{}, @config)
       assert changeset.errors[:password] == {"can't be blank", [validation: :required]}
 
-      assert {:error, changeset} = Context.update_password(@user, %{password: "", confirm_password: ""}, @config)
+      assert {:error, changeset} = Context.update_password(@user, %{password: "", password_confirmation: ""}, @config)
       assert changeset.errors[:password] == {"can't be blank", [validation: :required]}
     end
   end

--- a/test/extensions/reset_password/phoenix/controllers/reset_password_controller_test.exs
+++ b/test/extensions/reset_password/phoenix/controllers/reset_password_controller_test.exs
@@ -114,8 +114,8 @@ defmodule PowResetPassword.Phoenix.ResetPasswordControllerTest do
       assert html = html_response(conn, 200)
       assert html =~ "<label for=\"user_password\">Password</label>"
       assert html =~ "<input id=\"user_password\" name=\"user[password]\" type=\"password\">"
-      assert html =~ "<label for=\"user_confirm_password\">Confirm password</label>"
-      assert html =~ "<input id=\"user_confirm_password\" name=\"user[confirm_password]\" type=\"password\">"
+      assert html =~ "<label for=\"user_password_confirmation\">Password confirmation</label>"
+      assert html =~ "<input id=\"user_password_confirmation\" name=\"user[password_confirmation]\" type=\"password\">"
       assert html =~ "<a href=\"/session/new\">Sign in</a>"
     end
   end
@@ -124,8 +124,8 @@ defmodule PowResetPassword.Phoenix.ResetPasswordControllerTest do
     @valid_token "valid"
     @invalid_token "invalid"
 
-    @valid_params %{"user" => %{"password" => @password, "confirm_password" => @password}}
-    @invalid_params %{"user" => %{"password" => @password, "confirm_password" => "invalid"}}
+    @valid_params %{"user" => %{"password" => @password, "password_confirmation" => @password}}
+    @invalid_params %{"user" => %{"password" => @password, "password_confirmation" => "invalid"}}
 
     setup %{ets: ets} do
       ResetTokenCache.put([backend: ets], @valid_token, @user)
@@ -167,7 +167,7 @@ defmodule PowResetPassword.Phoenix.ResetPasswordControllerTest do
       assert html =~ "<span class=\"help-block\">does not match confirmation</span>"
 
       changeset = conn.assigns[:changeset]
-      assert changeset.errors[:confirm_password]
+      assert changeset.errors[:password_confirmation]
       assert changeset.action == :update
 
       assert ResetTokenCache.get([backend: ets], @valid_token) == @user

--- a/test/pow/ecto/context_test.exs
+++ b/test/pow/ecto/context_test.exs
@@ -123,15 +123,14 @@ defmodule Pow.Ecto.ContextTest do
       "email" => "test@example.com",
       "custom" => "custom",
       "password" => @password,
-      "confirm_password" => @password
+      "password_confirmation" => @password
     }
 
     test "creates" do
-      assert {:error, _changeset} = Context.create(Map.delete(@valid_params, "confirm_password"), @config)
+      assert {:error, _changeset} = Context.create(Map.delete(@valid_params, "password_confirmation"), @config)
       assert {:ok, user} = Context.create(@valid_params, @config)
       assert user.custom == "custom"
       refute user.password
-      refute user.confirm_password
     end
 
     test "as `use Pow.Ecto.Context`" do
@@ -148,7 +147,7 @@ defmodule Pow.Ecto.ContextTest do
       "email" => "new@example.com",
       "custom" => "custom",
       "password" => "new_#{@password}",
-      "confirm_password" => "new_#{@password}",
+      "password_confirmation" => "new_#{@password}",
       "current_password" => @password
     }
 
@@ -165,7 +164,6 @@ defmodule Pow.Ecto.ContextTest do
       assert Context.authenticate(@valid_params, @config) == updated_user
       assert updated_user.custom == "custom"
       refute updated_user.password
-      refute updated_user.confirm_password
       refute updated_user.current_password
     end
 

--- a/test/pow/extension/ecto/schema_test.exs
+++ b/test/pow/extension/ecto/schema_test.exs
@@ -110,7 +110,7 @@ defmodule Pow.Extension.Ecto.SchemaTest do
   @valid_params %{
     "email" => "john.doe@example.com",
     "password" => @password,
-    "confirm_password" => @password,
+    "password_confirmation" => @password,
     "custom" => "valid"
   }
 

--- a/test/pow/phoenix/controllers/registration_controller_test.exs
+++ b/test/pow/phoenix/controllers/registration_controller_test.exs
@@ -16,8 +16,8 @@ defmodule Pow.Phoenix.RegistrationControllerTest do
       assert html =~ "<input id=\"user_email\" name=\"user[email]\" type=\"text\">"
       assert html =~ "<label for=\"user_password\">Password</label>"
       assert html =~ "<input id=\"user_password\" name=\"user[password]\" type=\"password\">"
-      assert html =~ "<label for=\"user_confirm_password\">Confirm password</label>"
-      assert html =~ "<input id=\"user_confirm_password\" name=\"user[confirm_password]\" type=\"password\">"
+      assert html =~ "<label for=\"user_password_confirmation\">Password confirmation</label>"
+      assert html =~ "<input id=\"user_password_confirmation\" name=\"user[password_confirmation]\" type=\"password\">"
       assert html =~ "<a href=\"/session/new\">Sign in</a>"
     end
 

--- a/test/pow/phoenix/html/form_template_test.exs
+++ b/test/pow/phoenix/html/form_template_test.exs
@@ -8,7 +8,7 @@ defmodule Pow.Phoenix.HTML.FormTemplateTest do
     html = FormTemplate.render([
       {:text, {:changeset, :pow_user_id_field}},
       {:password, :password},
-      {:password, :confirm_password}
+      {:password, :password_confirmation}
     ])
 
     refute html =~ "<div class=\"form-group\">"
@@ -24,7 +24,7 @@ defmodule Pow.Phoenix.HTML.FormTemplateTest do
     html = FormTemplate.render([
       {:text, {:changeset, :pow_user_id_field}},
       {:password, :password},
-      {:password, :confirm_password}
+      {:password, :password_confirmation}
     ], bootstrap: true)
 
     assert html =~ "<div class=\"form-group\">"


### PR DESCRIPTION
Resolves #375 

Removes `:confirm_password` virtual field, and uses `password_confirmation` instead of `confirm_password` field param. This is backwards compatible for setups that uses `confirm_password`