### PR TITLE
Match on ecto constraint instead of error message

### DIFF
--- a/lib/extensions/email_confirmation/phoenix/controllers/controller_callbacks.ex
+++ b/lib/extensions/email_confirmation/phoenix/controllers/controller_callbacks.ex
@@ -99,8 +99,8 @@ defmodule PowEmailConfirmation.Phoenix.ControllerCallbacks do
 
   defp prevent_information_leak?(_conn, %{errors: errors}) do
     Enum.find_value(errors, false, fn
-      {:email, {"has already been taken", _keys}} -> true
-      _any                                        -> false
+      {:email, {_msg, [constraint: :unique, constraint_name: _name]}} -> true
+      _any                                                            -> false
     end)
   end
   defp prevent_information_leak?(_conn, _changeset), do: false

--- a/test/extensions/email_confirmation/ecto/context_test.exs
+++ b/test/extensions/email_confirmation/ecto/context_test.exs
@@ -46,7 +46,7 @@ defmodule PowEmailConfirmation.Ecto.ContextTest do
       user = %{@user | unconfirmed_email: "taken@example.com"}
 
       assert {:error, changeset} = Context.confirm_email(user, @config)
-      assert changeset.errors[:email] == {"has already been taken", []}
+      assert changeset.errors[:email] == {"has already been taken", constraint: :unique, constraint_name: "users_email_index"}
     end
   end
 

--- a/test/extensions/email_confirmation/ecto/schema_test.exs
+++ b/test/extensions/email_confirmation/ecto/schema_test.exs
@@ -118,7 +118,7 @@ defmodule PowEmailConfirmation.Ecto.SchemaTest do
         |> User.changeset(Map.put(@valid_params, :email, "taken@example.com"))
         |> RepoMock.update([])
 
-      assert changeset.errors[:email] == {"has already been taken", [validation: :unsafe_unique, fields: [:email]]}
+      assert changeset.errors[:email] == {"has already been taken", validation: :unsafe_unique, fields: [:email]}
       assert Ecto.Changeset.get_change(changeset, :email) == "taken@example.com"
       assert Ecto.Changeset.get_change(changeset, :unconfirmed_email) == "taken@example.com"
     end

--- a/test/pow/ecto/schema/changeset_test.exs
+++ b/test/pow/ecto/schema/changeset_test.exs
@@ -92,7 +92,7 @@ defmodule Pow.Ecto.Schema.ChangesetTest do
         %User{}
         |> User.changeset(@valid_params)
         |> Repo.insert()
-      assert changeset.errors[:email] == {"has already been taken", [constraint: :unique, constraint_name: "users_email_index"]}
+      assert changeset.errors[:email] == {"has already been taken", constraint: :unique, constraint_name: "users_email_index"}
 
       {:ok, _user} =
         %UsernameUser{}
@@ -103,7 +103,7 @@ defmodule Pow.Ecto.Schema.ChangesetTest do
         %UsernameUser{}
         |> UsernameUser.changeset(@valid_params_username)
         |> Repo.insert()
-      assert changeset.errors[:username] == {"has already been taken", [constraint: :unique, constraint_name: "users_username_index"]}
+      assert changeset.errors[:username] == {"has already been taken", constraint: :unique, constraint_name: "users_username_index"}
     end
 
     test "requires password when password_hash is nil" do

--- a/test/support/extensions/email_confirmation/repo_mock.ex
+++ b/test/support/extensions/email_confirmation/repo_mock.ex
@@ -33,7 +33,7 @@ defmodule PowEmailConfirmation.Test.RepoMock do
   end
 
   def update(%{changes: %{email: "taken@example.com"}, valid?: true} = changeset, _opts) do
-    changeset = Ecto.Changeset.add_error(changeset, :email, "has already been taken")
+    changeset = Ecto.Changeset.add_error(changeset, :email, "has already been taken", constraint: :unique, constraint_name: "users_email_index")
 
     {:error, changeset}
   end
@@ -59,7 +59,7 @@ defmodule PowEmailConfirmation.Test.RepoMock do
 
   def insert(%{valid?: false} = changeset, _opts), do: {:error, %{changeset | action: :insert}}
   def insert(%{changes: %{email: "taken@example.com"}, valid?: true} = changeset, _opts) do
-    changeset = Ecto.Changeset.add_error(changeset, :email, "has already been taken")
+    changeset = Ecto.Changeset.add_error(changeset, :email, "has already been taken", constraint: :unique, constraint_name: "users_email_index")
 
     {:error, %{changeset | action: :insert}}
   end


### PR DESCRIPTION
It's probably better to match on the constraint rather than message.