### PR TITLE
Add pow_changeset to the custom changeset

### DIFF
--- a/guides/user_roles.md
+++ b/guides/user_roles.md
@@ -21,7 +21,7 @@ defmodule MyApp.Users.User do
 
   @spec changeset_role(Ecto.Schema.t() | Ecto.Changeset.t(), map()) :: Ecto.Changeset.t()
   def changeset_role(user_or_changeset, attrs) do
-    user_or_changeset
+    pow_changeset(user_or_changeset, attrs)
     |> Ecto.Changeset.cast(attrs, [:role])
     |> Ecto.Changeset.validate_inclusion(:role, ~w(user admin))
   end


### PR DESCRIPTION
Adding a changeset removes the default pow changeset validations. Most people probably don't want that to happen, so I think it'd be good to include a call to pow_changeset in the guide.