### PR TITLE
Refactor handling of stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.0.22 (TBA)
+
+### Enhancements
+
+* [`PowPersistentSession.Plug.Cookie`] Now stores the user struct instead of clauses
+
 ## v1.0.21 (2020-09-13)
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Enhancements
 
 * [`PowPersistentSession.Plug.Cookie`] Now stores the user struct instead of clauses
+* [`PowPersistentSession.Plug.Base`] Now includes `:pow_config` in the store config
+* [`PowResetPassword.Plug`] Now includes `:pow_config` in the store config
+* [`Pow.Plug.Base`] Now includes `:pow_config` in the store config
 
 ## v1.0.21 (2020-09-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [`Pow.Plug.Base`] Now includes `:pow_config` in the store config
 * [`Pow.Operations`] Added `Pow.Operations.reload/2` to reload structs
 * [`PowPersistentSession.Store.PersistentSessionCache`] Update `PowPersistentSession.Store.PersistentSessionCache.get/2` to reload the user using `Pow.Operations.reload/2`
+* [`Pow.Store.CredentialsCache`] Now support `reload: true` configuration so once fetched from the cache the user object will be reloaded through the context module
 
 ## v1.0.21 (2020-09-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 * [`PowPersistentSession.Plug.Base`] Now includes `:pow_config` in the store config
 * [`PowResetPassword.Plug`] Now includes `:pow_config` in the store config
 * [`Pow.Plug.Base`] Now includes `:pow_config` in the store config
+* [`Pow.Operations`] Added `Pow.Operations.reload/2` to reload structs
+* [`PowPersistentSession.Store.PersistentSessionCache`] Update `PowPersistentSession.Store.PersistentSessionCache.get/2` to reload the user using `Pow.Operations.reload/2`
 
 ## v1.0.21 (2020-09-13)
 

--- a/guides/api.md
+++ b/guides/api.md
@@ -108,7 +108,7 @@ defmodule MyAppWeb.APIAuthPlug do
       |> Conn.put_private(:api_renewal_token, sign_token(conn, renewal_token, config))
 
     CredentialsCache.put(store_config, access_token, {user, [renewal_token: renewal_token]})
-    PersistentSessionCache.put(store_config, renewal_token, {[id: user.id], [access_token: access_token]})
+    PersistentSessionCache.put(store_config, renewal_token, {user, [access_token: access_token]})
 
     {conn, user}
   end

--- a/guides/sync_user.md
+++ b/guides/sync_user.md
@@ -4,7 +4,15 @@ You may want to update the cached user credentials when an action outside of Pow
 
 In the following examples, we'll imagine that you've added a `plan` column on your `users` table. We may want to use that `plan` to give them access to certain controller actions. In this case, it's paramount that you load the user from the database.
 
-## Reload the user
+## Update `Pow.Store.CredentialsCache` config
+
+If you wish to load the user object each time it's fetched from the cache, all you have to do is to set `reload: true` for the `Pow.Store.CredentialsCache` config by adding this to your Pow config:
+
+```elixir
+credentials_cache_store: {Pow.Store.CredentialsCache, reload: true}
+```
+
+## Reload the user with a plug
 
 ```elixir
 defmodule MyAppWeb.ProPlanController do

--- a/lib/extensions/persistent_session/plug/base.ex
+++ b/lib/extensions/persistent_session/plug/base.ex
@@ -87,6 +87,7 @@ defmodule PowPersistentSession.Plug.Base do
     store_config
     |> Keyword.put_new(:backend, Config.get(config, :cache_store_backend, EtsCache))
     |> Keyword.put_new(:ttl, ttl(config))
+    |> Keyword.put_new(:pow_config, config)
   end
 
   @ttl :timer.hours(24) * 30

--- a/lib/extensions/persistent_session/store/persistent_session_cache.ex
+++ b/lib/extensions/persistent_session/store/persistent_session_cache.ex
@@ -4,17 +4,37 @@ defmodule PowPersistentSession.Store.PersistentSessionCache do
     ttl: :timer.hours(24) * 30,
     namespace: "persistent_session"
 
-  alias Pow.Store.Base
+  alias Pow.{Operations, Store.Base}
 
-  # TODO: Remove by 1.1.0
   @impl true
   def get(config, id) do
     config
     |> Base.get(backend_config(config), id)
     |> convert_old_value()
+    |> reload(config)
   end
 
+  # TODO: Remove by 1.1.0
   defp convert_old_value(:not_found), do: :not_found
   defp convert_old_value({user, metadata}), do: {user, metadata}
   defp convert_old_value(clauses) when is_list(clauses), do: {clauses, []}
+
+  defp reload(:not_found, _config), do: :not_found
+  # TODO: Remove by 1.1.0
+  defp reload({clauses, metadata}, config) when is_list(clauses) do
+    pow_config = Keyword.get(config, :pow_config)
+
+    case Operations.get_by(clauses, pow_config) do
+      nil  -> nil
+      user -> {user, metadata}
+    end
+  end
+  defp reload({user, metadata}, config) do
+    pow_config = Keyword.get(config, :pow_config)
+
+    case Operations.reload(user, pow_config) do
+      nil  -> nil
+      user -> {user, metadata}
+    end
+  end
 end

--- a/lib/extensions/persistent_session/store/persistent_session_cache.ex
+++ b/lib/extensions/persistent_session/store/persistent_session_cache.ex
@@ -22,7 +22,7 @@ defmodule PowPersistentSession.Store.PersistentSessionCache do
   defp reload(:not_found, _config), do: :not_found
   # TODO: Remove by 1.1.0
   defp reload({clauses, metadata}, config) when is_list(clauses) do
-    pow_config = Keyword.get(config, :pow_config)
+    pow_config = fetch_pow_config!(config)
 
     case Operations.get_by(clauses, pow_config) do
       nil  -> nil
@@ -30,11 +30,13 @@ defmodule PowPersistentSession.Store.PersistentSessionCache do
     end
   end
   defp reload({user, metadata}, config) do
-    pow_config = Keyword.get(config, :pow_config)
+    pow_config = fetch_pow_config!(config)
 
     case Operations.reload(user, pow_config) do
       nil  -> nil
       user -> {user, metadata}
     end
   end
+
+  defp fetch_pow_config!(config), do: Keyword.get(config, :pow_config) || raise "No `:pow_config` value found in the store config."
 end

--- a/lib/extensions/reset_password/plug.ex
+++ b/lib/extensions/reset_password/plug.ex
@@ -181,6 +181,8 @@ defmodule PowResetPassword.Plug do
   end
 
   defp store_opts(config, store_config \\ []) do
-    Keyword.put_new(store_config, :backend, Config.get(config, :cache_store_backend, EtsCache))
+    store_config
+    |> Keyword.put_new(:backend, Config.get(config, :cache_store_backend, EtsCache))
+    |> Keyword.put_new(:pow_config, config)
   end
 end

--- a/lib/pow/ecto/context.ex
+++ b/lib/pow/ecto/context.ex
@@ -216,18 +216,9 @@ defmodule Pow.Ecto.Context do
   defp reload_after_write({:ok, struct}, config) do
     # When ecto updates/inserts, has_many :through associations are set to nil.
     # So we'll just reload when writes happen.
-    opts    = repo_opts(config, [:prefix])
-    clauses = fetch_primary_key_values!(struct, config)
-    struct  = Config.repo!(config).get_by!(struct.__struct__, clauses, opts)
+    struct  = Operations.reload(struct, config) || raise "Record does not exist: #{inspect struct}"
 
     {:ok, struct}
-  end
-
-  defp fetch_primary_key_values!(struct, config) do
-    case Operations.fetch_primary_key_values(struct, config) do
-      {:error, error} -> raise error
-      {:ok, clauses}  -> clauses
-    end
   end
 
   # TODO: Remove by 1.1.0

--- a/lib/pow/operations.ex
+++ b/lib/pow/operations.ex
@@ -136,7 +136,7 @@ defmodule Pow.Operations do
   Takes a struct and will reload it.
 
   The clauses are fetched with `fetch_primary_key_values/2`, and the struct
-  loaded with `get_by/2`. A `RunTime` exception will be raised if the clauses
+  loaded with `get_by/2`. A `RuntimeError` exception will be raised if the clauses
   could not be fetched.
   """
   @spec reload(struct(), Config.t()) :: struct() | nil

--- a/lib/pow/operations.ex
+++ b/lib/pow/operations.ex
@@ -131,4 +131,19 @@ defmodule Pow.Operations do
     end
   end
   defp map_primary_key_values([], _struct, acc), do: {:ok, acc}
+
+  @doc """
+  Takes a struct and will reload it.
+
+  The clauses are fetched with `fetch_primary_key_values/2`, and the struct
+  loaded with `get_by/2`. A `RunTime` exception will be raised if the clauses
+  could not be fetched.
+  """
+  @spec reload(struct(), Config.t()) :: struct() | nil
+  def reload(struct, config) do
+    case fetch_primary_key_values(struct, config) do
+      {:error, error} -> raise error
+      {:ok, clauses}  -> get_by(clauses, config)
+    end
+  end
 end

--- a/lib/pow/plug/base.ex
+++ b/lib/pow/plug/base.ex
@@ -180,6 +180,8 @@ defmodule Pow.Plug.Base do
   end
 
   defp store_opts(config, store_config \\ []) do
-    Keyword.put_new(store_config, :backend, Config.get(config, :cache_store_backend, EtsCache))
+    store_config
+    |> Keyword.put_new(:backend, Config.get(config, :cache_store_backend, EtsCache))
+    |> Keyword.put_new(:pow_config, config)
   end
 end

--- a/lib/pow/store/credentials_cache.ex
+++ b/lib/pow/store/credentials_cache.ex
@@ -172,8 +172,10 @@ defmodule Pow.Store.CredentialsCache do
   defp user_to_struct_id!(_user, _config), do: raise "Only structs can be stored as credentials"
 
   defp fetch_primary_key_values!(user, config) do
+    pow_config = Keyword.get(config, :pow_config)
+
     user
-    |> Operations.fetch_primary_key_values(config)
+    |> Operations.fetch_primary_key_values(pow_config)
     |> case do
       {:error, error} -> raise error
       {:ok, clauses}  -> clauses

--- a/lib/pow/store/credentials_cache.ex
+++ b/lib/pow/store/credentials_cache.ex
@@ -166,6 +166,7 @@ defmodule Pow.Store.CredentialsCache do
   end
 
   defp maybe_reload(user, config) do
+    # TODO: By 1.1.0 set this to `true` and update docs
     case Keyword.get(config, :reload, false) do
       true  -> Operations.reload(user, fetch_pow_config!(config))
       _any -> user

--- a/test/extensions/persistent_session/phoenix/controllers/controller_callbacks_test.exs
+++ b/test/extensions/persistent_session/phoenix/controllers/controller_callbacks_test.exs
@@ -3,6 +3,7 @@ defmodule PowPersistentSession.Phoenix.ControllerCallbacksTest do
 
   alias Pow.Plug
   alias PowPersistentSession.{Plug.Cookie, Store.PersistentSessionCache}
+  alias PowPersistentSession.Test.Users.User
 
   @valid_params %{"email" => "test@example.com", "password" => "secret1234"}
   @max_age Integer.floor_div(:timer.hours(30) * 24, 1000)
@@ -14,7 +15,7 @@ defmodule PowPersistentSession.Phoenix.ControllerCallbacksTest do
 
       assert session_fingerprint = conn.private[:pow_session_metadata][:fingerprint]
       assert %{max_age: @max_age, path: "/", value: id} = conn.resp_cookies[@cookie_key]
-      assert get_from_cache(conn, id, backend: ets) == {[id: 1], session_metadata: [fingerprint: session_fingerprint]}
+      assert {%User{id: 1}, session_metadata: [fingerprint: ^session_fingerprint]} = get_from_cache(conn, id, backend: ets)
     end
 
     test "with persistent_session param set to false", %{conn: conn} do

--- a/test/extensions/persistent_session/phoenix/controllers/controller_callbacks_test.exs
+++ b/test/extensions/persistent_session/phoenix/controllers/controller_callbacks_test.exs
@@ -2,7 +2,7 @@ defmodule PowPersistentSession.Phoenix.ControllerCallbacksTest do
   use PowPersistentSession.TestWeb.Phoenix.ConnCase
 
   alias Pow.Plug
-  alias PowPersistentSession.{Plug.Cookie, Store.PersistentSessionCache}
+  alias PowPersistentSession.{Plug.Base, Plug.Cookie}
   alias PowPersistentSession.Test.{Users.User, RepoMock}
 
   @valid_params %{"email" => "test@example.com", "password" => "secret1234"}
@@ -10,13 +10,13 @@ defmodule PowPersistentSession.Phoenix.ControllerCallbacksTest do
   @cookie_key "persistent_session"
 
   describe "Pow.Phoenix.SessionController.create/2" do
-    test "generates cookie", %{conn: conn, ets: ets} do
+    test "generates cookie", %{conn: conn} do
       expected_user = RepoMock.get_by(User, [email: "test@example.com"], [])
       conn          = post conn, Routes.pow_session_path(conn, :create, %{"user" => @valid_params})
 
       assert session_fingerprint = conn.private[:pow_session_metadata][:fingerprint]
       assert %{max_age: @max_age, path: "/", value: id} = conn.resp_cookies[@cookie_key]
-      assert {^expected_user, session_metadata: [fingerprint: ^session_fingerprint]} = get_from_cache(conn, id, backend: ets)
+      assert {^expected_user, session_metadata: [fingerprint: ^session_fingerprint]} = get_from_cache(conn, id)
     end
 
     test "with persistent_session param set to false", %{conn: conn} do
@@ -35,7 +35,7 @@ defmodule PowPersistentSession.Phoenix.ControllerCallbacksTest do
   end
 
   describe "Pow.Phoenix.SessionController.delete/2" do
-    test "expires cookie", %{conn: conn, ets: ets} do
+    test "expires cookie", %{conn: conn} do
       conn = post conn, Routes.pow_session_path(conn, :create, %{"user" => @valid_params})
 
       assert %{value: id} = conn.resp_cookies[@cookie_key]
@@ -43,13 +43,15 @@ defmodule PowPersistentSession.Phoenix.ControllerCallbacksTest do
       conn = delete conn, Routes.pow_session_path(conn, :delete)
 
       assert conn.resp_cookies[@cookie_key] == %{max_age: 0, path: "/", universal_time: {{1970, 1, 1}, {0, 0, 0}}}
-      assert get_from_cache(conn, id, backend: ets) == :not_found
+      assert get_from_cache(conn, id) == :not_found
     end
   end
 
-  defp get_from_cache(conn, token, config) do
+  defp get_from_cache(conn, token) do
     assert {:ok, token} = Plug.verify_token(conn, Atom.to_string(Cookie), token)
 
-    PersistentSessionCache.get(config, token)
+    {store, opts} = Base.store(conn.private[:pow_config])
+
+    store.get(opts, token)
   end
 end

--- a/test/extensions/persistent_session/plug/cookie_test.exs
+++ b/test/extensions/persistent_session/plug/cookie_test.exs
@@ -5,8 +5,8 @@ defmodule PowPersistentSession.Plug.CookieTest do
   alias Plug.{Conn, ProcessStore, Test}
   alias Plug.Session, as: PlugSession
   alias Pow.{Plug, Plug.Session}
-  alias PowPersistentSession.{Plug.Cookie, Store.PersistentSessionCache}
-  alias PowPersistentSession.Test.Users.User
+  alias PowPersistentSession.{Plug.Cookie, Plug.Base, Store.PersistentSessionCache}
+  alias PowPersistentSession.Test.{Users.User, RepoMock}
   alias Pow.Test.EtsCacheMock
 
   @cookie_key "persistent_session"
@@ -18,8 +18,9 @@ defmodule PowPersistentSession.Plug.CookieTest do
 
     config = PowPersistentSession.Test.pow_config()
     conn   = conn_with_session_plug(config)
+    user   = RepoMock.get_by(User, [id: 1], [])
 
-    {:ok, conn: conn, config: config, ets: EtsCacheMock}
+    {:ok, conn: conn, config: config, user: user}
   end
 
   test "call/2 sets pow_persistent_session plug in conn", %{conn: conn, config: config} do
@@ -30,9 +31,8 @@ defmodule PowPersistentSession.Plug.CookieTest do
     refute conn.resp_cookies[@cookie_key]
   end
 
-  test "call/2 assigns user from cookie", %{conn: conn, ets: ets} do
-    user = %User{id: 1}
-    id   = store_in_cache(conn, "test", {user, []}, backend: ets)
+  test "call/2 assigns user from cookie", %{conn: conn, user: user} do
+    id   = store_in_cache(conn, "test", {user, []})
     conn =
       conn
       |> persistent_cookie(@cookie_key, id)
@@ -41,8 +41,8 @@ defmodule PowPersistentSession.Plug.CookieTest do
     assert Plug.current_user(conn) == user
     assert %{value: new_id, max_age: @max_age, path: "/"} = conn.resp_cookies[@cookie_key]
     refute new_id == id
-    assert get_from_cache(conn, id, backend: ets) == :not_found
-    assert get_from_cache(conn, new_id, backend: ets) == {user, []}
+    assert get_from_cache(conn, id) == :not_found
+    assert get_from_cache(conn, new_id) == {user, []}
   end
 
   defmodule PersistentSessionCacheWaitDelete do
@@ -67,12 +67,11 @@ defmodule PowPersistentSession.Plug.CookieTest do
     end
   end
 
-  test "call/2 assigns user from cookie and doesn't expire with simultanous request", %{conn: conn, ets: ets} do
+  test "call/2 assigns user from cookie and doesn't expire with simultanous request", %{conn: conn, user: user} do
     :ets.delete(EtsCacheMock)
     :ets.new(EtsCacheMock, [:ordered_set, :public, :named_table])
 
-    user   = %User{id: 1}
-    id     = store_in_cache(conn, "test", {user, []}, backend: ets)
+    id     = store_in_cache(conn, "test", {user, []})
     conn   = persistent_cookie(conn, @cookie_key, id)
     config = [persistent_session_store: {PersistentSessionCacheWaitDelete, ttl: :timer.hours(24) * 30, namespace: "persistent_session"}]
 
@@ -112,9 +111,8 @@ defmodule PowPersistentSession.Plug.CookieTest do
     task
   end
 
-  test "call/2 assigns user from cookie passing fingerprint to the session metadata", %{conn: conn, ets: ets} do
-    user = %User{id: 1}
-    id   = store_in_cache(conn, "test", {user, session_metadata: [fingerprint: "fingerprint"]}, backend: ets)
+  test "call/2 assigns user from cookie passing fingerprint to the session metadata", %{conn: conn, user: user} do
+    id   = store_in_cache(conn, "test", {user, session_metadata: [fingerprint: "fingerprint"]})
     conn =
       conn
       |> persistent_cookie(@cookie_key, id)
@@ -123,14 +121,13 @@ defmodule PowPersistentSession.Plug.CookieTest do
     assert Plug.current_user(conn) == user
     assert %{value: new_id, max_age: @max_age, path: "/"} = conn.resp_cookies[@cookie_key]
     refute new_id == id
-    assert get_from_cache(conn, id, backend: ets) == :not_found
-    assert get_from_cache(conn, new_id, backend: ets) == {user, session_metadata: [fingerprint: "fingerprint"]}
+    assert get_from_cache(conn, id) == :not_found
+    assert get_from_cache(conn, new_id) == {user, session_metadata: [fingerprint: "fingerprint"]}
     assert conn.private[:pow_session_metadata][:fingerprint] == "fingerprint"
   end
 
-  test "call/2 assigns user from cookie passing custom metadata to session metadata", %{conn: conn, ets: ets} do
-    user = %User{id: 1}
-    id   = store_in_cache(conn, "test", {user, session_metadata: [a: 1, b: 2, fingerprint: "fingerprint"]}, backend: ets)
+  test "call/2 assigns user from cookie passing custom metadata to session metadata", %{conn: conn, user: user} do
+    id   = store_in_cache(conn, "test", {user, session_metadata: [a: 1, b: 2, fingerprint: "fingerprint"]})
     conn =
       conn
       |> persistent_cookie(@cookie_key, id)
@@ -140,14 +137,13 @@ defmodule PowPersistentSession.Plug.CookieTest do
 
     assert Plug.current_user(conn) == user
     assert %{value: id, max_age: @max_age, path: "/"} = conn.resp_cookies[@cookie_key]
-    assert get_from_cache(conn, id, backend: ets) == {user, session_metadata: [fingerprint: "new_fingerprint", b: 2, a: 2]}
+    assert get_from_cache(conn, id) == {user, session_metadata: [fingerprint: "new_fingerprint", b: 2, a: 2]}
     assert [inserted_at: _, b: 2, a: 3, fingerprint: "new_fingerprint"] = conn.private[:pow_session_metadata]
   end
 
-  test "call/2 assigns user from cookie with prepended `:otp_app`", %{config: config, ets: ets} do
-    user = %User{id: 1}
+  test "call/2 assigns user from cookie with prepended `:otp_app`", %{config: config, user: user} do
     conn = conn_with_session_plug(config ++ [otp_app: :test_app])
-    id   = store_in_cache(conn, "test_app_test", {user, []}, backend: ets)
+    id   = store_in_cache(conn, "test_app_test", {user, []})
     conn =
       conn
       |> persistent_cookie("test_app_" <> @cookie_key, id)
@@ -157,12 +153,11 @@ defmodule PowPersistentSession.Plug.CookieTest do
     assert %{value: new_id, max_age: @max_age, path: "/"} = conn.resp_cookies["test_app_" <> @cookie_key]
     assert {:ok, decoded_id} = Plug.verify_token(conn, Atom.to_string(Cookie), new_id)
     assert String.starts_with?(decoded_id, "test_app")
-    assert get_from_cache(conn, new_id, backend: ets) == {user, []}
+    assert get_from_cache(conn, new_id) == {user, []}
   end
 
-  test "call/2 when user already assigned", %{conn: conn, ets: ets} do
-    user = %User{id: 1}
-    id   = store_in_cache(conn, "test", {user, []}, backend: ets)
+  test "call/2 when user already assigned", %{conn: conn, user: user} do
+    id   = store_in_cache(conn, "test", {user, []})
     conn =
       conn
       |> persistent_cookie(@cookie_key, id)
@@ -170,12 +165,12 @@ defmodule PowPersistentSession.Plug.CookieTest do
       |> run_plug()
 
     refute conn.resp_cookies[@cookie_key]
-    assert get_from_cache(conn, id, backend: ets) == {user, []}
+    assert get_from_cache(conn, id) == {user, []}
   end
 
-  test "call/2 when user doesn't exist in database", %{conn: conn, ets: ets} do
+  test "call/2 when user doesn't exist in database", %{conn: conn} do
     user = %User{id: -1}
-    id   = store_in_cache(conn, "test", {user, []}, backend: ets)
+    id   = store_in_cache(conn, "test", {user, []})
     conn =
       conn
       |> persistent_cookie(@cookie_key, id)
@@ -183,13 +178,12 @@ defmodule PowPersistentSession.Plug.CookieTest do
 
     refute Plug.current_user(conn)
     refute conn.resp_cookies[@cookie_key]
-    assert get_from_cache(conn, id, backend: ets) == :not_found
+    assert get_from_cache(conn, id) == :not_found
   end
 
-  test "call/2 with unsigned token", %{conn: conn, ets: ets} do
-    user = %User{id: 1}
+  test "call/2 with unsigned token", %{conn: conn, user: user} do
     id = "test"
-    store_in_cache(conn, id, {user, []}, backend: ets)
+    store_in_cache(conn, id, {user, []})
     conn =
       conn
       |> persistent_cookie(@cookie_key, id)
@@ -197,7 +191,8 @@ defmodule PowPersistentSession.Plug.CookieTest do
 
     refute Plug.current_user(conn)
     refute conn.resp_cookies[@cookie_key]
-    assert PersistentSessionCache.get([backend: ets], id) == {user, []}
+
+    assert get_unsigned_from_cache(id) == {user, []}
   end
 
   test "call/2 when persistent session cache doesn't have credentials", %{conn: conn} do
@@ -210,9 +205,9 @@ defmodule PowPersistentSession.Plug.CookieTest do
     refute conn.resp_cookies[@cookie_key]
   end
 
-  test "call/2 handles clause error", %{conn: conn, ets: ets} do
+  test "call/2 handles clause error", %{conn: conn} do
     user = %User{id: nil}
-    id   = store_in_cache(conn, "test", {user, []}, backend: ets)
+    id   = store_in_cache(conn, "test", {user, []})
 
     assert_raise RuntimeError, "Primary key value for key `:id` in #{inspect User} can't be `nil`", fn ->
       conn
@@ -222,9 +217,8 @@ defmodule PowPersistentSession.Plug.CookieTest do
    end
 
   # TODO: Remove by 1.1.0
-  test "call/2 is backwards-compatible with user fetch clause", %{conn: conn, ets: ets} do
-    user = %User{id: 1}
-    id   = store_in_cache(conn, "test", {[id: user.id], []}, backend: ets)
+  test "call/2 is backwards-compatible with user fetch clause", %{conn: conn, user: user} do
+    id   = store_in_cache(conn, "test", {[id: user.id], []})
     conn =
       conn
       |> persistent_cookie(@cookie_key, id)
@@ -233,14 +227,13 @@ defmodule PowPersistentSession.Plug.CookieTest do
     assert Plug.current_user(conn) == user
     assert %{value: new_id, max_age: @max_age, path: "/"} = conn.resp_cookies[@cookie_key]
     refute new_id == id
-    assert get_from_cache(conn, id, backend: ets) == :not_found
-    assert get_from_cache(conn, new_id, backend: ets) == {user, []}
+    assert get_from_cache(conn, id) == :not_found
+    assert get_from_cache(conn, new_id) == {user, []}
   end
 
   # TODO: Remove by 1.1.0
-  test "call/2 is backwards-compatible with just user fetch clause", %{conn: conn, ets: ets} do
-    user = %User{id: 1}
-    id   = store_in_cache(conn, "test", [id: user.id], backend: ets)
+  test "call/2 is backwards-compatible with just user fetch clause", %{conn: conn, user: user} do
+    id   = store_in_cache(conn, "test", [id: user.id])
     conn =
       conn
       |> persistent_cookie(@cookie_key, id)
@@ -249,14 +242,13 @@ defmodule PowPersistentSession.Plug.CookieTest do
     assert Plug.current_user(conn) == user
     assert %{value: new_id, max_age: @max_age, path: "/"} = conn.resp_cookies[@cookie_key]
     refute new_id == id
-    assert get_from_cache(conn, id, backend: ets) == :not_found
-    assert get_from_cache(conn, new_id, backend: ets) == {user, []}
+    assert get_from_cache(conn, id) == :not_found
+    assert get_from_cache(conn, new_id) == {user, []}
   end
 
   # TODO: Remove by 1.1.0
-  test "call/2 is backwards-compatible with `:session_fingerprint` metadata", %{conn: conn, ets: ets} do
-    user = %User{id: 1}
-    id   = store_in_cache(conn, "test", {user, session_fingerprint: "fingerprint"}, backend: ets)
+  test "call/2 is backwards-compatible with `:session_fingerprint` metadata", %{conn: conn, user: user} do
+    id   = store_in_cache(conn, "test", {user, session_fingerprint: "fingerprint"})
     conn =
       conn
       |> persistent_cookie(@cookie_key, id)
@@ -265,17 +257,17 @@ defmodule PowPersistentSession.Plug.CookieTest do
     assert Plug.current_user(conn) == user
     assert %{value: new_id, max_age: @max_age, path: "/"} = conn.resp_cookies[@cookie_key]
     refute new_id == id
-    assert get_from_cache(conn, id, backend: ets) == :not_found
-    assert get_from_cache(conn, new_id, backend: ets) == {user, session_metadata: [fingerprint: "fingerprint"]}
+    assert get_from_cache(conn, id) == :not_found
+    assert get_from_cache(conn, new_id) == {user, session_metadata: [fingerprint: "fingerprint"]}
     assert conn.private[:pow_session_metadata][:fingerprint] == "fingerprint"
   end
 
-  test "create/3 with custom TTL", %{conn: conn, config: config} do
+  test "create/3 with custom TTL", %{conn: conn, config: config, user: user} do
     config = Keyword.put(config, :persistent_session_ttl, 1000)
     conn   =
       conn
       |> init_plug(config)
-      |> run_create(%User{id: 1}, config)
+      |> run_create(user, config)
 
     assert_received {:ets, :put, [{_key, _value} | _rest], config}
     assert config[:ttl] == 1000
@@ -283,12 +275,12 @@ defmodule PowPersistentSession.Plug.CookieTest do
     assert %{max_age: 1, path: "/"} = conn.resp_cookies[@cookie_key]
   end
 
-  test "create/3 with custom cookie options", %{conn: conn, config: config} do
+  test "create/3 with custom cookie options", %{conn: conn, config: config, user: user} do
     config = Keyword.put(config, :persistent_session_cookie_opts, @custom_cookie_opts)
     conn   =
       conn
       |> init_plug(config)
-      |> run_create(%User{id: 1}, config)
+      |> run_create(user, config)
 
     assert %{
       domain: "domain.com",
@@ -300,33 +292,30 @@ defmodule PowPersistentSession.Plug.CookieTest do
     } = conn.resp_cookies[@cookie_key]
   end
 
-  test "create/3 deletes previous persistent session", %{conn: conn, config: config, ets: ets} do
-    user = %User{id: 1}
-    id   = store_in_cache(conn, "previous_persistent_session", {user, []}, backend: ets)
+  test "create/3 deletes previous persistent session", %{conn: conn, config: config, user: user} do
+    id   = store_in_cache(conn, "previous_persistent_session", {user, []})
     conn = persistent_cookie(conn, @cookie_key, id)
 
-    assert get_from_cache(conn, id, backend: ets) == {user, []}
+    assert get_from_cache(conn, id) == {user, []}
 
     conn
     |> init_plug(config)
     |> run_create(user, config)
 
     assert_received {:ets, :put, [{_key, {^user, []}}], _config}
-    assert get_from_cache(conn, id, backend: ets) == :not_found
+    assert get_from_cache(conn, id) == :not_found
   end
 
-  test "create/3 with `[:pow_session_metadata][:fingerprint]` defined in conn.private", %{conn: conn, config: config} do
+  test "create/3 with `[:pow_session_metadata][:fingerprint]` defined in conn.private", %{conn: conn, config: config, user: user} do
     conn
     |> Conn.put_private(:pow_session_metadata, fingerprint: "fingerprint")
     |> init_plug(config)
-    |> run_create(%User{id: 1}, config)
+    |> run_create(user, config)
 
     assert_received {:ets, :put, [{_key, {user, session_metadata: [fingerprint: "fingerprint"]}}], _config}
   end
 
-  test "create/3 with custom metadata", %{conn: conn, config: config} do
-    user = %User{id: 1}
-
+  test "create/3 with custom metadata", %{conn: conn, config: config, user: user} do
     conn
     |> Conn.put_private(:pow_persistent_session_metadata, session_metadata: [a: 1])
     |> init_plug(config)
@@ -335,9 +324,8 @@ defmodule PowPersistentSession.Plug.CookieTest do
     assert_received {:ets, :put, [{_key, {user, session_metadata: [a: 1]}}], _config}
   end
 
-  test "delete/3", %{conn: conn, ets: ets, config: config} do
-    user = %User{id: 1}
-    id   = store_in_cache(conn, "test", {user, []}, backend: ets)
+  test "delete/3", %{conn: conn, config: config, user: user} do
+    id   = store_in_cache(conn, "test", {user, []})
     conn =
       conn
       |> persistent_cookie(@cookie_key, id)
@@ -345,12 +333,11 @@ defmodule PowPersistentSession.Plug.CookieTest do
       |> run_delete(config)
 
     assert conn.resp_cookies[@cookie_key] == %{max_age: 0, path: "/", universal_time: {{1970, 1, 1}, {0, 0, 0}}}
-    assert get_from_cache(conn, id, backend: ets) == :not_found
+    assert get_from_cache(conn, id) == :not_found
   end
 
-  test "delete/3 with custom cookie options", %{conn: conn, ets: ets, config: config} do
-    user   = %User{id: 1}
-    id     = store_in_cache(conn, "test", {user, []}, backend: ets)
+  test "delete/3 with custom cookie options", %{conn: conn, config: config, user: user} do
+    id     = store_in_cache(conn, "test", {user, []})
     config = Keyword.put(config, :persistent_session_cookie_opts, @custom_cookie_opts)
     conn   =
       conn
@@ -359,7 +346,7 @@ defmodule PowPersistentSession.Plug.CookieTest do
       |> run_delete(config)
 
     assert conn.resp_cookies[@cookie_key] == %{max_age: 0, universal_time: {{1970, 1, 1}, {0, 0, 0}}, path: "/path", domain: "domain.com", extra: "SameSite=Lax", http_only: false, secure: true}
-    assert get_from_cache(conn, id, backend: ets) == :not_found
+    assert get_from_cache(conn, id) == :not_found
   end
 
   defp conn_with_session_plug(config) do
@@ -396,15 +383,23 @@ defmodule PowPersistentSession.Plug.CookieTest do
     |> Conn.send_resp(200, "")
   end
 
-  defp store_in_cache(conn, token, value, config) do
-    PersistentSessionCache.put(config, token, value)
+  defp store_in_cache(conn, token, value) do
+    {store, opts} = Base.store(conn.private[:pow_config])
+
+    store.put(opts, token, value)
 
     Plug.sign_token(conn, Atom.to_string(Cookie), token)
   end
 
-  defp get_from_cache(conn, token, config) do
+  defp get_from_cache(conn, token) do
     assert {:ok, token} = Plug.verify_token(conn, Atom.to_string(Cookie), token)
 
-    PersistentSessionCache.get(config, token)
+    get_unsigned_from_cache(token)
+  end
+
+  defp get_unsigned_from_cache(token) do
+    {store, opts} = Base.store(PowPersistentSession.Test.pow_config())
+
+    store.get(opts, token)
   end
 end

--- a/test/extensions/reset_password/phoenix/controllers/reset_password_controller_test.exs
+++ b/test/extensions/reset_password/phoenix/controllers/reset_password_controller_test.exs
@@ -174,14 +174,6 @@ defmodule PowResetPassword.Phoenix.ResetPasswordControllerTest do
 
       assert {:ok, _conn} = Plug.load_user_by_token(conn, token)
     end
-
-    test "with missing user", %{conn: conn} do
-      token = create_reset_token(conn, "missing@example.com")
-      conn  = put conn, Routes.pow_reset_password_reset_password_path(conn, :update, token, @valid_params)
-
-      assert redirected_to(conn) == Routes.pow_session_path(conn, :new)
-      assert get_flash(conn, :info) == "The password has been updated."
-    end
   end
 
   defp create_reset_token(conn, email) do

--- a/test/pow/ecto/context_test.exs
+++ b/test/pow/ecto/context_test.exs
@@ -39,6 +39,12 @@ defmodule Pow.Ecto.ContextTest do
     def get_by([email: :test]), do: %User{email: :ok, password_hash: Password.pbkdf2_hash("secret1234")}
   end
 
+  defmodule ReloadErrorUsers do
+    use Context, repo: Repo, user: User
+
+    def get_by([id: _any]), do: nil
+  end
+
   describe "authenticate/2" do
     @password "secret1234"
     @valid_params %{"email" => "test@example.com", "password" => @password}
@@ -143,6 +149,12 @@ defmodule Pow.Ecto.ContextTest do
 
       assert Users.create(:test_macro) == :ok
     end
+
+    test "when can't be reloaded after write" do
+      assert_raise RuntimeError, ~r/Record does not exist: %Pow.Test.Ecto.Users.User{/, fn ->
+        Context.create(@valid_params, @config ++ [users_context: ReloadErrorUsers])
+      end
+    end
   end
 
   describe "update/2" do
@@ -176,6 +188,12 @@ defmodule Pow.Ecto.ContextTest do
       refute user.password
 
       assert Users.update(user, :test_macro) == :ok
+    end
+
+    test "when can't be reloaded after write", %{user: user} do
+      assert_raise RuntimeError, ~r/Record does not exist: %Pow.Test.Ecto.Users.User{/, fn ->
+        Context.update(user, @valid_params, @config ++ [users_context: ReloadErrorUsers])
+      end
     end
   end
 

--- a/test/support/extensions/email_confirmation/repo_mock.ex
+++ b/test/support/extensions/email_confirmation/repo_mock.ex
@@ -14,6 +14,7 @@ defmodule PowEmailConfirmation.Test.RepoMock do
     }, state: :loaded)
   end
 
+  def get_by(User, [id: 1], _opts), do: Process.get({:user, 1})
   def get_by(User, [email: "test@example.com"], _opts), do: user()
   def get_by(User, [email: "with-unconfirmed-changed-email@example.com"], _opts) do
     %{user() | unconfirmed_email: "new@example.com", email_confirmed_at: DateTime.utc_now()}
@@ -73,17 +74,14 @@ defmodule PowEmailConfirmation.Test.RepoMock do
     {:ok, user}
   end
 
-  def get_by!(User, [id: 1], _opts), do: Process.get({:user, 1})
-
   defmodule Invitation do
     @moduledoc false
     alias PowEmailConfirmation.PowInvitation.Test.Users.User
     alias PowEmailConfirmation.Test.RepoMock
 
+    def get_by(User, [id: 1], _opts), do: Process.get({:user, 1})
     def get_by(User, [invitation_token: "token"], _opts), do: Ecto.put_meta(%User{id: 1, email: "test@example.com"}, state: :loaded)
 
     def update(changeset, opts), do: RepoMock.update(changeset, opts)
-
-    def get_by!(User, [id: 1], _opts), do: Process.get({:user, 1})
   end
 end

--- a/test/support/extensions/email_confirmation/repo_mock.ex
+++ b/test/support/extensions/email_confirmation/repo_mock.ex
@@ -3,11 +3,13 @@ defmodule PowEmailConfirmation.Test.RepoMock do
   alias Pow.Ecto.Schema.Password
   alias PowEmailConfirmation.Test.Users.User
 
+  @password_hash Password.pbkdf2_hash("secret1234")
+
   defp user() do
     Ecto.put_meta(%User{
       id: 1,
       email: "test@example.com",
-      password_hash: Password.pbkdf2_hash("secret1234"),
+      password_hash: @password_hash,
       email_confirmation_token: "valid"
     }, state: :loaded)
   end

--- a/test/support/extensions/invitation/repo_mock.ex
+++ b/test/support/extensions/invitation/repo_mock.ex
@@ -27,8 +27,7 @@ defmodule PowInvitation.Test.RepoMock do
   end
   def insert(%{valid?: false} = changeset, _opts), do: {:error, %{changeset | action: :insert}}
 
-  def get_by!(User, [id: 1], _opts), do: Process.get({:user, 1})
-
+  def get_by(User, [id: 1], _opts), do: Process.get({:user, 1})
   def get_by(User, [invitation_token: "valid"], _opts), do: %{@user | invitation_token: "valid"}
   def get_by(User, [invitation_token: "valid_but_accepted"], _opts), do: %{@user | invitation_accepted_at: :now}
   def get_by(User, [invitation_token: "invalid"], _opts), do: nil

--- a/test/support/extensions/persistent_session/repo_mock.ex
+++ b/test/support/extensions/persistent_session/repo_mock.ex
@@ -3,11 +3,10 @@ defmodule PowPersistentSession.Test.RepoMock do
   alias Pow.Ecto.Schema.Password
   alias PowPersistentSession.Test.Users.User
 
-  def get_by(User, [id: 1], _opts), do: %User{id: 1}
+  @user %User{id: 1, email: "test@example.com", password_hash: Password.pbkdf2_hash("secret1234")}
+
+  def get_by(User, [id: 1], _opts), do: @user
   def get_by(User, [id: -1], _opts), do: nil
 
-  @password_hash Password.pbkdf2_hash("secret1234")
-
-  def get_by(User, [email: "test@example.com"], _opts),
-    do: %User{id: 1, password_hash: @password_hash}
+  def get_by(User, [email: "test@example.com"], _opts), do: @user
 end

--- a/test/support/extensions/persistent_session/repo_mock.ex
+++ b/test/support/extensions/persistent_session/repo_mock.ex
@@ -7,6 +7,5 @@ defmodule PowPersistentSession.Test.RepoMock do
 
   def get_by(User, [id: 1], _opts), do: @user
   def get_by(User, [id: -1], _opts), do: nil
-
   def get_by(User, [email: "test@example.com"], _opts), do: @user
 end

--- a/test/support/extensions/persistent_session/repo_mock.ex
+++ b/test/support/extensions/persistent_session/repo_mock.ex
@@ -6,6 +6,8 @@ defmodule PowPersistentSession.Test.RepoMock do
   def get_by(User, [id: 1], _opts), do: %User{id: 1}
   def get_by(User, [id: -1], _opts), do: nil
 
+  @password_hash Password.pbkdf2_hash("secret1234")
+
   def get_by(User, [email: "test@example.com"], _opts),
-    do: %User{id: 1, password_hash: Password.pbkdf2_hash("secret1234")}
+    do: %User{id: 1, password_hash: @password_hash}
 end

--- a/test/support/extensions/reset_password/repo_mock.ex
+++ b/test/support/extensions/reset_password/repo_mock.ex
@@ -4,9 +4,9 @@ defmodule PowResetPassword.Test.RepoMock do
 
   @user %User{id: 1}
 
+  def get_by(User, [id: 1], _opts), do: Process.get({:user, 1})
   def get_by(User, [email: "test@example.com"], _opts), do: @user
   def get_by(User, [email: "invalid@example.com"], _opts), do: nil
-  def get_by(User, [email: "missing@example.com"], _opts), do: %User{id: :missing}
 
   def update(%{valid?: true} = changeset, _opts) do
     user = Ecto.Changeset.apply_changes(changeset)
@@ -17,7 +17,4 @@ defmodule PowResetPassword.Test.RepoMock do
     {:ok, user}
   end
   def update(%{valid?: false} = changeset, _opts), do: {:error, %{changeset | action: :update}}
-
-  def get_by!(User, [id: 1], _opts), do: Process.get({:user, 1})
-  def get_by!(User, [id: :missing], _opts), do: nil
 end


### PR DESCRIPTION
In #386 an Ecto backend store is discussed, and I believe that it should be easier to handle it as association to user. I want to make the stores just pass on the user struct to the backend store instead of doing any transformations on the user.

With this setup, in persistent session store it would be essential to reload the user, so I've added an additional method to `Pow.Operations` that can convert a struct into a get clauses so it can be used in `get_by`. Not sure about the name of the method, but the approach feels right.

In this case both Ecto and Phoenix modules will rely on `Pow.Operations` as the way to convert back and fourth. I've thought of maybe having just a `reload` method in `Pow.Operations` instead, but the get clauses are necessary for `Pow.Store.CredentialsCache` to construct a key.

This PR DRYs up a few things as well. I'll have to give this some more thought, as I'm thinking that I should maybe commit smaller bits of this first.

Resolves #563