### PR TITLE
Refactor primary key clauses handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [`PowPersistentSession.Plug.Cookie`] Changed default cookie name to `persistent_session`
 * [`PowPersistentSession.Plug.Cookie`] Removed renewal of cookie as the token will always expire
 * [`PowPersistentSession.Plug.Cookie`] No longer expires invalid cookies
+* [`Pow.Operations`] Added `Pow.Operations.fetch_primary_key_values/2`
 
 ## Removed
 

--- a/lib/pow/ecto/context.ex
+++ b/lib/pow/ecto/context.ex
@@ -222,10 +222,18 @@ defmodule Pow.Ecto.Context do
   defp reload_after_write({:ok, struct}, config) do
     # When ecto updates/inserts, has_many :through associations are set to nil.
     # So we'll just reload when writes happen.
-    opts = repo_opts(config, [:prefix])
-    struct = Config.repo!(config).get!(struct.__struct__, struct.id, opts)
+    opts    = repo_opts(config, [:prefix])
+    clauses = fetch_primary_key_values!(struct, config)
+    struct  = Config.repo!(config).get_by!(struct.__struct__, clauses, opts)
 
     {:ok, struct}
+  end
+
+  defp fetch_primary_key_values!(struct, config) do
+    case Operations.fetch_primary_key_values(struct, config) do
+      {:error, error} -> raise error
+      {:ok, clauses}  -> clauses
+    end
   end
 
   # TODO: Remove by 1.1.0

--- a/test/extensions/email_confirmation/phoenix/controllers/confirmation_controller_test.exs
+++ b/test/extensions/email_confirmation/phoenix/controllers/confirmation_controller_test.exs
@@ -1,6 +1,8 @@
 defmodule PowEmailConfirmation.Phoenix.ConfirmationControllerTest do
   use PowEmailConfirmation.TestWeb.Phoenix.ConnCase
 
+  alias PowEmailConfirmation.Test.Users.User
+
   @session_key "auth"
 
   describe "show/2" do
@@ -51,7 +53,7 @@ defmodule PowEmailConfirmation.Phoenix.ConfirmationControllerTest do
       session_id = conn.private[:plug_session][@session_key]
       conn       =
         conn
-        |> Pow.Plug.assign_current_user(%{id: 1}, [])
+        |> Pow.Plug.assign_current_user(%User{id: 1}, [])
         |> get(Routes.pow_email_confirmation_confirmation_path(conn, :show, "valid"))
 
       assert redirected_to(conn) == Routes.pow_registration_path(conn, :edit)
@@ -63,7 +65,7 @@ defmodule PowEmailConfirmation.Phoenix.ConfirmationControllerTest do
       session_id = conn.private[:plug_session][@session_key]
       conn       =
         conn
-        |> Pow.Plug.assign_current_user(%{id: 2}, [])
+        |> Pow.Plug.assign_current_user(%User{id: 2}, [])
         |> get(Routes.pow_email_confirmation_confirmation_path(conn, :show, "valid"))
 
       assert redirected_to(conn) == Routes.pow_registration_path(conn, :edit)

--- a/test/extensions/persistent_session/plug/cookie_test.exs
+++ b/test/extensions/persistent_session/plug/cookie_test.exs
@@ -220,6 +220,12 @@ defmodule PowPersistentSession.Plug.CookieTest do
     assert %{max_age: 1, path: "/"} = conn.resp_cookies[@cookie_key]
   end
 
+  test "create/3 handles clause error", %{conn: conn, config: config} do
+    assert_raise RuntimeError, "Primary key value for key `:id` in #{inspect User} can't be `nil`", fn ->
+      Cookie.create(conn, %User{id: nil}, config)
+    end
+  end
+
   test "create/3 with custom cookie options", %{conn: conn, config: config} do
     config = Keyword.put(config, :persistent_session_cookie_opts, @custom_cookie_opts)
     conn   = Cookie.create(conn, %User{id: 1}, config)

--- a/test/pow/operations_test.exs
+++ b/test/pow/operations_test.exs
@@ -1,4 +1,59 @@
 defmodule Pow.OperationsTest do
   use ExUnit.Case
   doctest Pow.Operations
+
+  alias Pow.Operations
+
+  defmodule PrimaryFieldUser do
+    use Ecto.Schema
+
+    schema "users" do
+      timestamps()
+    end
+  end
+
+  defmodule NoPrimaryFieldUser do
+    use Ecto.Schema
+
+    @primary_key false
+    schema "users" do
+      timestamps()
+    end
+  end
+
+  defmodule CompositePrimaryFieldsUser do
+    use Ecto.Schema
+
+    @primary_key false
+    schema "users" do
+      field :some_id, :integer, primary_key: true
+      field :another_id, :integer, primary_key: true
+
+      timestamps()
+    end
+  end
+
+  defmodule NonEctoUser do
+    defstruct [:id]
+  end
+
+  @config []
+
+  describe "fetch_primary_key_values/2" do
+    test "handles nil primary key value" do
+      assert Operations.fetch_primary_key_values(%PrimaryFieldUser{id: nil}, @config) == {:error, "Primary key value for key `:id` in #{inspect PrimaryFieldUser} can't be `nil`"}
+      assert Operations.fetch_primary_key_values(%CompositePrimaryFieldsUser{}, @config) == {:error, "Primary key value for key `:some_id` in #{inspect CompositePrimaryFieldsUser} can't be `nil`"}
+      assert Operations.fetch_primary_key_values(%NonEctoUser{}, @config) == {:error, "Primary key value for key `:id` in #{inspect NonEctoUser} can't be `nil`"}
+    end
+
+    test "requires primary key" do
+      assert Operations.fetch_primary_key_values(%NoPrimaryFieldUser{}, @config) == {:error, "No primary keys found for #{inspect NoPrimaryFieldUser}"}
+    end
+
+    test "returns keyword list" do
+      assert Operations.fetch_primary_key_values(%PrimaryFieldUser{id: 1}, @config) == {:ok, id: 1}
+      assert Operations.fetch_primary_key_values(%CompositePrimaryFieldsUser{some_id: 1, another_id: 2}, @config) == {:ok, some_id: 1, another_id: 2}
+      assert Operations.fetch_primary_key_values(%NonEctoUser{id: 1}, @config) == {:ok, id: 1}
+    end
+  end
 end

--- a/test/support/extensions/email_confirmation/repo_mock.ex
+++ b/test/support/extensions/email_confirmation/repo_mock.ex
@@ -78,7 +78,7 @@ defmodule PowEmailConfirmation.Test.RepoMock do
     {:ok, user}
   end
 
-  def get!(User, 1, _opts), do: Process.get({:user, 1})
+  def get_by!(User, [id: 1], _opts), do: Process.get({:user, 1})
 
   defmodule Invitation do
     @moduledoc false
@@ -89,6 +89,6 @@ defmodule PowEmailConfirmation.Test.RepoMock do
 
     def update(changeset, opts), do: RepoMock.update(changeset, opts)
 
-    def get!(User, 1, _opts), do: Process.get({:user, 1})
+    def get_by!(User, [id: 1], _opts), do: Process.get({:user, 1})
   end
 end

--- a/test/support/extensions/invitation/repo_mock.ex
+++ b/test/support/extensions/invitation/repo_mock.ex
@@ -27,7 +27,7 @@ defmodule PowInvitation.Test.RepoMock do
   end
   def insert(%{valid?: false} = changeset, _opts), do: {:error, %{changeset | action: :insert}}
 
-  def get!(User, 1, _opts), do: Process.get({:user, 1})
+  def get_by!(User, [id: 1], _opts), do: Process.get({:user, 1})
 
   def get_by(User, [invitation_token: "valid"], _opts), do: %{@user | invitation_token: "valid"}
   def get_by(User, [invitation_token: "valid_but_accepted"], _opts), do: %{@user | invitation_accepted_at: :now}

--- a/test/support/extensions/reset_password/repo_mock.ex
+++ b/test/support/extensions/reset_password/repo_mock.ex
@@ -17,6 +17,6 @@ defmodule PowResetPassword.Test.RepoMock do
   end
   def update(%{valid?: false} = changeset, _opts), do: {:error, %{changeset | action: :update}}
 
-  def get!(User, 1, _opts), do: Process.get({:user, 1})
-  def get!(User, :missing, _opts), do: nil
+  def get_by!(User, [id: 1], _opts), do: Process.get({:user, 1})
+  def get_by!(User, [id: :missing], _opts), do: nil
 end


### PR DESCRIPTION
Moved this out of #392. It makes sense to move primary key logic over to operations instead of handling it in other module groups. With this, there is no expectation of certain structure for the user struct in the Plug/Phoenix/Store modules except for the clauses validation step in `PowPersistentSession.Plug.Cookie`.