### PR TITLE
Use `:before_send` callback with plugs for sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
 * [`PowPersistentSession.Plug.Cookie`] Removed renewal of cookie as the token will always expire
 * [`PowPersistentSession.Plug.Cookie`] No longer expires invalid cookies
 * [`Pow.Operations`] Added `Pow.Operations.fetch_primary_key_values/2`
+* [`PowPersistentSession.Plug.Base`] Now registers `:before_send` callbacks
+* [`PowPersistentSession.Plug.Cookie`] Now updates cookie and backend store in `:before_send` callback
+* [`Pow.Plug.Base`] Now registers `:before_send` callbacks
+* [`Pow.Plug.Session`] Now updates plug session and backend store in  `:before_send` callback
 
 ### Removed
 


### PR DESCRIPTION
In https://github.com/danschultzer/pow/issues/356#issuecomment-579633558 I discussed how the store might be updated before a response gets aborted. I haven't dug too much into how it all works, but I think this is the proper path after looking at how [`Plug.Session`](https://hexdocs.pm/plug/1.8.3/Plug.Session.html#content) handles writes in the `:before_send` callback with [`Plug.Conn.register_before_send/2`](https://hexdocs.pm/plug/1.8.3/Plug.Conn.html#register_before_send/2).

This PR makes so`PowPersistentSession.Plug.Cookie` and `Pow.Plug.Session` also uses `:before_send` callback for writes.