### PR TITLE
Rename `:session_store` to `:credentials_cache_store`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 ### Deprecations
 
 * [`Pow.Ecto.Changeset`] `Pow.Ecto.Schema.Changeset.confirm_password_changeset/3` has deprecated use of `:confirm_password` in params in favor of `:password_confirmation`
+* [`Pow.Plug.Session`] `:session_store` option has been renamed to `:credentials_cache_store`
 
 ## v1.0.16 (2020-01-07)
 


### PR DESCRIPTION
It's confusing to call it `:session_store` when the store module is called `Pow.Store.CredentialsCache` and the namespace is `credentials`. I'll review the other stores to see if the options are named right.