### PR TITLE
Add explicit methods for calling `do_create/3` and `do_delete/2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
 * [`PowPersistentSession.Plug.Cookie`] Now updates cookie and backend store in `:before_send` callback
 * [`Pow.Plug.Base`] Now registers `:before_send` callbacks
 * [`Pow.Plug.Session`] Now updates plug session and backend store in  `:before_send` callback
+* [`Pow.Plug`] Added `Pow.Plug.create/3`
+* [`Pow.Plug`] Added `Pow.Plug.delete/2`
 
 ### Removed
 
@@ -36,6 +38,7 @@
 
 * [`Pow.Ecto.Changeset`] `Pow.Ecto.Schema.Changeset.confirm_password_changeset/3` has deprecated use of `:confirm_password` in params in favor of `:password_confirmation`
 * [`Pow.Plug.Session`] `:session_store` option has been renamed to `:credentials_cache_store`
+* [`Pow.Plug`] `Pow.Plug.clear_authenticated_user/1` deprecated in favor of `Pow.Plug.delete/1`
 
 ## v1.0.16 (2020-01-07)
 

--- a/guides/api.md
+++ b/guides/api.md
@@ -251,9 +251,9 @@ defmodule MyAppWeb.API.V1.SessionController do
 
   @spec delete(Conn.t(), map()) :: Conn.t()
   def delete(conn, _params) do
-    {:ok, conn} = Pow.Plug.clear_authenticated_user(conn)
-
-    json(conn, %{data: %{}})
+    conn
+    |> Pow.Plug.delete()
+    |> json(conn, %{data: %{}})
   end
 end
 ```

--- a/guides/custom_controllers.md
+++ b/guides/custom_controllers.md
@@ -142,9 +142,9 @@ defmodule MyAppWeb.SessionController do
   end
 
   def delete(conn, _params) do
-    {:ok, conn} = Pow.Plug.clear_authenticated_user(conn)
-
-    redirect(conn, to: Routes.page_path(conn, :index))
+    conn
+    |> Pow.Plug.delete()
+    |> redirect(to: Routes.page_path(conn, :index))
   end
 end
 ```
@@ -213,7 +213,7 @@ defmodule MyAppWeb.SessionController do
 
       false ->
         conn
-        |> Pow.Plug.clear_authenticated_user()
+        |> Pow.Plug.delete()
         |> put_flash(:info, "Your e-mail address has not been confirmed.")
         |> redirect(to: Routes.login_path(conn, :new))
     end

--- a/guides/lock_users.md
+++ b/guides/lock_users.md
@@ -115,9 +115,8 @@ defmodule MyAppWeb.EnsureUserNotLockedPlug do
   defp locked?(_user), do: false
 
   defp maybe_halt(true, conn) do
-    {:ok, conn} = Plug.clear_authenticated_user(conn)
-
     conn
+    |> Plug.delete()
     |> Controller.put_flash(:error, "Sorry, your account is locked.")
     |> Controller.redirect(to: Routes.pow_session_path(conn, :new))
   end

--- a/guides/sync_user.md
+++ b/guides/sync_user.md
@@ -76,19 +76,14 @@ end
 
 Let's say that you want to show the user `plan` on most pages. In this case we can safely rely on the cached credentials since we don't need to know the actual value in the database. The worst case is that a different plan may be shown if you haven't ensured that all plan update actions uses the below method.
 
-We can use `do_create/3` defined in the `Pow.Plug.Base` macro to update the cached credentials.
+We can use `Pow.Plug.create/2` to call the plug and update the cached credentials.
 
 First we'll make a helper and import it to our controllers:
 
 ```elixir
 defmodule MyAppWeb.PowHelper do
   @spec sync_user(Plug.Conn.t(), map()) :: Plug.Conn.t()
-  def sync_user(conn, user) do
-    config = Pow.Plug.fetch_config(conn)
-    plug   = Pow.Plug.get_plug(config)
-
-    plug.do_create(conn, user, config)
-  end
+  def sync_user(conn, user), do: Pow.Plug.create(conn, user)
 end
 ```
 

--- a/lib/extensions/email_confirmation/phoenix/controllers/controller_callbacks.ex
+++ b/lib/extensions/email_confirmation/phoenix/controllers/controller_callbacks.ex
@@ -82,12 +82,12 @@ defmodule PowEmailConfirmation.Phoenix.ControllerCallbacks do
   end
 
   defp halt_and_send_confirmation_email(conn, return_path) do
-    user        = Plug.current_user(conn)
-    {:ok, conn} = Plug.clear_authenticated_user(conn)
+    send_confirmation_email(Plug.current_user(conn), conn)
 
-    send_confirmation_email(user, conn)
-
-    conn = redirect_with_email_confirmation_required(conn, return_path)
+    conn =
+      conn
+      |> Plug.delete()
+      |> redirect_with_email_confirmation_required(return_path)
 
     {:halt, conn}
   end

--- a/lib/extensions/email_confirmation/plug.ex
+++ b/lib/extensions/email_confirmation/plug.ex
@@ -58,7 +58,7 @@ defmodule PowEmailConfirmation.Plug do
 
   defp maybe_renew_conn(conn, user, config) do
     case equal_user?(user, Plug.current_user(conn, config), config) do
-      true  -> Plug.get_plug(config).do_create(conn, user, config)
+      true  -> Plug.create(conn, user, config)
       false -> conn
     end
   end

--- a/lib/extensions/invitation/plug.ex
+++ b/lib/extensions/invitation/plug.ex
@@ -54,7 +54,7 @@ defmodule PowInvitation.Plug do
     |> invited_user()
     |> InvitationContext.update(params, config)
     |> case do
-      {:ok, user}         -> {:ok, user, Plug.get_plug(config).do_create(conn, user, config)}
+      {:ok, user}         -> {:ok, user, Plug.create(conn, user, config)}
       {:error, changeset} -> {:error, changeset, conn}
     end
   end

--- a/lib/extensions/persistent_session/plug/cookie.ex
+++ b/lib/extensions/persistent_session/plug/cookie.ex
@@ -217,7 +217,6 @@ defmodule PowPersistentSession.Plug.Cookie do
   defp do_authenticate(conn, key_id, config) do
     {store, store_config} = store(config)
     res                   = store.get(store_config, key_id)
-    plug                  = Plug.get_plug(config)
 
     case res do
       :not_found ->
@@ -226,11 +225,11 @@ defmodule PowPersistentSession.Plug.Cookie do
       res ->
         expire_token_in_store(key_id, config)
 
-        fetch_and_auth_user(conn, res, plug, config)
+        fetch_and_auth_user(conn, res, config)
     end
   end
 
-  defp fetch_and_auth_user(conn, {clauses, metadata}, plug, config) do
+  defp fetch_and_auth_user(conn, {clauses, metadata}, config) do
     clauses
     |> filter_invalid!()
     |> Operations.get_by(config)
@@ -243,12 +242,12 @@ defmodule PowPersistentSession.Plug.Cookie do
         |> update_persistent_session_metadata(metadata)
         |> update_session_metadata(metadata)
         |> create(user, config)
-        |> plug.do_create(user, config)
+        |> Plug.create(user, config)
     end
   end
   # TODO: Remove by 1.1.0
-  defp fetch_and_auth_user(conn, user_id, plug, config),
-    do: fetch_and_auth_user(conn, {user_id, []}, plug, config)
+  defp fetch_and_auth_user(conn, user_id, config),
+    do: fetch_and_auth_user(conn, {user_id, []}, config)
 
   defp filter_invalid!([id: _value] = clauses), do: clauses
   defp filter_invalid!(clauses), do: raise "Invalid get_by clauses stored: #{inspect clauses}"

--- a/lib/pow/phoenix/controllers/session_controller.ex
+++ b/lib/pow/phoenix/controllers/session_controller.ex
@@ -52,7 +52,7 @@ defmodule Pow.Phoenix.SessionController do
 
   @doc false
   @spec process_delete(Conn.t(), map()) :: {:ok, Conn.t()}
-  def process_delete(conn, _params), do: Plug.clear_authenticated_user(conn)
+  def process_delete(conn, _params), do: {:ok, Plug.delete(conn)}
 
   @doc false
   @spec respond_delete({:ok, Conn.t()}) :: Conn.t()

--- a/test/pow/plug_test.exs
+++ b/test/pow/plug_test.exs
@@ -83,7 +83,7 @@ defmodule Pow.PlugTest do
     end
   end
 
-  test "clear_authenticated_user/1" do
+  test "delete/1" do
     EtsCacheMock.init()
 
     conn = auth_user_conn()
@@ -92,7 +92,7 @@ defmodule Pow.PlugTest do
     assert {key, _metadata} = EtsCacheMock.get([namespace: "credentials"], session_id)
     assert EtsCacheMock.get([namespace: "credentials"], key) == user
 
-    {:ok, conn} = Plug.clear_authenticated_user(conn)
+    conn = Plug.delete(conn)
     refute Plug.current_user(conn)
     refute fetch_session_id(conn)
     assert EtsCacheMock.get([namespace: "credentials"], session_id) == :not_found


### PR DESCRIPTION
It makes more sense to have proper methods in `Pow.Plug` to call the Pow plug set in the `conn` rather than messing around with `Pow.Plug.get_plug/2`.

Prompted by [the logic here](https://github.com/danschultzer/pow/issues/397#issuecomment-581348537):

```elixir
  defp create_session(conn, user) do
    config = Pow.Plug.fetch_config(conn)
    plug = Pow.Plug.get_plug(config)

    conn
    |> plug.do_create(user, config)
    |> PowPersistentSession.Plug.create(user)
  end
```

This could just be:

```elixir
  defp create_session(conn, user) do
    conn
    |> Pow.Plug.create(user)
    |> PowPersistentSession.Plug.create(user)
  end
```