### PR TITLE
Set global lock to prevent race condition when handling sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v1.0.19 (TBA)
+
+### Enhancements
+
+* [`Pow.Plug.Session`] Now sets a global lock when renewing the session
+* [`PowPersistentSession.Plug.Cookie`] Now sets a global lock when authenticating the user
+
 ## v1.0.18 (2020-02-14)
 
 ### Bug fixes

--- a/lib/extensions/persistent_session/plug/cookie.ex
+++ b/lib/extensions/persistent_session/plug/cookie.ex
@@ -175,9 +175,11 @@ defmodule PowPersistentSession.Plug.Cookie do
   If a persistent session cookie exists, it'll fetch the credentials from the
   persistent session cache.
 
-  If credentials was fetched successfully, the token in the cache is deleted, a
-  new session is created, and `create/2` is called to create a new persistent
-  session cookie.
+  If credentials was fetched successfully, a global lock is set and the token
+  in the cache is deleted, a new session is created, and `create/2` is called
+  to create a new persistent session cookie. If setting the lock failed, the
+  user will fetched will be set for the `conn` with
+  `Pow.Plug.assign_current_user/3`.
 
   If a `:session_metadata` keyword list is fetched from the persistent session
   metadata, all the values will be merged into the private
@@ -206,9 +208,7 @@ defmodule PowPersistentSession.Plug.Cookie do
         conn
 
       {token, {user, metadata}} ->
-        expire_token_in_store(token, config)
-
-        auth_user(conn, user, metadata, config)
+        lock_auth_user(conn, token, user, metadata, config)
     end
   end
 
@@ -228,6 +228,18 @@ defmodule PowPersistentSession.Plug.Cookie do
 
   defp filter_invalid!([id: _value] = clauses), do: clauses
   defp filter_invalid!(clauses), do: raise "Invalid get_by clauses stored: #{inspect clauses}"
+
+  defp lock_auth_user(conn, token, user, metadata, config) do
+    nodes = Node.list() ++ [node()]
+
+    case :global.set_lock({[__MODULE__, token], self()}, nodes, 0) do
+      true ->
+        auth_user(conn, user, metadata, config)
+
+      false ->
+        Plug.assign_current_user(conn, user, config)
+    end
+  end
 
   defp auth_user(conn, user, metadata, config) do
     conn

--- a/lib/pow/plug/session.ex
+++ b/lib/pow/plug/session.ex
@@ -115,8 +115,9 @@ defmodule Pow.Plug.Session do
 
   This will fetch a session from the credentials cache with the session id
   fetched through `Plug.Conn.get_session/2` session. If the credentials are
-  stale (timestamp is older than the `:session_ttl_renewal` value), the session
-  will be regenerated with `create/3`.
+  stale (timestamp is older than the `:session_ttl_renewal` value), a global
+  lock will be set, and the session will be regenerated with `create/3`.
+  Nothing happens if setting the lock failed.
 
   The metadata of the session will be assigned as a private
   `:pow_session_metadata` key in the conn so it may be used in `create/3`.
@@ -229,17 +230,26 @@ defmodule Pow.Plug.Session do
   defp convert_old_session_value(any), do: any
 
   defp handle_fetched_session_value({_session_id, :not_found}, conn, _config), do: {conn, nil}
-  defp handle_fetched_session_value({_session_id, {user, metadata}}, conn, config) when is_list(metadata) do
+  defp handle_fetched_session_value({session_id, {user, metadata}}, conn, config) when is_list(metadata) do
     conn
     |> Conn.put_private(:pow_session_metadata, metadata)
-    |> renew_stale_session(user, metadata, config)
+    |> renew_stale_session(session_id, user, metadata, config)
   end
 
-  defp renew_stale_session(conn, user, metadata, config) do
+  defp renew_stale_session(conn, session_id, user, metadata, config) do
     metadata
     |> Keyword.get(:inserted_at)
     |> session_stale?(config)
     |> case do
+      true  -> lock_create(conn, session_id, user, config)
+      false -> {conn, user}
+    end
+  end
+
+  defp lock_create(conn, session_id, user, config) do
+    nodes = Node.list() ++ [node()]
+
+    case :global.set_lock({[__MODULE__, session_id], self()}, nodes, 0) do
       true  -> create(conn, user, config)
       false -> {conn, user}
     end

--- a/test/extensions/persistent_session/plug/cookie_test.exs
+++ b/test/extensions/persistent_session/plug/cookie_test.exs
@@ -58,7 +58,7 @@ defmodule PowPersistentSession.Plug.CookieTest do
     assert Plug.current_user(conn_1) == user
     assert %{value: _id, max_age: @max_age, path: "/"} = conn_1.resp_cookies[@cookie_key]
 
-    refute Plug.current_user(conn_2)
+    assert Plug.current_user(conn_2) == user
     refute conn_2.resp_cookies[@cookie_key]
   end
 

--- a/test/pow/plug/session_test.exs
+++ b/test/pow/plug/session_test.exs
@@ -114,32 +114,42 @@ defmodule Pow.Plug.SessionTest do
 
   test "call/2 creates new session when :session_renewal_ttl reached and doesn't delete with simultanous request", %{conn: conn} do
     ttl             = 100
-    id              = "token"
+    session_id      = "token"
     config          = Keyword.put(@default_opts, :session_ttl_renewal, ttl)
     stale_timestamp = :os.system_time(:millisecond) - ttl - 1
-
-    CredentialsCache.put(@store_config, id, {@user, inserted_at: stale_timestamp})
 
     conn =
       conn
       |> Conn.fetch_session()
-      |> Conn.put_session(config[:session_key], id)
+      |> Conn.put_session(config[:session_key], session_id)
       |> Conn.send_resp(200, "")
+      |> recycle_session_conn()
 
-    conn = recycle_session_conn(conn)
+    sid          = Conn.fetch_cookies(conn).cookies["foobar"]
+    session_data = Process.get({:session, sid})
 
-    first_conn = run_plug(conn, config)
+    CredentialsCache.put(@store_config, session_id, {@user, inserted_at: stale_timestamp})
 
-    assert Plug.current_user(first_conn) == @user
-    assert first_conn.resp_cookies["foobar"]
-    assert new_id = first_conn.private[:plug_session][config[:session_key]]
-    refute new_id == id
-    assert {@user, _metadata} = CredentialsCache.get(@store_config, new_id)
+    task_1 = Task.async(fn ->
+      Process.put({:session, sid}, session_data)
+      run_plug(conn, config)
+    end)
+    task_2 = Task.async(fn ->
+      Process.put({:session, sid}, session_data)
+      run_plug(conn, config)
+    end)
+    conn_1 = Task.await(task_1)
+    conn_2 = Task.await(task_2)
 
-    second_conn = run_plug(conn, config)
+    assert Plug.current_user(conn_1) == @user
+    assert conn_1.resp_cookies["foobar"]
+    refute get_session_id(conn_1) == session_id
+    assert {@user, _metadata} = CredentialsCache.get(@store_config, get_session_id(conn_1))
 
-    refute second_conn.resp_cookies["foobar"]
-    assert second_conn.private[:plug_session] == %{}
+    refute Plug.current_user(conn_2)
+    refute conn_2.resp_cookies["foobar"]
+    assert get_session_id(conn_2) == session_id
+    assert CredentialsCache.get(@store_config, get_session_id(conn_2)) == :not_found
   end
 
   test "call/2 with prepended `:otp_app` session key", %{conn: conn} do

--- a/test/pow/plug/session_test.exs
+++ b/test/pow/plug/session_test.exs
@@ -112,10 +112,35 @@ defmodule Pow.Plug.SessionTest do
     assert conn.private[:pow_session_metadata][:fingerprint] == "fingerprint"
   end
 
+  defmodule CredentialsCacheWaitDelete do
+    alias Pow.Store.CredentialsCache
+
+    @timeout :timer.seconds(5)
+
+    defdelegate put(config, session_id, record_or_records), to: CredentialsCache
+
+    defdelegate get(config, session_id), to: CredentialsCache
+
+    def delete(config, session_id)do
+      send(self(), {__MODULE__, :wait})
+
+      receive do
+        {__MODULE__, :commit} -> :ok
+      after
+        @timeout -> raise "Timeout reached"
+      end
+
+      CredentialsCache.delete(config, session_id)
+    end
+  end
+
   test "call/2 creates new session when :session_renewal_ttl reached and doesn't delete with simultanous request", %{conn: conn} do
+    :ets.delete(EtsCacheMock)
+    :ets.new(EtsCacheMock, [:ordered_set, :public, :named_table])
+
     ttl             = 100
     session_id      = "token"
-    config          = Keyword.put(@default_opts, :session_ttl_renewal, ttl)
+    config          = Keyword.merge(@default_opts, session_ttl_renewal: ttl, credentials_cache_store: {CredentialsCacheWaitDelete, [ttl: :timer.minutes(30), namespace: "credentials"]})
     stale_timestamp = :os.system_time(:millisecond) - ttl - 1
 
     conn =
@@ -130,16 +155,27 @@ defmodule Pow.Plug.SessionTest do
 
     CredentialsCache.put(@store_config, session_id, {@user, inserted_at: stale_timestamp})
 
-    task_1 = Task.async(fn ->
-      Process.put({:session, sid}, session_data)
-      run_plug(conn, config)
-    end)
-    task_2 = Task.async(fn ->
-      Process.put({:session, sid}, session_data)
-      run_plug(conn, config)
-    end)
-    conn_1 = Task.await(task_1)
-    conn_2 = Task.await(task_2)
+    task_1 =
+      fn ->
+        Process.put({:session, sid}, session_data)
+        run_plug(conn, config)
+      end
+      |> Task.async()
+      |> wait_till_ready()
+
+    conn_2 =
+      fn ->
+        Process.put({:session, sid}, session_data)
+        run_plug(conn, config)
+      end
+      |> Task.async()
+      |> continue_work()
+      |> Task.await()
+
+    conn_1 =
+      task_1
+      |> continue_work()
+      |> Task.await()
 
     assert Plug.current_user(conn_1) == @user
     assert conn_1.resp_cookies["foobar"]
@@ -150,6 +186,19 @@ defmodule Pow.Plug.SessionTest do
     refute conn_2.resp_cookies["foobar"]
     assert get_session_id(conn_2) == session_id
     assert CredentialsCache.get(@store_config, get_session_id(conn_2)) == :not_found
+  end
+
+  defp wait_till_ready(%{pid: tracking_pid} = task) do
+    :erlang.trace(tracking_pid, true, [:receive])
+    assert_receive {:trace, ^tracking_pid, :receive, {CredentialsCacheWaitDelete, :wait}}
+
+    task
+  end
+
+  defp continue_work(%{pid: tracking_pid} = task) do
+    send(tracking_pid, {CredentialsCacheWaitDelete, :commit})
+
+    task
   end
 
   test "call/2 with prepended `:otp_app` session key", %{conn: conn} do

--- a/test/pow/plug/session_test.exs
+++ b/test/pow/plug/session_test.exs
@@ -146,7 +146,7 @@ defmodule Pow.Plug.SessionTest do
     refute get_session_id(conn_1) == session_id
     assert {@user, _metadata} = CredentialsCache.get(@store_config, get_session_id(conn_1))
 
-    refute Plug.current_user(conn_2)
+    assert Plug.current_user(conn_2) == @user
     refute conn_2.resp_cookies["foobar"]
     assert get_session_id(conn_2) == session_id
     assert CredentialsCache.get(@store_config, get_session_id(conn_2)) == :not_found

--- a/test/support/ets_cache_mock.ex
+++ b/test/support/ets_cache_mock.ex
@@ -2,7 +2,7 @@ defmodule Pow.Test.EtsCacheMock do
   @moduledoc false
   @tab __MODULE__
 
-  def init, do: :ets.new(@tab, [:ordered_set, :protected, :named_table])
+  def init, do: :ets.new(@tab, [:ordered_set, :public, :named_table])
 
   def get(config, key) do
     ets_key = ets_key(config, key)

--- a/test/support/ets_cache_mock.ex
+++ b/test/support/ets_cache_mock.ex
@@ -2,7 +2,7 @@ defmodule Pow.Test.EtsCacheMock do
   @moduledoc false
   @tab __MODULE__
 
-  def init, do: :ets.new(@tab, [:ordered_set, :public, :named_table])
+  def init, do: :ets.new(@tab, [:ordered_set, :protected, :named_table])
 
   def get(config, key) do
     ets_key = ets_key(config, key)


### PR DESCRIPTION
This resolves issue mentioned in https://github.com/danschultzer/pow/issues/356#issuecomment-583201252

A global lock is set across all nodes when either renewal logic, or persistent session token reauth is triggered.