### PR TITLE
Add signed token logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [`Pow.Plug.Session`] Now uses signed session ID's to prevent timing attacks
 * [`Pow.Plug`] Added `Pow.Plug.sign_token/4` to sign tokens
 * [`Pow.Plug`] Added `Pow.Plug.verify_token/4` to decode and verify signed tokens
+* [`Pow.Plug.MessageVerifier`] Added `Pow.Plug.MessageVerifier` module to sign and verify messages
 
 ### Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v1.0.19 (TBA)
 
+**Warning:** This release will now sign and verify all tokens, causing previous tokens to no longer work. Any sessions and persistent sessions will be invalidated.
+
 ### Enhancements
 
 * [`Pow.Plug.Session`] Now sets a global lock when renewing the session

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@
 
 * [`Pow.Plug.Session`] Now sets a global lock when renewing the session
 * [`PowPersistentSession.Plug.Cookie`] Now sets a global lock when authenticating the user
+* [`PowEmailConfirmation.Plug`] Added `PowEmailConfirmation.Plug.sign_confirmation_token/2` to sign the `email_confirmation_token` to prevent timing attacks
+* [`PowEmailConfirmation.Plug`] Added `PowEmailConfirmation.Plug.confirm_email_by_token/2` to verify the signed `email_confirmation_token` to prevent timing attacks
+* [`PowInvitation.Plug`] Added `PowInvitation.Plug.sign_invitation_token/2` to sign the `invitation_token`
+* [`PowInvitation.Plug`] Added `PowInvitation.Plug.load_invited_user_by_token/2` to verify the signed `invitation_token` to prevent timing attacks
+* [`PowResetPassword.Plug`] Changed `PowResetPassword.Plug.create_reset_token/2` to sign the `:token`
+* [`PowResetPassword.Plug`] Added `PowResetPassword.Plug.load_user_by_token/2` to verify the signed token to prevent timing attacks
+* [`PowResetPassword.Plug`] Changed `PowResetPassword.Plug.update_user_password/2` so it decodes the signed token
+* [`PowPersistentSession.Plug.Cookie`] Now uses signed tokens to prevent timing attacks
+* [`Pow.Plug.Session`] Now uses signed session ID's to prevent timing attacks
+* [`Pow.Plug`] Added `Pow.Plug.sign_token/4` to sign tokens
+* [`Pow.Plug`] Added `Pow.Plug.verify_token/4` to decode and verify signed tokens
+
+### Deprecations
+
+* [`PowEmailConfirmation.Plug`] `PowEmailConfirmation.Plug.confirm_email/2` has been deprecated in favor of `PowEmailConfirmation.Plug.confirm_email_by_token/2`
+* [`PowInvitation.Plug`] `PowInvitation.Plug.invited_user_from_token/2` has been deprecated in favor of `PowInvitation.Plug.load_invited_user_by_token/2`
+* [`PowInvitation.Plug`] `PowInvitation.Plug.assign_invited_user/2` has been deprecated
+* [`PowResetPassword.Plug`] `PowResetPassword.Plug.user_from_token/2` has been deprecated in favor of `PowResetPassword.Plug.load_user_by_token/2`
+* [`PowResetPassword.Plug`] `PowResetPassword.Plug.assign_reset_password_user/2` has been deprecated
+
+### Documentation
+
+* Updated the [API guide](guides/api.md) with signed tokens
 
 ## v1.0.18 (2020-02-14)
 

--- a/guides/api.md
+++ b/guides/api.md
@@ -69,14 +69,19 @@ defmodule MyAppWeb.APIAuthPlug do
   use Pow.Plug.Base
 
   alias Plug.Conn
-  alias Pow.{Config, Store.CredentialsCache}
+  alias Pow.{Config, Plug, Store.CredentialsCache}
   alias PowPersistentSession.Store.PersistentSessionCache
 
   @impl true
   @spec fetch(Conn.t(), Config.t()) :: {Conn.t(), map() | nil}
   def fetch(conn, config) do
-    token = fetch_auth_token(conn)
+    conn
+    |> fetch_auth_token(config)
+    |> fetch_from_store(conn, config)
+  end
 
+  defp fetch_from_store(nil, conn, _config), do: {conn, nil}
+  defp fetch_from_store(token, conn, config) do
     config
     |> store_config()
     |> CredentialsCache.get(token)
@@ -94,35 +99,39 @@ defmodule MyAppWeb.APIAuthPlug do
     renew_token  = Pow.UUID.generate()
     conn         =
       conn
-      |> Conn.put_private(:api_auth_token, token)
-      |> Conn.put_private(:api_renew_token, renew_token)
+      |> Conn.put_private(:api_auth_token, sign_token(conn, token, config))
+      |> Conn.put_private(:api_renew_token, sign_token(conn, renew_token, config))
 
     CredentialsCache.put(store_config, token, {user, []})
     PersistentSessionCache.put(store_config, renew_token, {[id: user.id], []})
 
     {conn, user}
   end
-  
+
   @impl true
   @spec delete(Conn.t(), Config.t()) :: Conn.t()
   def delete(conn, config) do
-    token = fetch_auth_token(conn)
+    case fetch_auth_token(conn, config) do
+      nil ->
+        :ok
 
-    config
-    |> store_config()
-    |> CredentialsCache.delete(token)
+      token ->
+        config
+        |> store_config()
+        |> CredentialsCache.delete(token)
+    end
 
     conn
   end
-  
+
   @doc """
   Create a new token with the provided authorization token.
-  
+
   The renewal authorization token will be deleted from the store after the user id has been fetched.
   """
   @spec renew(Conn.t(), Config.t()) :: {Conn.t(), map() | nil}
   def renew(conn, config) do
-    renew_token  = fetch_auth_token(conn)
+    renew_token  = fetch_auth_token(conn, config)
     store_config = store_config(config)
     res          = PersistentSessionCache.get(store_config, renew_token)
 
@@ -133,7 +142,7 @@ defmodule MyAppWeb.APIAuthPlug do
       res        -> load_and_create_session(conn, res, config)
     end
   end
-  
+
   defp load_and_create_session(conn, {clauses, _metadata}, config) do
     case Pow.Operations.get_by(clauses, config) do
       nil  -> {conn, nil}
@@ -141,12 +150,21 @@ defmodule MyAppWeb.APIAuthPlug do
     end
   end
 
-  defp fetch_auth_token(conn) do
-    conn
-    |> Plug.Conn.get_req_header("authorization")
-    |> List.first()
+  defp sign_token(conn, token, config) do
+    Plug.sign_token(conn, signing_salt(), token, config)
   end
-  
+
+  defp signing_salt(), do: Atom.to_string(__MODULE__)
+
+  defp fetch_auth_token(conn, config) do
+    with [token | _rest] <- Conn.get_req_header(conn, "authorization"),
+         {:ok, token}    <- Plug.verify_token(conn, signing_salt(), token, config) do
+      token
+    else
+      _any -> nil
+    end
+  end
+
   defp store_config(config) do
     backend = Config.get(config, :cache_store_backend, Pow.Store.Backend.EtsCache)
 
@@ -293,9 +311,11 @@ defmodule MyAppWeb.APIAuthPlugTest do
   alias MyAppWeb.APIAuthPlug
   alias MyApp.{Repo, Users.User}
 
-  @pow_config [otp_app: :my_app]
+  @pow_config [otp_app: :pow_demo]
+  @secret_key_base String.duplicate("abcdefghijklmnopqrstuvxyz0123456789", 2)
 
   test "can fetch, create, delete, and renew session for user", %{conn: conn} do
+    conn = %{conn | secret_key_base: @secret_key_base}
     user = Repo.insert!(%User{id: 1, email: "test@example.com"})
 
     assert {_conn, nil} = APIAuthPlug.fetch(conn, @pow_config)
@@ -364,15 +384,16 @@ defmodule MyAppWeb.API.V1.SessionControllerTest do
   use MyAppWeb.ConnCase
 
   alias MyApp.{Repo, Users.User}
-  alias MyAppWeb.APIAuthPlug
+  alias MyAppWeb.{APIAuthPlug, Endpoint}
   alias Pow.Ecto.Schema.Password
 
   @pow_config [otp_app: :my_app]
 
-  setup do
+  setup %{conn: conn} do
+    conn = %{conn | secret_key_base: Application.get_env(@pow_config[:otp_app], Endpoint)[:secret_key_base]}
     user = Repo.insert!(%User{email: "test@example.com", password_hash: Password.pbkdf2_hash("secret1234")})
 
-    {:ok, user: user}
+    {:ok, user: user, conn: conn}
   end
 
   describe "create/2" do

--- a/guides/security_practices.md
+++ b/guides/security_practices.md
@@ -24,6 +24,12 @@ Some of the below is based on [OWASP](https://www.owasp.org/) or [NIST SP800-63b
 
 * If a user couldn't be found or the `:password_hash` is `nil` a blank password is used
 * A UUID is always generated during reset password flow
+* Tokens are signed for public consumption and verified before lookup:
+  * Session ID in `Pow.Plug.Session`
+  * Persistent session token in `PowPersistentSession.Plug.Cookie`
+  * Reset password token in `PowResetPassword.Plug`
+  * E-mail confirmation token in `PowEmailConfirmation.Plug`
+  * Invitation token in `PowInvitation.Plug`
 
 ## User enumeration attacks
 

--- a/lib/extensions/email_confirmation/phoenix/controllers/confirmation_controller.ex
+++ b/lib/extensions/email_confirmation/phoenix/controllers/confirmation_controller.ex
@@ -6,7 +6,7 @@ defmodule PowEmailConfirmation.Phoenix.ConfirmationController do
   alias PowEmailConfirmation.Plug
 
   @spec process_show(Conn.t(), map()) :: {:ok | :error, map(), Conn.t()}
-  def process_show(conn, %{"id" => token}), do: Plug.confirm_email(conn, token)
+  def process_show(conn, %{"id" => token}), do: Plug.confirm_email_by_token(conn, token)
 
   @spec respond_show({:ok | :error, map(), Conn.t()}) :: Conn.t()
   def respond_show({:ok, _user, conn}) do

--- a/lib/extensions/email_confirmation/phoenix/controllers/controller_callbacks.ex
+++ b/lib/extensions/email_confirmation/phoenix/controllers/controller_callbacks.ex
@@ -126,14 +126,16 @@ defmodule PowEmailConfirmation.Phoenix.ControllerCallbacks do
   """
   @spec send_confirmation_email(map(), Conn.t()) :: any()
   def send_confirmation_email(user, conn) do
-    url               = confirmation_url(conn, user.email_confirmation_token)
+    url               = confirmation_url(conn, user)
     unconfirmed_user  = %{user | email: user.unconfirmed_email || user.email}
     email             = Mailer.email_confirmation(conn, unconfirmed_user, url)
 
     Pow.Phoenix.Mailer.deliver(conn, email)
   end
 
-  defp confirmation_url(conn, token) do
+  defp confirmation_url(conn, user) do
+    token = Plug.sign_confirmation_token(conn, user)
+
     routes(conn).url_for(conn, ConfirmationController, :show, [token])
   end
 end

--- a/lib/extensions/email_confirmation/plug.ex
+++ b/lib/extensions/email_confirmation/plug.ex
@@ -31,22 +31,41 @@ defmodule PowEmailConfirmation.Plug do
   end
 
   @doc """
-  Confirms the e-mail for the user found by the provided confirmation token.
+  Signs the e-mail confirmation token for public consumption.
+
+  The token will be signed using `Pow.Plug.sign_token/4`.
+  """
+  @spec sign_confirmation_token(Conn.t(), map()) :: binary()
+  def sign_confirmation_token(conn, %{email_confirmation_token: token}),
+    do: Plug.sign_token(conn, signing_salt(), token)
+
+  defp signing_salt(), do: Atom.to_string(__MODULE__)
+
+  @doc """
+  Verifies the token and confirms the e-mail for the user found with it.
 
   If successful, and a session exists, the session will be regenerated.
+
+  The token should have been signed with `sign_confirmation_token/2`. The token
+  will be decoded and verified with `Pow.Plug.verify_token/4`.
   """
-  @spec confirm_email(Conn.t(), binary()) :: {:ok, map(), Conn.t()} | {:error, map(), Conn.t()}
-  def confirm_email(conn, token) do
+  @spec confirm_email_by_token(Conn.t(), binary()) :: {:ok, map(), Conn.t()} | {:error, map(), Conn.t()}
+  def confirm_email_by_token(conn, signed_token) do
     config = Plug.fetch_config(conn)
 
-    token
-    |> Context.get_by_confirmation_token(config)
+    conn
+    |> verify_and_get_by_token(signed_token, config)
     |> maybe_confirm_email(conn, config)
   end
 
-  defp maybe_confirm_email(nil, conn, _config) do
-    {:error, nil, conn}
+  defp verify_and_get_by_token(conn, signed_token, config) do
+    case Plug.verify_token(conn, signing_salt(), signed_token, config) do
+      :error       -> nil
+      {:ok, token} -> Context.get_by_confirmation_token(token, config)
+    end
   end
+
+  defp maybe_confirm_email(nil, conn, _config), do: {:error, nil, conn}
   defp maybe_confirm_email(user, conn, config) do
     user
     |> Context.confirm_email(config)
@@ -69,5 +88,16 @@ defmodule PowEmailConfirmation.Plug do
     {:ok, clauses2} = Operations.fetch_primary_key_values(current_user, config)
 
     Keyword.equal?(clauses1, clauses2)
+  end
+
+  # TODO: Remove by 1.1.0
+  @doc false
+  @deprecated "Use `confirm_email_by_token/2`"
+  def confirm_email(conn, token) do
+    config = Plug.fetch_config(conn)
+
+    token
+    |> Context.get_by_confirmation_token(config)
+    |> maybe_confirm_email(conn, config)
   end
 end

--- a/lib/extensions/invitation/phoenix/controllers/invitation_controller.ex
+++ b/lib/extensions/invitation/phoenix/controllers/invitation_controller.ex
@@ -61,7 +61,9 @@ defmodule PowInvitation.Phoenix.InvitationController do
   end
 
   defp invitation_url(conn, user) do
-    routes(conn).url_for(conn, __MODULE__, :edit, [user.invitation_token])
+    token = Plug.sign_invitation_token(conn, user)
+
+    routes(conn).url_for(conn, __MODULE__, :edit, [token])
   end
 
   defp invitation_sent_redirect(conn) do
@@ -110,15 +112,15 @@ defmodule PowInvitation.Phoenix.InvitationController do
   end
 
   defp load_user_from_invitation_token(%{params: %{"id" => token}} = conn, _opts) do
-    case Plug.invited_user_from_token(conn, token) do
-      nil  ->
+    case Plug.load_invited_user_by_token(conn, token) do
+      {:error, conn}  ->
         conn
         |> put_flash(:error, extension_messages(conn).invalid_invitation(conn))
         |> redirect(to: routes(conn).path_for(conn, SessionController, :new))
         |> halt()
 
-      user ->
-        Plug.assign_invited_user(conn, user)
+      {:ok, conn} ->
+        conn
     end
   end
 

--- a/lib/extensions/reset_password/phoenix/controllers/reset_password_controller.ex
+++ b/lib/extensions/reset_password/phoenix/controllers/reset_password_controller.ex
@@ -82,15 +82,15 @@ defmodule PowResetPassword.Phoenix.ResetPasswordController do
   end
 
   defp load_user_from_reset_token(%{params: %{"id" => token}} = conn, _opts) do
-    case Plug.user_from_token(conn, token) do
-      nil ->
+    case Plug.load_user_by_token(conn, token) do
+      {:error, conn} ->
         conn
         |> put_flash(:error, extension_messages(conn).invalid_token(conn))
         |> redirect(to: routes(conn).path_for(conn, __MODULE__, :new))
         |> halt()
 
-      user ->
-        Plug.assign_reset_password_user(conn, user)
+      {:ok, conn} ->
+        conn
     end
   end
 

--- a/lib/extensions/reset_password/plug.ex
+++ b/lib/extensions/reset_password/plug.ex
@@ -24,10 +24,9 @@ defmodule PowResetPassword.Plug do
     |> struct()
   end
 
-  @doc """
-  Assigns a `:reset_password_user` key with the user in the connection.
-  """
-  @spec assign_reset_password_user(Conn.t(), map()) :: Conn.t()
+  # TODO: Remove by 1.1.0
+  @doc false
+  @deprecated "No longer used"
   def assign_reset_password_user(conn, user) do
     Conn.assign(conn, :reset_password_user, user)
   end
@@ -36,8 +35,9 @@ defmodule PowResetPassword.Plug do
   Finds a user for the provided params, creates a token, and stores the user
   for the token.
 
-  To prevent timing attacks, `Pow.UUID.generate/0` is called whether the user
-  exists or not.
+  The returned `:token` is signed for public consumption using
+  `Pow.Plug.sign_token/4`. Additionally `Pow.UUID.generate/0` is called whether
+  the user exists or not to prevent timing attacks.
 
   `:reset_password_token_store` can be passed in the config for the conn. This
   value defaults to
@@ -62,17 +62,51 @@ defmodule PowResetPassword.Plug do
 
         store.put(store_config, token, user)
 
-        {:ok, %{token: token, user: user}, conn}
+        signed = Plug.sign_token(conn, signing_salt(), token, config)
+
+        {:ok, %{token: signed, user: user}, conn}
     end
   end
 
+  defp signing_salt(), do: Atom.to_string(__MODULE__)
+
   @doc """
-  Fetches user from the store by the provided token.
+  Verifies the signed token and fetches invited user from store.
+
+  If a user is found, it'll be assigned to `conn.assign` for key
+  `:reset_password_user`.
+
+  The token will be decoded and verified with `Pow.Plug.verify_token/4`.
 
   See `create_reset_token/2` for more on `:reset_password_token_store` config
   option.
   """
-  @spec user_from_token(Conn.t(), binary()) :: map() | nil
+  @spec load_user_by_token(Conn.t(), binary()) :: {:ok, Conn.t()} | {:error, Conn.t()}
+  def load_user_by_token(conn, signed_token) do
+    config = Plug.fetch_config(conn)
+
+    with {:ok, token}               <- Plug.verify_token(conn, signing_salt(), signed_token, config),
+         user when not is_nil(user) <- fetch_user_from_token(token, config) do
+      {:ok, Conn.assign(conn, :reset_password_user, user)}
+    else
+      _any -> {:error, conn}
+    end
+  end
+
+  defp fetch_user_from_token(token, config) do
+    {store, store_config} = store(config)
+
+    store_config
+    |> store.get(token)
+    |> case do
+      :not_found -> nil
+      user       -> user
+    end
+  end
+
+  # TODO: Remove by 1.1.0
+  @doc false
+  @deprecated "Use `load_user_by_token/2` instead"
   def user_from_token(conn, token) do
     {store, store_config} =
       conn
@@ -92,6 +126,8 @@ defmodule PowResetPassword.Plug do
 
   See `create_reset_token/2` for more on `:reset_password_token_store` config
   option.
+
+  The token will be decoded and verified with `Pow.Plug.verify_token/4`.
   """
   @spec update_user_password(Conn.t(), map()) :: {:ok, map(), Conn.t()} | {:error, map(), Conn.t()}
   def update_user_password(conn, params) do
@@ -105,7 +141,10 @@ defmodule PowResetPassword.Plug do
   end
 
   defp maybe_expire_token({:ok, user}, conn, token, config) do
-    expire_token(token, config)
+    case Plug.verify_token(conn, signing_salt(), token, config) do
+      :error       -> :ok
+      {:ok, token} -> expire_token(token, config)
+    end
 
     {:ok, user, conn}
   end

--- a/lib/pow/plug/message_verifier.ex
+++ b/lib/pow/plug/message_verifier.ex
@@ -1,0 +1,55 @@
+defmodule Pow.Plug.MessageVerifier do
+  @moduledoc """
+  This module can sign and verify messages.
+
+  Based on `Phoenix.Token`.
+  """
+  alias Plug.{Conn, Crypto.KeyGenerator, Crypto.MessageVerifier}
+
+  @callback sign(Conn.t(), binary(), binary(), keyword()) :: binary()
+  @callback verify(Conn.t(), binary(), binary(), keyword()) :: {:ok, binary()} | :error
+
+  @doc """
+  Signs a message.
+
+  `Plug.Crypto.MessageVerifier.sign/2` is used. The secret is derived from the
+  `salt` and `conn.secret_key_base` using
+  `Plug.Crypto.KeyGenerator.generate/3`. If `:key_generator_opts` is set in the
+  config, this will be passed on to `Plug.Crypto.KeyGenerator`.
+  """
+  @spec sign(Conn.t(), binary(), binary(), keyword()) :: binary()
+  def sign(conn, salt, message, config) do
+    secret = derive(conn, salt, key_opts(config))
+
+    MessageVerifier.sign(message, secret)
+  end
+
+  @doc """
+  Verifies a message.
+
+  `Plug.Crypto.MessageVerifier.sign/2` is used. The secret is derived from the
+  `salt` and `conn.secret_key_base` using
+  `Plug.Crypto.KeyGenerator.generate/3`. If `:key_generator_opts` is set in the
+  config, this will be passed on to `Plug.Crypto.KeyGenerator`.
+  """
+  @spec verify(Conn.t(), binary(), binary(), keyword()) :: {:ok, binary()} | :error
+  def verify(conn, salt, message, config) do
+    secret = derive(conn, salt, key_opts(config))
+
+    MessageVerifier.verify(message, secret)
+  end
+
+  defp derive(conn, key, key_opts) do
+    conn.secret_key_base
+    |> validate_secret_key_base()
+    |> KeyGenerator.generate(key, key_opts)
+  end
+
+  defp validate_secret_key_base(nil),
+    do: raise ArgumentError, "No conn.secret_key_base set"
+  defp validate_secret_key_base(secret_key_base) when byte_size(secret_key_base) < 64,
+    do: raise ArgumentError, "conn.secret_key_base has to be at least 64 bytes"
+  defp validate_secret_key_base(secret_key_base), do: secret_key_base
+
+  defp key_opts(config), do: Keyword.get(config, :key_generator_opts, [])
+end

--- a/test/extensions/email_confirmation/phoenix/controllers/confirmation_controller_test.exs
+++ b/test/extensions/email_confirmation/phoenix/controllers/confirmation_controller_test.exs
@@ -2,8 +2,9 @@ defmodule PowEmailConfirmation.Phoenix.ConfirmationControllerTest do
   use PowEmailConfirmation.TestWeb.Phoenix.ConnCase
 
   alias Plug.Conn
+  alias Pow.Plug, as: PowPlug
   alias PowEmailConfirmation.Plug
-  alias PowEmailConfirmation.Test.Users.User
+  alias PowEmailConfirmation.{Test, Test.Users.User}
 
   @session_key "auth"
 
@@ -85,11 +86,9 @@ defmodule PowEmailConfirmation.Phoenix.ConfirmationControllerTest do
     end
   end
 
-  @secret_key_base String.duplicate("abcdefghijklmnopqrstuvxyz0123456789", 2)
-
   defp sign_token(token) do
-    conn = %Conn{secret_key_base: @secret_key_base, private: %{pow_config: []}}
-
-    Plug.sign_confirmation_token(conn, %{email_confirmation_token: token})
+    %Conn{}
+    |> PowPlug.put_config(Test.pow_config())
+    |> Plug.sign_confirmation_token(%{email_confirmation_token: token})
   end
 end

--- a/test/extensions/email_confirmation/phoenix/controllers/controller_callbacks_test.exs
+++ b/test/extensions/email_confirmation/phoenix/controllers/controller_callbacks_test.exs
@@ -5,7 +5,7 @@ defmodule PowEmailConfirmation.Phoenix.ControllerCallbacksTest do
   alias PowEmailConfirmation.Plug
   alias Pow.Ecto.Schema.Password
   alias Pow.Plug, as: PowPlug
-  alias PowEmailConfirmation.Test.Users.User
+  alias PowEmailConfirmation.{Test, Test.Users.User}
 
   @password "secret1234"
 
@@ -146,11 +146,12 @@ defmodule PowEmailConfirmation.Phoenix.ControllerCallbacksTest do
     @token               "token"
     @params              %{"email" => "test@example.com", "password" => @password, "password_confirmation" => @password}
     @change_email_params %{"email" => "new@example.com", "password" => @password, "password_confirmation" => @password}
-    @secret_key_base     String.duplicate("abcdefghijklmnopqrstuvxyz0123456789", 2)
 
-    setup %{conn: conn} do
-      conn  = %{conn | secret_key_base: @secret_key_base, private: %{pow_config: []}}
-      token = PowInvitationPlug.sign_invitation_token(conn, %{invitation_token: @token})
+    setup do
+      token =
+        %Conn{}
+        |> PowPlug.put_config(Test.pow_config())
+        |> PowInvitationPlug.sign_invitation_token(%{invitation_token: @token})
 
       {:ok, token: token}
     end

--- a/test/extensions/email_confirmation/phoenix/controllers/controller_callbacks_test.exs
+++ b/test/extensions/email_confirmation/phoenix/controllers/controller_callbacks_test.exs
@@ -2,7 +2,9 @@ defmodule PowEmailConfirmation.Phoenix.ControllerCallbacksTest do
   use PowEmailConfirmation.TestWeb.Phoenix.ConnCase
 
   alias Plug.Conn
-  alias Pow.{Ecto.Schema.Password, Plug}
+  alias PowEmailConfirmation.Plug
+  alias Pow.Ecto.Schema.Password
+  alias Pow.Plug, as: PowPlug
   alias PowEmailConfirmation.Test.Users.User
 
   @password "secret1234"
@@ -16,20 +18,20 @@ defmodule PowEmailConfirmation.Phoenix.ControllerCallbacksTest do
       assert get_flash(conn, :error) == "You'll need to confirm your e-mail before you can sign in. An e-mail confirmation link has been sent to you."
       assert redirected_to(conn) == "/after_signed_in"
 
-      refute Plug.current_user(conn)
+      refute PowPlug.current_user(conn)
       refute conn.private[:plug_session]["auth"]
 
       assert_received {:mail_mock, mail}
       assert token = mail.user.email_confirmation_token
       refute mail.user.email_confirmed_at
-      assert mail.html =~ "<a href=\"http://localhost/confirm-email/#{token}\">"
+      assert mail.html =~ "<a href=\"http://localhost/confirm-email/#{sign_token(conn, token)}\">"
       assert mail.user.email == "test@example.com"
     end
 
     test "when current email has been confirmed", %{conn: conn} do
       conn = post conn, Routes.pow_session_path(conn, :create, %{"user" => Map.put(@valid_params, "email", "confirmed-email@example.com")})
 
-      assert Plug.current_user(conn)
+      assert PowPlug.current_user(conn)
       assert conn.private[:plug_session]["auth"]
       assert get_flash(conn, :info) == "signed_in"
       assert redirected_to(conn) == "/after_signed_in"
@@ -38,7 +40,7 @@ defmodule PowEmailConfirmation.Phoenix.ControllerCallbacksTest do
     test "when current email confirmed and has unconfirmed changed email", %{conn: conn} do
       conn = post conn, Routes.pow_session_path(conn, :create, %{"user" => Map.put(@valid_params, "email", "with-unconfirmed-changed-email@example.com")})
 
-      assert %{id: 1} = Plug.current_user(conn)
+      assert %{id: 1} = PowPlug.current_user(conn)
       assert conn.private[:plug_session]["auth"]
 
       refute_received {:mail_mock, _mail}
@@ -56,13 +58,13 @@ defmodule PowEmailConfirmation.Phoenix.ControllerCallbacksTest do
       assert get_flash(conn, :error) == "You'll need to confirm your e-mail before you can sign in. An e-mail confirmation link has been sent to you."
       assert redirected_to(conn) == "/after_registration"
 
-      refute Plug.current_user(conn)
+      refute PowPlug.current_user(conn)
       refute conn.private[:plug_session]["auth"]
 
       assert_received {:mail_mock, mail}
       assert token = mail.user.email_confirmation_token
       refute mail.user.email_confirmed_at
-      assert mail.html =~ "<a href=\"http://localhost/confirm-email/#{token}\">"
+      assert mail.html =~ "<a href=\"http://localhost/confirm-email/#{sign_token(conn, token)}\">"
       assert mail.user.email == "test@example.com"
     end
 
@@ -80,7 +82,7 @@ defmodule PowEmailConfirmation.Phoenix.ControllerCallbacksTest do
       assert get_flash(conn, :error) == "You'll need to confirm your e-mail before you can sign in. An e-mail confirmation link has been sent to you."
       assert redirected_to(conn) == "/after_registration"
 
-      refute Plug.current_user(conn)
+      refute PowPlug.current_user(conn)
       refute conn.private[:plug_session]["auth"]
 
       refute_received {:mail_mock, _mail}
@@ -105,7 +107,7 @@ defmodule PowEmailConfirmation.Phoenix.ControllerCallbacksTest do
 
     setup %{conn: conn} do
       user = Ecto.put_meta(@user, state: :loaded)
-      conn = Plug.assign_current_user(conn, user, [])
+      conn = PowPlug.assign_current_user(conn, user, [])
 
       {:ok, conn: conn}
     end
@@ -113,7 +115,7 @@ defmodule PowEmailConfirmation.Phoenix.ControllerCallbacksTest do
     test "when email changes", %{conn: conn} do
       conn = put conn, Routes.pow_registration_path(conn, :update, %{"user" => @change_email_params})
 
-      assert %{id: 1, email: "test@example.com", email_confirmation_token: new_token} = Plug.current_user(conn)
+      assert %{id: 1, email: "test@example.com", email_confirmation_token: new_token} = PowPlug.current_user(conn)
 
       assert get_flash(conn, :error) == "You'll need to confirm the e-mail before it's updated. An e-mail confirmation link has been sent to you."
       assert get_flash(conn, :info) == "Your account has been updated."
@@ -121,8 +123,8 @@ defmodule PowEmailConfirmation.Phoenix.ControllerCallbacksTest do
 
       assert_received {:mail_mock, mail}
       assert mail.subject == "Confirm your email address"
-      assert mail.text =~ "\nhttp://localhost/confirm-email/#{new_token}\n"
-      assert mail.html =~ "<a href=\"http://localhost/confirm-email/#{new_token}\">"
+      assert mail.text =~ "\nhttp://localhost/confirm-email/#{sign_token(conn, new_token)}\n"
+      assert mail.html =~ "<a href=\"http://localhost/confirm-email/#{sign_token(conn, new_token)}\">"
       assert mail.user.email == "new@example.com"
     end
 
@@ -130,7 +132,7 @@ defmodule PowEmailConfirmation.Phoenix.ControllerCallbacksTest do
       conn = put conn, Routes.pow_registration_path(conn, :update, %{"user" => @params})
 
       assert get_flash(conn, :info) == "Your account has been updated."
-      assert %{id: 1, unconfirmed_email: nil, email_confirmation_token: nil} = Plug.current_user(conn)
+      assert %{id: 1, unconfirmed_email: nil, email_confirmation_token: nil} = PowPlug.current_user(conn)
 
       refute_received {:mail_mock, _mail}
     end
@@ -138,29 +140,40 @@ defmodule PowEmailConfirmation.Phoenix.ControllerCallbacksTest do
 
   alias PowEmailConfirmation.PowInvitation.TestWeb.Phoenix.Endpoint, as: PowInvitationEndpoint
   alias PowEmailConfirmation.PowInvitation.TestWeb.Phoenix.Router.Helpers, as: PowInvitationRoutes
+  alias PowInvitation.Plug, as: PowInvitationPlug
 
   describe "PowInvitation.Phoenix.InvitationController.update/2" do
     @token               "token"
     @params              %{"email" => "test@example.com", "password" => @password, "password_confirmation" => @password}
     @change_email_params %{"email" => "new@example.com", "password" => @password, "password_confirmation" => @password}
+    @secret_key_base     String.duplicate("abcdefghijklmnopqrstuvxyz0123456789", 2)
 
-    test "when email changes", %{conn: conn} do
-      conn = Phoenix.ConnTest.dispatch(conn, PowInvitationEndpoint, :put, PowInvitationRoutes.pow_invitation_invitation_path(conn, :update, @token, %{"user" => @change_email_params}))
+    setup %{conn: conn} do
+      conn  = %{conn | secret_key_base: @secret_key_base, private: %{pow_config: []}}
+      token = PowInvitationPlug.sign_invitation_token(conn, %{invitation_token: @token})
+
+      {:ok, token: token}
+    end
+
+    test "when email changes", %{conn: conn, token: token} do
+      conn = Phoenix.ConnTest.dispatch(conn, PowInvitationEndpoint, :put, PowInvitationRoutes.pow_invitation_invitation_path(conn, :update, token, %{"user" => @change_email_params}))
 
       assert get_flash(conn, :error) == "You'll need to confirm the e-mail before it's updated. An e-mail confirmation link has been sent to you."
-      assert %{id: 1, email_confirmation_token: new_token} = Plug.current_user(conn)
+      assert %{id: 1, email_confirmation_token: new_token} = PowPlug.current_user(conn)
       refute is_nil(new_token)
 
       assert_received {:mail_mock, _mail}
     end
 
-    test "when email hasn't changed", %{conn: conn} do
-      conn = Phoenix.ConnTest.dispatch(conn, PowInvitationEndpoint, :put, PowInvitationRoutes.pow_invitation_invitation_path(conn, :update, @token, %{"user" => @params}))
+    test "when email hasn't changed", %{conn: conn, token: token} do
+      conn = Phoenix.ConnTest.dispatch(conn, PowInvitationEndpoint, :put, PowInvitationRoutes.pow_invitation_invitation_path(conn, :update, token, %{"user" => @params}))
 
       refute get_flash(conn, :error)
-      assert %{id: 1, email_confirmation_token: nil} = Plug.current_user(conn)
+      assert %{id: 1, email_confirmation_token: nil} = PowPlug.current_user(conn)
 
       refute_received {:mail_mock, _mail}
     end
   end
+
+  defp sign_token(conn, token), do: Plug.sign_confirmation_token(conn, %{email_confirmation_token: token})
 end

--- a/test/extensions/invitation/phoenix/controllers/invitation_controller_test.exs
+++ b/test/extensions/invitation/phoenix/controllers/invitation_controller_test.exs
@@ -2,8 +2,9 @@ defmodule PowInvitation.Phoenix.InvitationControllerTest do
   use PowInvitation.TestWeb.Phoenix.ConnCase
 
   alias Plug.Conn
+  alias Pow.Plug, as: PowPlug
   alias PowInvitation.Plug
-  alias PowInvitation.Test.Users.{User, UsernameUser}
+  alias PowInvitation.{Test, Test.Users.User, Test.Users.UsernameUser}
 
   @user %User{id: 1, email: "test@example.com"}
   @url_regex ~r/http:\/\/localhost\/invitations\/[a-zA-Z0-9\-\_\.]*\/edit/
@@ -236,11 +237,9 @@ defmodule PowInvitation.Phoenix.InvitationControllerTest do
     end
   end
 
-  @secret_key_base String.duplicate("abcdefghijklmnopqrstuvxyz0123456789", 2)
-
   defp sign_token(token) do
-    conn = %Conn{secret_key_base: @secret_key_base, private: %{pow_config: []}}
-
-    Plug.sign_invitation_token(conn, %{invitation_token: token})
+    %Conn{}
+    |> PowPlug.put_config(Test.pow_config())
+    |> Plug.sign_invitation_token(%{invitation_token: token})
   end
 end

--- a/test/extensions/persistent_session/phoenix/controllers/controller_callbacks_test.exs
+++ b/test/extensions/persistent_session/phoenix/controllers/controller_callbacks_test.exs
@@ -1,7 +1,8 @@
 defmodule PowPersistentSession.Phoenix.ControllerCallbacksTest do
   use PowPersistentSession.TestWeb.Phoenix.ConnCase
 
-  alias PowPersistentSession.Store.PersistentSessionCache
+  alias Pow.Plug
+  alias PowPersistentSession.{Plug.Cookie, Store.PersistentSessionCache}
 
   @valid_params %{"email" => "test@example.com", "password" => "secret1234"}
   @max_age Integer.floor_div(:timer.hours(30) * 24, 1000)
@@ -13,7 +14,7 @@ defmodule PowPersistentSession.Phoenix.ControllerCallbacksTest do
 
       assert session_fingerprint = conn.private[:pow_session_metadata][:fingerprint]
       assert %{max_age: @max_age, path: "/", value: id} = conn.resp_cookies[@cookie_key]
-      assert PersistentSessionCache.get([backend: ets], id) == {[id: 1], session_metadata: [fingerprint: session_fingerprint]}
+      assert get_from_cache(conn, id, backend: ets) == {[id: 1], session_metadata: [fingerprint: session_fingerprint]}
     end
 
     test "with persistent_session param set to false", %{conn: conn} do
@@ -40,7 +41,13 @@ defmodule PowPersistentSession.Phoenix.ControllerCallbacksTest do
       conn = delete conn, Routes.pow_session_path(conn, :delete)
 
       assert conn.resp_cookies[@cookie_key] == %{max_age: 0, path: "/", universal_time: {{1970, 1, 1}, {0, 0, 0}}}
-      assert PersistentSessionCache.get([backend: ets], id) == :not_found
+      assert get_from_cache(conn, id, backend: ets) == :not_found
     end
+  end
+
+  defp get_from_cache(conn, token, config) do
+    assert {:ok, token} = Plug.verify_token(conn, Atom.to_string(Cookie), token, config)
+
+    PersistentSessionCache.get(config, token)
   end
 end

--- a/test/extensions/persistent_session/phoenix/controllers/controller_callbacks_test.exs
+++ b/test/extensions/persistent_session/phoenix/controllers/controller_callbacks_test.exs
@@ -46,7 +46,7 @@ defmodule PowPersistentSession.Phoenix.ControllerCallbacksTest do
   end
 
   defp get_from_cache(conn, token, config) do
-    assert {:ok, token} = Plug.verify_token(conn, Atom.to_string(Cookie), token, config)
+    assert {:ok, token} = Plug.verify_token(conn, Atom.to_string(Cookie), token)
 
     PersistentSessionCache.get(config, token)
   end

--- a/test/extensions/persistent_session/plug/cookie_test.exs
+++ b/test/extensions/persistent_session/plug/cookie_test.exs
@@ -349,12 +349,9 @@ defmodule PowPersistentSession.Plug.CookieTest do
     assert get_from_cache(conn, id, backend: ets) == :not_found
   end
 
-  @secret_key_base String.duplicate("abcdefghijklmnopqrstuvxyz0123456789", 2)
-
   defp conn_with_session_plug(config) do
     :get
     |> Test.conn("/")
-    |> Map.put(:secret_key_base, @secret_key_base)
     |> PlugSession.call(PlugSession.init(store: ProcessStore, key: "foobar"))
     |> Session.call(Session.init(config))
   end

--- a/test/extensions/reset_password/phoenix/controllers/reset_password_controller_test.exs
+++ b/test/extensions/reset_password/phoenix/controllers/reset_password_controller_test.exs
@@ -43,13 +43,13 @@ defmodule PowResetPassword.Phoenix.ResetPasswordControllerTest do
 
     test "with valid params", %{conn: conn, ets: ets} do
       conn         = post conn, Routes.pow_reset_password_reset_password_path(conn, :create, @valid_params)
-      [{token, _}] = ResetTokenCache.all([backend: ets], [:_])
+      [{[token], _}] = ResetTokenCache.all([backend: ets], [:_])
 
       assert_received {:mail_mock, mail}
 
       assert mail.subject == "Reset password link"
-      assert mail.text =~ "\nhttp://localhost/reset-password/#{token}\n"
-      assert mail.html =~ "<a href=\"http://localhost/reset-password/#{token}\">"
+      assert mail.text =~ "\nhttp://localhost/reset-password/#{sign_token(conn, token)}\n"
+      assert mail.html =~ "<a href=\"http://localhost/reset-password/#{sign_token(conn, token)}\">"
 
       assert redirected_to(conn) == Routes.pow_session_path(conn, :new)
       assert get_flash(conn, :info) == "If an account for the provided email exists, an email with reset instructions will be sent to you. Please check your inbox."
@@ -74,14 +74,17 @@ defmodule PowResetPassword.Phoenix.ResetPasswordControllerTest do
     end
   end
 
+  @secret_key_base String.duplicate("abcdefghijklmnopqrstuvxyz0123456789", 2)
+
   describe "edit/2" do
     setup %{conn: conn} do
+      conn = %{conn | secret_key_base: @secret_key_base}
       {:ok, %{token: token}, _conn} =
         conn
         |> PowPlug.put_config(Test.pow_config())
         |> Plug.create_reset_token(%{"email" => "test@example.com"})
 
-      {:ok, token: token}
+      {:ok, conn: conn, token: token}
     end
 
     test "already signed in", %{conn: conn, token: token} do
@@ -93,8 +96,16 @@ defmodule PowResetPassword.Phoenix.ResetPasswordControllerTest do
       assert_authenticated_redirect(conn)
     end
 
-    test "invalid token", %{conn: conn} do
+    test "with invalid token", %{conn: conn} do
       conn = get conn, Routes.pow_reset_password_reset_password_path(conn, :edit, "invalid")
+
+      assert redirected_to(conn) == Routes.pow_reset_password_reset_password_path(conn, :new)
+      assert get_flash(conn, :error) == "The reset token has expired."
+    end
+
+    test "with unsigned token", %{conn: conn, token: token} do
+      {:ok, token} = PowPlug.verify_token(conn, Atom.to_string(Plug), token, [])
+      conn = get conn, Routes.pow_reset_password_reset_password_path(conn, :edit, token)
 
       assert redirected_to(conn) == Routes.pow_reset_password_reset_password_path(conn, :new)
       assert get_flash(conn, :error) == "The reset token has expired."
@@ -117,12 +128,13 @@ defmodule PowResetPassword.Phoenix.ResetPasswordControllerTest do
     @invalid_params %{"user" => %{"password" => @password, "password_confirmation" => "invalid"}}
 
     setup %{conn: conn} do
+      conn = %{conn | secret_key_base: @secret_key_base}
       {:ok, %{token: token}, _conn} =
         conn
         |> PowPlug.put_config(Test.pow_config())
         |> Plug.create_reset_token(%{"email" => "test@example.com"})
 
-      {:ok, token: token}
+      {:ok, conn: conn, token: token}
     end
 
     test "already signed in", %{conn: conn, token: token} do
@@ -134,8 +146,16 @@ defmodule PowResetPassword.Phoenix.ResetPasswordControllerTest do
       assert_authenticated_redirect(conn)
     end
 
-    test "invalid token", %{conn: conn} do
+    test "with invalid token", %{conn: conn} do
       conn = put conn, Routes.pow_reset_password_reset_password_path(conn, :update, "invalid", @valid_params)
+
+      assert redirected_to(conn) == Routes.pow_reset_password_reset_password_path(conn, :new)
+      assert get_flash(conn, :error) == "The reset token has expired."
+    end
+
+    test "with unsigned token", %{conn: conn, token: token} do
+      {:ok, token} = PowPlug.verify_token(conn, Atom.to_string(Plug), token, [])
+      conn = put conn, Routes.pow_reset_password_reset_password_path(conn, :update, token, @valid_params)
 
       assert redirected_to(conn) == Routes.pow_reset_password_reset_password_path(conn, :new)
       assert get_flash(conn, :error) == "The reset token has expired."
@@ -147,7 +167,7 @@ defmodule PowResetPassword.Phoenix.ResetPasswordControllerTest do
       assert redirected_to(conn) == Routes.pow_session_path(conn, :new)
       assert get_flash(conn, :info) == "The password has been updated."
 
-      refute Plug.user_from_token(conn, token)
+      assert {:error, _conn} = Plug.load_user_by_token(conn, token)
     end
 
     test "with invalid params", %{conn: conn, token: token} do
@@ -162,7 +182,7 @@ defmodule PowResetPassword.Phoenix.ResetPasswordControllerTest do
       assert changeset.errors[:password_confirmation]
       assert changeset.action == :update
 
-      assert Plug.user_from_token(conn, token)
+      assert {:ok, _conn} = Plug.load_user_by_token(conn, token)
     end
 
     test "with missing user", %{conn: conn} do
@@ -177,4 +197,6 @@ defmodule PowResetPassword.Phoenix.ResetPasswordControllerTest do
       assert get_flash(conn, :info) == "The password has been updated."
     end
   end
+
+  defp sign_token(conn, token), do: PowPlug.sign_token(conn, Atom.to_string(Plug), token)
 end

--- a/test/extensions/reset_password/phoenix/controllers/reset_password_controller_test.exs
+++ b/test/extensions/reset_password/phoenix/controllers/reset_password_controller_test.exs
@@ -42,7 +42,7 @@ defmodule PowResetPassword.Phoenix.ResetPasswordControllerTest do
     end
 
     test "with valid params", %{conn: conn, ets: ets} do
-      conn         = post conn, Routes.pow_reset_password_reset_password_path(conn, :create, @valid_params)
+      conn           = post conn, Routes.pow_reset_password_reset_password_path(conn, :create, @valid_params)
       [{[token], _}] = ResetTokenCache.all([backend: ets], [:_])
 
       assert_received {:mail_mock, mail}
@@ -74,15 +74,9 @@ defmodule PowResetPassword.Phoenix.ResetPasswordControllerTest do
     end
   end
 
-  @secret_key_base String.duplicate("abcdefghijklmnopqrstuvxyz0123456789", 2)
-
   describe "edit/2" do
     setup %{conn: conn} do
-      conn = %{conn | secret_key_base: @secret_key_base}
-      {:ok, %{token: token}, _conn} =
-        conn
-        |> PowPlug.put_config(Test.pow_config())
-        |> Plug.create_reset_token(%{"email" => "test@example.com"})
+      token = create_reset_token(conn, "test@example.com")
 
       {:ok, conn: conn, token: token}
     end
@@ -104,8 +98,8 @@ defmodule PowResetPassword.Phoenix.ResetPasswordControllerTest do
     end
 
     test "with unsigned token", %{conn: conn, token: token} do
-      {:ok, token} = PowPlug.verify_token(conn, Atom.to_string(Plug), token, [])
-      conn = get conn, Routes.pow_reset_password_reset_password_path(conn, :edit, token)
+      token = decode_token(conn, token)
+      conn  = get conn, Routes.pow_reset_password_reset_password_path(conn, :edit, token)
 
       assert redirected_to(conn) == Routes.pow_reset_password_reset_password_path(conn, :new)
       assert get_flash(conn, :error) == "The reset token has expired."
@@ -128,11 +122,7 @@ defmodule PowResetPassword.Phoenix.ResetPasswordControllerTest do
     @invalid_params %{"user" => %{"password" => @password, "password_confirmation" => "invalid"}}
 
     setup %{conn: conn} do
-      conn = %{conn | secret_key_base: @secret_key_base}
-      {:ok, %{token: token}, _conn} =
-        conn
-        |> PowPlug.put_config(Test.pow_config())
-        |> Plug.create_reset_token(%{"email" => "test@example.com"})
+      token = create_reset_token(conn, "test@example.com")
 
       {:ok, conn: conn, token: token}
     end
@@ -154,8 +144,8 @@ defmodule PowResetPassword.Phoenix.ResetPasswordControllerTest do
     end
 
     test "with unsigned token", %{conn: conn, token: token} do
-      {:ok, token} = PowPlug.verify_token(conn, Atom.to_string(Plug), token, [])
-      conn = put conn, Routes.pow_reset_password_reset_password_path(conn, :update, token, @valid_params)
+      token = decode_token(conn, token)
+      conn  = put conn, Routes.pow_reset_password_reset_password_path(conn, :update, token, @valid_params)
 
       assert redirected_to(conn) == Routes.pow_reset_password_reset_password_path(conn, :new)
       assert get_flash(conn, :error) == "The reset token has expired."
@@ -186,16 +176,30 @@ defmodule PowResetPassword.Phoenix.ResetPasswordControllerTest do
     end
 
     test "with missing user", %{conn: conn} do
-      {:ok, %{token: token}, _conn} =
-        conn
-        |> PowPlug.put_config(Test.pow_config())
-        |> Plug.create_reset_token(%{"email" => "missing@example.com"})
-
-      conn = put conn, Routes.pow_reset_password_reset_password_path(conn, :update, token, @valid_params)
+      token = create_reset_token(conn, "missing@example.com")
+      conn  = put conn, Routes.pow_reset_password_reset_password_path(conn, :update, token, @valid_params)
 
       assert redirected_to(conn) == Routes.pow_session_path(conn, :new)
       assert get_flash(conn, :info) == "The password has been updated."
     end
+  end
+
+  defp create_reset_token(conn, email) do
+    {:ok, %{token: token}, _conn} =
+      conn
+      |> PowPlug.put_config(Test.pow_config())
+      |> Plug.create_reset_token(%{"email" => email})
+
+    token
+  end
+
+  defp decode_token(conn, token) do
+    {:ok, token} =
+      conn
+      |> PowPlug.put_config(Test.pow_config())
+      |> PowPlug.verify_token(Atom.to_string(Plug), token)
+
+    token
   end
 
   defp sign_token(conn, token), do: PowPlug.sign_token(conn, Atom.to_string(Plug), token)

--- a/test/support/extensions/mocks.ex
+++ b/test/support/extensions/mocks.ex
@@ -42,7 +42,9 @@ defmodule Pow.Test.ExtensionMocks do
       messages_backend: Module.concat([web_module, Phoenix.Messages]),
       routes_backend: Module.concat([web_module, Phoenix.Routes]),
       extensions: extensions,
-      controller_callbacks: Pow.Extension.Phoenix.ControllerCallbacks]
+      controller_callbacks: Pow.Extension.Phoenix.ControllerCallbacks,
+      message_verifier: Pow.Test.MessageVerifier
+    ]
 
     __user_schema__(context_module, extensions)
     __phoenix_endpoint__(web_module, config, opts)

--- a/test/support/message_verifier.ex
+++ b/test/support/message_verifier.ex
@@ -1,0 +1,19 @@
+defmodule Pow.Test.MessageVerifier do
+  @moduledoc false
+
+  @behaviour Pow.Plug.MessageVerifier
+
+  @impl true
+  def sign(_conn, salt, message, _config),
+    do: "signed.#{salt}.#{message}"
+
+  @impl true
+  def verify(_conn, salt, message, _config) do
+    prepend = "signed." <> salt <> "."
+
+    case String.replace(message, prepend, "") do
+      ^message -> :error
+      message  -> {:ok, message}
+    end
+  end
+end


### PR DESCRIPTION
There are potential timing attack vectors in the current token implementation. Tokens are looked up in the backend store without ensuring constant-time string comparison. While I don't know if this is an issue with Mnesia/ETS, it definitely is with a DB based store.

I've been working on two implementations:

1. Split-token; Store a verifier along with the token, use the first part of the token to look up, and the second part to constant-time compare with the stored verifier.
2. Sign token; Sign tokens for public consumption, verify before looking up in store.

I worked on both implementations, and the second makes more sense. Nothing needs to be passed on to the store, the Ecto modules stay the same, everything is dealt with in the Plug layer.

This PR will cause all current tokens to no longer work.