### PR TITLE
Update ReadMe with config explanation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,16 +54,15 @@ PRIV_PATH/repo/migrations/TIMESTAMP_create_user.ex
 Add the following to `config/config.exs`:
 
 ```elixir
+use Mix.Config
 
-# General application configuration
-config :my_app,
-  ecto_repos: [MyApp.Repo]
+# ... existing config
   
-# New configuration block placed futher down
-# See: https://github.com/danschultzer/pow/issues/17
 config :my_app, :pow,
   user: MyApp.Users.User,
   repo: MyApp.Repo
+
+# ... import_config
 ```
 
 Set up `WEB_PATH/endpoint.ex` to enable session based authentication (`Pow.Plug.Session` is added after `Plug.Session`):

--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ PRIV_PATH/repo/migrations/TIMESTAMP_create_user.ex
 Add the following to `config/config.exs`:
 
 ```elixir
+
+# General application configuration
+config :my_app,
+  ecto_repos: [MyApp.Repo]
+  
+# New configuration block placed futher down
+# See: https://github.com/danschultzer/pow/issues/17
 config :my_app, :pow,
   user: MyApp.Users.User,
   repo: MyApp.Repo


### PR DESCRIPTION
Adding some basic config annotation to avoid the `No :user configuration option found for user schema module.`
I just hit it as well and I think adding this will save new users some time & frustration in getting off the ground. 🤸‍♀ 