### PR TITLE
:allow_unconfirmed_access

### DIFF
--- a/lib/extensions/email_confirmation/ecto/context.ex
+++ b/lib/extensions/email_confirmation/ecto/context.ex
@@ -40,4 +40,14 @@ defmodule PowEmailConfirmation.Ecto.Context do
     |> Schema.confirm_email_changeset()
     |> Context.do_update(config)
   end
+
+  @doc """
+  Makes sure the confirmation token is present before send the email.
+  """
+  @spec ensure_confirmation_token(Context.user(), Config.t()) :: {:ok, Context.user()} | {:error, Context.changeset()}
+  def ensure_confirmation_token(user, config) do
+    user
+    |> Schema.ensure_confirmation_token_changeset()
+    |> Context.do_update(config)
+  end
 end

--- a/lib/extensions/email_confirmation/ecto/schema.ex
+++ b/lib/extensions/email_confirmation/ecto/schema.ex
@@ -95,6 +95,18 @@ defmodule PowEmailConfirmation.Ecto.Schema do
   end
   def changeset(changeset, _attrs, _config), do: changeset
 
+  def ensure_confirmation_token_changeset(%Changeset{} = changeset) do
+    changeset
+    |> Changeset.put_change(:email_confirmation_token, changeset.data.email_confirmation_token || UUID.generate())
+    |> Changeset.unique_constraint(:email_confirmation_token)
+  end
+
+  def ensure_confirmation_token_changeset(user) do
+    user
+    |> Changeset.change()
+    |> ensure_confirmation_token_changeset()
+  end
+
   defp built?(changeset), do: Ecto.get_meta(changeset.data, :state) == :built
 
   defp email_reverted?(changeset, attrs) do

--- a/lib/extensions/email_confirmation/phoenix/controllers/base.ex
+++ b/lib/extensions/email_confirmation/phoenix/controllers/base.ex
@@ -1,0 +1,22 @@
+defmodule PowEmailConfirmation.Phoenix.Base do
+
+  use Pow.Extension.Phoenix.Controller.Base
+
+  alias PowEmailConfirmation.Phoenix.ConfirmationController
+  alias PowEmailConfirmation.Phoenix.Mailer
+  alias PowEmailConfirmation.Plug
+
+  def send_confirmation_email(conn) do
+    user = Plug.refreshed_user_with_confirmation_token(conn)
+    url = confirmation_url(conn, user.email_confirmation_token)
+    unconfirmed_user = %{user | email: user.unconfirmed_email || user.email}
+    email = Mailer.email_confirmation(conn, unconfirmed_user, url)
+    Pow.Phoenix.Mailer.deliver(conn, email)
+
+    conn
+  end
+
+  defp confirmation_url(conn, token) do
+    routes(conn).url_for(conn, ConfirmationController, :show, [token])
+  end
+end

--- a/lib/extensions/email_confirmation/phoenix/controllers/confirmation_controller.ex
+++ b/lib/extensions/email_confirmation/phoenix/controllers/confirmation_controller.ex
@@ -23,7 +23,9 @@ defmodule PowEmailConfirmation.Phoenix.ConfirmationController do
   defp redirect_to(conn) do
     case Pow.Plug.current_user(conn) do
       nil   -> routes(conn).session_path(conn, :new)
-      _user -> routes(conn).registration_path(conn, :edit)
+      _user ->
+        routes(conn).after_email_confirmed_path(conn)
+        # routes(conn).registration_path(conn, :edit)
     end
   end
 end

--- a/lib/extensions/email_confirmation/phoenix/controllers/confirmation_controller.ex
+++ b/lib/extensions/email_confirmation/phoenix/controllers/confirmation_controller.ex
@@ -4,6 +4,18 @@ defmodule PowEmailConfirmation.Phoenix.ConfirmationController do
 
   alias Plug.Conn
   alias PowEmailConfirmation.Plug
+  alias PowEmailConfirmation.Phoenix.Base
+
+  @spec process_resend_confirmation(Conn.t(), map()) :: {:ok | :error, map(), Conn.t()}
+  def process_resend_confirmation(conn, _params), do: {:ok, conn}
+
+  @spec respond_resend_confirmation({:ok | :error, map(), Conn.t()}) :: Conn.t()
+  def respond_resend_confirmation({:ok, conn}) do
+    conn
+    |> Base.send_confirmation_email()
+    |> put_flash(:success, extension_messages(conn).confirmation_email_has_been_resent(conn))
+    |> redirect(to: routes(conn).after_sign_in_path(conn))
+  end
 
   @spec process_show(Conn.t(), map()) :: {:ok | :error, map(), Conn.t()}
   def process_show(conn, %{"id" => token}), do: Plug.confirm_email(conn, token)
@@ -11,21 +23,12 @@ defmodule PowEmailConfirmation.Phoenix.ConfirmationController do
   @spec respond_show({:ok | :error, map(), Conn.t()}) :: Conn.t()
   def respond_show({:ok, _user, conn}) do
     conn
-    |> put_flash(:info, extension_messages(conn).email_has_been_confirmed(conn))
-    |> redirect(to: redirect_to(conn))
+    |> put_flash(:success, extension_messages(conn).email_has_been_confirmed(conn))
+    |> redirect(to: routes(conn).after_sign_in_path(conn))
   end
   def respond_show({:error, _changeset, conn}) do
     conn
     |> put_flash(:error, extension_messages(conn).email_confirmation_failed(conn))
-    |> redirect(to: redirect_to(conn))
-  end
-
-  defp redirect_to(conn) do
-    case Pow.Plug.current_user(conn) do
-      nil   -> routes(conn).session_path(conn, :new)
-      _user ->
-        routes(conn).after_email_confirmed_path(conn)
-        # routes(conn).registration_path(conn, :edit)
-    end
+    |> redirect(to: routes(conn).after_sign_in_path(conn))
   end
 end

--- a/lib/extensions/email_confirmation/phoenix/controllers/controller_callbacks.ex
+++ b/lib/extensions/email_confirmation/phoenix/controllers/controller_callbacks.ex
@@ -48,7 +48,8 @@ defmodule PowEmailConfirmation.Phoenix.ControllerCallbacks do
   def before_respond(Pow.Phoenix.RegistrationController, :create, {:ok, user, conn}, _config) do
     return_path = routes(conn).after_registration_path(conn)
 
-    halt_unconfirmed(conn, {:ok, user, conn}, return_path)
+    conn = send_confirmation_email(user, conn, :create)
+    halt_or_continue(conn, {:ok, user, conn}, return_path)
   end
   def before_respond(Pow.Phoenix.RegistrationController, :create, {:error, changeset, conn}, _config) do
     case PowPlug.__prevent_user_enumeration__(conn, changeset) do
@@ -68,35 +69,32 @@ defmodule PowEmailConfirmation.Phoenix.ControllerCallbacks do
   def before_respond(Pow.Phoenix.SessionController, :create, {:ok, conn}, _config) do
     return_path = routes(conn).after_sign_in_path(conn)
 
-    halt_unconfirmed(conn, {:ok, conn}, return_path)
+    halt_or_continue(conn, {:ok, conn}, return_path)
   end
   def before_respond(PowInvitation.Phoenix.InvitationController, :update, {:ok, user, conn}, _config) do
     warn_unconfirmed(conn, user)
   end
 
-  defp halt_unconfirmed(conn, success_response, return_path) do
-    case Plug.email_unconfirmed?(conn) do
-      true  -> halt_and_send_confirmation_email(conn, return_path)
-      false -> success_response
+  defp halt_or_continue(conn, success_response, return_path) do
+    unconfirmed_access_allowed = !!Pow.Config.get(Pow.Plug.fetch_config(conn), :allow_unconfirmed_access)
+    email_is_unconfirmed = Plug.email_unconfirmed?(conn)
+
+    case {unconfirmed_access_allowed, email_is_unconfirmed} do
+      {false, true} ->
+        conn =
+          conn
+          |> PowPlug.delete()
+          |> redirect_with_email_confirmation_required(return_path)
+
+        {:halt, conn}
+
+      _otherwise ->
+        success_response
     end
   end
 
-  defp halt_and_send_confirmation_email(conn, return_path) do
-    send_confirmation_email(PowPlug.current_user(conn), conn)
-
-    conn =
-      conn
-      |> PowPlug.delete()
-      |> redirect_with_email_confirmation_required(return_path)
-
-    {:halt, conn}
-  end
-
   defp redirect_with_email_confirmation_required(conn, return_path) do
-    error = extension_messages(conn).email_confirmation_required(conn)
-
     conn
-    |> Phoenix.Controller.put_flash(:error, error)
     |> Phoenix.Controller.redirect(to: return_path)
   end
 
@@ -113,7 +111,7 @@ defmodule PowEmailConfirmation.Phoenix.ControllerCallbacks do
     error = extension_messages(conn).email_confirmation_required_for_update(conn)
     conn  = Phoenix.Controller.put_flash(conn, :error, error)
 
-    send_confirmation_email(user, conn)
+    conn = send_confirmation_email(user, conn, :update)
 
     {:ok, user, conn}
   end
@@ -124,16 +122,30 @@ defmodule PowEmailConfirmation.Phoenix.ControllerCallbacks do
   The user struct passed to the mailer will have the `:email` set to the
   `:unconfirmed_email` value if `:unconfirmed_email` is set.
   """
-  @spec send_confirmation_email(map(), Conn.t()) :: any()
-  def send_confirmation_email(user, conn) do
+  @spec send_confirmation_email(map(), Conn.t(), atom()) :: any()
+  def send_confirmation_email(user, conn, type) do
     url               = confirmation_url(conn, user.email_confirmation_token)
     unconfirmed_user  = %{user | email: user.unconfirmed_email || user.email}
     email             = Mailer.email_confirmation(conn, unconfirmed_user, url)
 
     Pow.Phoenix.Mailer.deliver(conn, email)
+    flash_message_confirmation_email_sent(conn, type)
   end
 
   defp confirmation_url(conn, token) do
     routes(conn).url_for(conn, ConfirmationController, :show, [token])
   end
+
+  defp flash_message_confirmation_email_sent(conn, type) do
+    message = case type do
+      :create ->
+        extension_messages(conn).email_confirmation_required(conn)
+      :update ->
+        extension_messages(conn).email_confirmation_required_for_update(conn)
+    end
+
+    conn
+    |> Phoenix.Controller.put_flash(:info, message)
+  end
+
 end

--- a/lib/extensions/email_confirmation/phoenix/messages.ex
+++ b/lib/extensions/email_confirmation/phoenix/messages.ex
@@ -8,6 +8,11 @@ defmodule PowEmailConfirmation.Phoenix.Messages do
   @doc """
   Flash message to show when email has been confirmed.
   """
+  def confirmation_email_has_been_resent(_conn), do: "A confirmation email has been sent."
+
+  @doc """
+  Flash message to show when email has been confirmed.
+  """
   def email_has_been_confirmed(_conn), do: "The email address has been confirmed."
 
   @doc """

--- a/lib/extensions/email_confirmation/phoenix/router.ex
+++ b/lib/extensions/email_confirmation/phoenix/router.ex
@@ -7,6 +7,7 @@ defmodule PowEmailConfirmation.Phoenix.Router do
   defmacro routes(_config) do
     quote location: :keep do
       Router.pow_resources "/confirm-email", ConfirmationController, only: [:show]
+      Router.pow_route :post, "/resend-confirmation", ConfirmationController, :resend_confirmation
     end
   end
 end

--- a/lib/extensions/email_confirmation/plug.ex
+++ b/lib/extensions/email_confirmation/plug.ex
@@ -44,6 +44,18 @@ defmodule PowEmailConfirmation.Plug do
     |> maybe_confirm_email(conn, config)
   end
 
+  @spec refreshed_user_with_confirmation_token(Conn.t()) :: any()
+  def refreshed_user_with_confirmation_token(conn) do
+    refreshed_user = conn
+      |> Plug.refresh_current_user()
+      |> Plug.current_user()
+
+      case Context.ensure_confirmation_token(refreshed_user, Plug.fetch_config(conn)) do
+        {:ok, maybe_updated_user} -> maybe_updated_user
+        {:error, _changeset} -> refreshed_user
+      end
+  end
+
   defp maybe_confirm_email(nil, conn, _config) do
     {:error, nil, conn}
   end

--- a/lib/extensions/reset_password/phoenix/controllers/reset_password_controller.ex
+++ b/lib/extensions/reset_password/phoenix/controllers/reset_password_controller.ex
@@ -72,7 +72,7 @@ defmodule PowResetPassword.Phoenix.ResetPasswordController do
   @spec respond_update({:ok, map(), Conn.t()}) :: Conn.t()
   def respond_update({:ok, _user, conn}) do
     conn
-    |> put_flash(:info, extension_messages(conn).password_has_been_reset(conn))
+    |> put_flash(:success, extension_messages(conn).password_has_been_reset(conn))
     |> redirect(to: routes(conn).session_path(conn, :new))
   end
   def respond_update({:error, changeset, conn}) do

--- a/lib/pow/phoenix/controllers/registration_controller.ex
+++ b/lib/pow/phoenix/controllers/registration_controller.ex
@@ -30,9 +30,7 @@ defmodule Pow.Phoenix.RegistrationController do
 
   @spec respond_create({:ok | :error, map(), Conn.t()}) :: Conn.t()
   def respond_create({:ok, _user, conn}) do
-    conn
-    |> put_flash(:info, messages(conn).user_has_been_created(conn))
-    |> redirect(to: routes(conn).after_registration_path(conn))
+    routes(conn).after_registration(conn)
   end
   def respond_create({:error, changeset, conn}) do
     conn
@@ -59,9 +57,7 @@ defmodule Pow.Phoenix.RegistrationController do
 
   @spec respond_update({:ok, map(), Conn.t()}) :: Conn.t()
   def respond_update({:ok, _user, conn}) do
-    conn
-    |> put_flash(:info, messages(conn).user_has_been_updated(conn))
-    |> redirect(to: routes(conn).after_user_updated_path(conn))
+    routes(conn).after_user_updated(conn)
   end
   def respond_update({:error, changeset, conn}) do
     conn
@@ -76,14 +72,10 @@ defmodule Pow.Phoenix.RegistrationController do
 
   @spec respond_delete({:ok | :error, map(), Conn.t()}) :: Conn.t()
   def respond_delete({:ok, _user, conn}) do
-    conn
-    |> put_flash(:info, messages(conn).user_has_been_deleted(conn))
-    |> redirect(to: routes(conn).after_user_deleted_path(conn))
+    routes(conn).after_user_deleted(conn)
   end
   def respond_delete({:error, _changeset, conn}) do
-    conn
-    |> put_flash(:error, messages(conn).user_could_not_be_deleted(conn))
-    |> redirect(to: routes(conn).path_for(conn, __MODULE__, :edit))
+    routes(conn).after_user_not_deleted(conn)
   end
 
   defp assign_create_path(conn, _opts) do

--- a/lib/pow/phoenix/controllers/session_controller.ex
+++ b/lib/pow/phoenix/controllers/session_controller.ex
@@ -39,9 +39,7 @@ defmodule Pow.Phoenix.SessionController do
   @doc false
   @spec respond_create({:ok | :error, Conn.t()}) :: Conn.t()
   def respond_create({:ok, conn}) do
-    conn
-    |> put_flash(:info, messages(conn).signed_in(conn))
-    |> redirect(to: routes(conn).after_sign_in_path(conn))
+    routes(conn).after_sign_in(conn)
   end
   def respond_create({:error, conn}) do
     conn
@@ -57,9 +55,7 @@ defmodule Pow.Phoenix.SessionController do
   @doc false
   @spec respond_delete({:ok, Conn.t()}) :: Conn.t()
   def respond_delete({:ok, conn}) do
-    conn
-    |> put_flash(:info, messages(conn).signed_out(conn))
-    |> redirect(to: routes(conn).after_sign_out_path(conn))
+    routes(conn).after_sign_out(conn)
   end
 
   defp assign_request_path(%{params: %{"request_path" => request_path}} = conn, _opts) do

--- a/lib/pow/phoenix/controllers/session_controller.ex
+++ b/lib/pow/phoenix/controllers/session_controller.ex
@@ -49,13 +49,18 @@ defmodule Pow.Phoenix.SessionController do
   end
 
   @doc false
-  @spec process_delete(Conn.t(), map()) :: {:ok, Conn.t()}
-  def process_delete(conn, _params), do: {:ok, Plug.delete(conn)}
+  @spec process_delete(Conn.t(), map()) :: {:ok, any(), Conn.t()}
+  def process_delete(conn, _params) do
+    conn = conn
+    |> Conn.assign(:signed_out_user, Plug.current_user(conn))
+    |> Plug.delete()
+    {:ok, conn}
+  end
 
   @doc false
-  @spec respond_delete({:ok, Conn.t()}) :: Conn.t()
+  @spec respond_delete({:ok, any(), Conn.t()}) :: Conn.t()
   def respond_delete({:ok, conn}) do
-    routes(conn).after_sign_out(conn)
+    routes(conn).after_sign_out(conn, Map.get(conn.assigns, :signed_out_user))
   end
 
   defp assign_request_path(%{params: %{"request_path" => request_path}} = conn, _opts) do

--- a/lib/pow/plug.ex
+++ b/lib/pow/plug.ex
@@ -32,6 +32,20 @@ defmodule Pow.Plug do
   end
 
   @doc """
+  Refreshes the current_user with the persistent version in case it changed
+  """
+  @spec refresh_current_user(Conn.t()) :: Conn.t()
+  def refresh_current_user(conn) do
+    config = fetch_config(conn)
+
+    {:ok, clauses} = current_user(conn, config)
+    |> Pow.Operations.fetch_primary_key_values(config)
+
+    refreshed_user = Pow.Operations.get_by(clauses, config)
+    create(conn, refreshed_user, config)
+  end
+
+  @doc """
   Assign an authenticated user to the connection.
 
   This will assign the user to the conn. The key is by default `:current_user`,


### PR DESCRIPTION
I added the `:allow_unconfirmed_access` option. It works fine for me.

But I haven't tested it deeply for now, especially haven't checked the tests, nor really tried the `update` case.

I also changed the logic so that confirmation email is sent once, not on every session open failed trial, because it would feel like too many emails for me.

To be discussed.