### PR TITLE
Fixup app atom from `:pow_demo` to `:my_app`

### DIFF
--- a/guides/api.md
+++ b/guides/api.md
@@ -311,7 +311,7 @@ defmodule MyAppWeb.APIAuthPlugTest do
   alias MyAppWeb.APIAuthPlug
   alias MyApp.{Repo, Users.User}
 
-  @pow_config [otp_app: :pow_demo]
+  @pow_config [otp_app: :my_app]
   @secret_key_base String.duplicate("abcdefghijklmnopqrstuvxyz0123456789", 2)
 
   test "can fetch, create, delete, and renew session for user", %{conn: conn} do


### PR DESCRIPTION
The rest of this guide refers to the app as `:my_app` but there's one spot where `:pow_demo` is referenced. Changing it here so it's easier to understand what params need to be changed to keep tests happy.