### PR TITLE
Make extension changeset methods overridable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 * [`Pow.Plug.Session`] Now sets a global lock when renewing the session
 * [`PowPersistentSession.Plug.Cookie`] Now sets a global lock when authenticating the user
 * [`PowEmailConfirmation.Plug`] Added `PowEmailConfirmation.Plug.sign_confirmation_token/2` to sign the `email_confirmation_token` to prevent timing attacks
-* [`PowEmailConfirmation.Plug`] Added `PowEmailConfirmation.Plug.confirm_email_by_token/2` to verify the signed `email_confirmation_token` to prevent timing attacks
+* [`PowEmailConfirmation.Plug`] Added `PowEmailConfirmation.Plug.load_user_by_token/2` to verify the signed `email_confirmation_token` to prevent timing attacks
+* [`PowEmailConfirmation.Plug`] Added `PowEmailConfirmation.Plug.confirm_email/2` with map as second argument
 * [`PowInvitation.Plug`] Added `PowInvitation.Plug.sign_invitation_token/2` to sign the `invitation_token`
 * [`PowInvitation.Plug`] Added `PowInvitation.Plug.load_invited_user_by_token/2` to verify the signed `invitation_token` to prevent timing attacks
 * [`PowResetPassword.Plug`] Changed `PowResetPassword.Plug.create_reset_token/2` to sign the `:token`
@@ -20,14 +21,21 @@
 * [`Pow.Plug`] Added `Pow.Plug.sign_token/4` to sign tokens
 * [`Pow.Plug`] Added `Pow.Plug.verify_token/4` to decode and verify signed tokens
 * [`Pow.Plug.MessageVerifier`] Added `Pow.Plug.MessageVerifier` module to sign and verify messages
+* [`PowEmailConfirmation.Ecto.Context`] Added `PowEmailConfirmation.Ecto.Context.confirm_email/3`
+* [`PowEmailConfirmation.Ecto.Schema`] Added `confirm_email_changeset/2` and `pow_confirm_email_changeset/2` to the macro
+* [`PowEmailConfirmation.Ecto.Schema`] Added `PowEmailConfirmation.Ecto.Schema.confirm_email_changeset/2`
+* [`PowInvitation.Ecto.Schema`] Added `accept_invitation_changeset/2` and `pow_accept_invitation_changeset/2` to the macro
+* [`PowResetPassword.Ecto.Schema`] Added `reset_password_changeset/2` and `pow_reset_password_changeset/2` to the macro
 
 ### Deprecations
 
-* [`PowEmailConfirmation.Plug`] `PowEmailConfirmation.Plug.confirm_email/2` has been deprecated in favor of `PowEmailConfirmation.Plug.confirm_email_by_token/2`
+* [`PowEmailConfirmation.Plug`] `PowEmailConfirmation.Plug.confirm_email/2` with token param as second argument has been deprecated in favor of `PowEmailConfirmation.Plug.load_user_by_token/2`, and `PowEmailConfirmation.Plug.confirm_email/2` with map as second argument
 * [`PowInvitation.Plug`] `PowInvitation.Plug.invited_user_from_token/2` has been deprecated in favor of `PowInvitation.Plug.load_invited_user_by_token/2`
 * [`PowInvitation.Plug`] `PowInvitation.Plug.assign_invited_user/2` has been deprecated
 * [`PowResetPassword.Plug`] `PowResetPassword.Plug.user_from_token/2` has been deprecated in favor of `PowResetPassword.Plug.load_user_by_token/2`
 * [`PowResetPassword.Plug`] `PowResetPassword.Plug.assign_reset_password_user/2` has been deprecated
+* [`PowEmailConfirmation.Ecto.Context`] `PowEmailConfirmation.Ecto.Context.confirm_email/2` deprecated in favor of `PowEmailConfirmation.Ecto.Context.confirm_email/3`
+* [`PowEmailConfirmation.Ecto.Schema`] `PowEmailConfirmation.Ecto.Schema.confirm_email_changeset/1` deprecated in favor of `PowEmailConfirmation.Ecto.Schema.confirm_email_changeset/2`
 
 ### Documentation
 

--- a/lib/extensions/email_confirmation/README.md
+++ b/lib/extensions/email_confirmation/README.md
@@ -30,7 +30,7 @@ To prevent that `PowPersistentSession` creates a new persistent session when the
 
 ## Test and seed
 
-If you want your user to be automatically confirmed in test and seed, you just have to call: `PowEmailConfirmation.Ecto.Context.confirm_email(user, otp_app: :my_app)`
+If you want your user to be automatically confirmed in test and seed, you just have to call: `PowEmailConfirmation.Ecto.Context.confirm_email(user, %{}, otp_app: :my_app)`
 
 You can also update or insert the row directly and set `email_confirmed_at: DateTime.utc_now()`.
 

--- a/lib/extensions/email_confirmation/ecto/context.ex
+++ b/lib/extensions/email_confirmation/ecto/context.ex
@@ -3,7 +3,6 @@ defmodule PowEmailConfirmation.Ecto.Context do
   Handles e-mail confirmation context for user.
   """
   alias Pow.{Config, Ecto.Context, Operations}
-  alias PowEmailConfirmation.Ecto.Schema
 
   @doc """
   Finds a user by the `email_confirmation_token` column.
@@ -32,12 +31,17 @@ defmodule PowEmailConfirmation.Ecto.Context do
   @doc """
   Confirms e-mail.
 
-  See `PowEmailConfirmation.Ecto.Schema.confirm_email_changeset/1`.
+  See `PowEmailConfirmation.Ecto.Schema.confirm_email_changeset/2`.
   """
-  @spec confirm_email(Context.user(), Config.t()) :: {:ok, Context.user()} | {:error, Context.changeset()}
-  def confirm_email(user, config) do
+  @spec confirm_email(Context.user(), map(), Config.t()) :: {:ok, Context.user()} | {:error, Context.changeset()}
+  def confirm_email(%user_mod{} = user, params, config) do
     user
-    |> Schema.confirm_email_changeset()
+    |> user_mod.confirm_email_changeset(params)
     |> Context.do_update(config)
   end
+
+  # TODO: Remove by 1.1.0
+  @doc false
+  @deprecated "Use confirm_email/3 instead"
+  def confirm_email(user, config), do: confirm_email(user, %{}, config)
 end

--- a/lib/extensions/email_confirmation/email_confirmation.ex
+++ b/lib/extensions/email_confirmation/email_confirmation.ex
@@ -6,6 +6,9 @@ defmodule PowEmailConfirmation do
   def ecto_schema?(), do: true
 
   @impl true
+  def use_ecto_schema?(), do: true
+
+  @impl true
   def phoenix_controller_callbacks?(), do: true
 
   @impl true

--- a/lib/extensions/invitation/ecto/context.ex
+++ b/lib/extensions/invitation/ecto/context.ex
@@ -3,7 +3,6 @@ defmodule PowInvitation.Ecto.Context do
   Handles invitation context for user.
   """
   alias Pow.{Config, Ecto.Context, Operations}
-  alias PowInvitation.Ecto.Schema
 
   @doc """
   Creates an invited user.
@@ -26,9 +25,9 @@ defmodule PowInvitation.Ecto.Context do
   See `PowInvitation.Ecto.Schema.accept_invitation_changeset/2`.
   """
   @spec update(Context.user(), map(), Config.t()) :: {:ok, Context.user()} | {:error, Context.changeset()}
-  def update(user, params, config) do
+  def update(%user_mod{} = user, params, config) do
     user
-    |> Schema.accept_invitation_changeset(params)
+    |> user_mod.accept_invitation_changeset(params)
     |> Context.do_update(config)
   end
 

--- a/lib/extensions/invitation/ecto/schema.ex
+++ b/lib/extensions/invitation/ecto/schema.ex
@@ -64,7 +64,11 @@ defmodule PowInvitation.Ecto.Schema do
 
       defdelegate pow_invite_changeset(changeset, invited_by, attrs), to: unquote(__MODULE__), as: :invite_changeset
 
-      defoverridable invite_changeset: 3
+      def accept_invitation_changeset(changeset, attrs), do: pow_accept_invitation_changeset(changeset, attrs)
+
+      defdelegate pow_accept_invitation_changeset(changeset, attrs), to: unquote(__MODULE__), as: :accept_invitation_changeset
+
+      defoverridable invite_changeset: 3, accept_invitation_changeset: 2
     end
   end
 

--- a/lib/extensions/invitation/plug.ex
+++ b/lib/extensions/invitation/plug.ex
@@ -44,6 +44,9 @@ defmodule PowInvitation.Plug do
   @doc """
   Updates current user in the connection with the params.
 
+  Expects the invited user to exist in `conn.assigns` for key
+  `:invited_user`.
+
   If successful the session will be regenerated.
   """
   @spec update_user(Conn.t(), map()) :: {:ok, map(), Conn.t()} | {:error, map(), Conn.t()}
@@ -73,9 +76,9 @@ defmodule PowInvitation.Plug do
   defp signing_salt(), do: Atom.to_string(__MODULE__)
 
   @doc """
-  Verifies the token and fetches invited user by the invitation token.
+  Verifies the signed token and fetches invited user.
 
-  If a user is found, it'll be assigned to `conn.assign` for key
+  If a user is found, it'll be assigned to `conn.assigns` for key
   `:invited_user`.
 
   The token should have been signed with `sign_invitation_token/2`. The token

--- a/lib/extensions/reset_password/ecto/context.ex
+++ b/lib/extensions/reset_password/ecto/context.ex
@@ -7,9 +7,9 @@ defmodule PowResetPassword.Ecto.Context do
   def get_by_email(email, config), do: Operations.get_by([email: email], config)
 
   @spec update_password(Context.user(), map(), Config.t()) :: {:ok, Context.user()} | {:error, Context.changeset()}
-  def update_password(user, params, config) do
+  def update_password(%user_mod{} = user, params, config) do
     user
-    |> Schema.reset_password_changeset(params)
+    |> user_mod.reset_password_changeset(params)
     |> Context.do_update(config)
   end
 

--- a/lib/extensions/reset_password/ecto/schema.ex
+++ b/lib/extensions/reset_password/ecto/schema.ex
@@ -10,6 +10,18 @@ defmodule PowResetPassword.Ecto.Schema do
     Schema.require_schema_field!(module, :email, PowResetPassword)
   end
 
+  @doc false
+  @impl true
+  defmacro __using__(_config) do
+    quote do
+      def reset_password_changeset(changeset, attrs), do: pow_reset_password_changeset(changeset, attrs)
+
+      defdelegate pow_reset_password_changeset(changeset, attrs), to: unquote(__MODULE__), as: :reset_password_changeset
+
+      defoverridable reset_password_changeset: 2
+    end
+  end
+
   @spec reset_password_changeset(map(), map()) :: Changeset.t()
   def reset_password_changeset(%user_mod{} = user, params) do
     user

--- a/lib/extensions/reset_password/plug.ex
+++ b/lib/extensions/reset_password/plug.ex
@@ -5,7 +5,7 @@ defmodule PowResetPassword.Plug do
   alias Plug.Conn
   alias Pow.{Config, Plug, Store.Backend.EtsCache, UUID}
   alias PowResetPassword.Ecto.Context, as: ResetPasswordContext
-  alias PowResetPassword.{Ecto.Schema, Store.ResetTokenCache}
+  alias PowResetPassword.Store.ResetTokenCache
 
   @doc """
   Creates a changeset from the user fetched in the connection.
@@ -14,7 +14,7 @@ defmodule PowResetPassword.Plug do
   def change_user(conn, params \\ %{}) do
     user = reset_password_user(conn) || user_struct(conn)
 
-    Schema.reset_password_changeset(user, params)
+    user.__struct__.reset_password_changeset(user, params)
   end
 
   defp user_struct(conn) do
@@ -71,9 +71,9 @@ defmodule PowResetPassword.Plug do
   defp signing_salt(), do: Atom.to_string(__MODULE__)
 
   @doc """
-  Verifies the signed token and fetches invited user from store.
+  Verifies the signed token and fetches user from store.
 
-  If a user is found, it'll be assigned to `conn.assign` for key
+  If a user is found, it'll be assigned to `conn.assigns` for key
   `:reset_password_user`.
 
   The token will be decoded and verified with `Pow.Plug.verify_token/4`.
@@ -123,6 +123,9 @@ defmodule PowResetPassword.Plug do
 
   @doc """
   Updates the password for the user fetched in the connection.
+
+  Expects the user to exist in `conn.assigns` for key
+  `:reset_password_user`.
 
   See `create_reset_token/2` for more on `:reset_password_token_store` config
   option.

--- a/lib/extensions/reset_password/reset_password.ex
+++ b/lib/extensions/reset_password/reset_password.ex
@@ -6,6 +6,9 @@ defmodule PowResetPassword do
   def ecto_schema?(), do: true
 
   @impl true
+  def use_ecto_schema?(), do: true
+
+  @impl true
   def phoenix_messages?(), do: true
 
   @impl true

--- a/test/extensions/email_confirmation/ecto/context_test.exs
+++ b/test/extensions/email_confirmation/ecto/context_test.exs
@@ -19,9 +19,11 @@ defmodule PowEmailConfirmation.Ecto.ContextTest do
     end
   end
 
+  @valid_params %{}
+
   describe "confirm_email/2" do
     test "confirms with no :unconfirmed_email" do
-      assert {:ok, user} = Context.confirm_email(@user, @config)
+      assert {:ok, user} = Context.confirm_email(@user, @valid_params, @config)
       assert user.email_confirmed_at
       assert user.email == "test@example.com"
     end
@@ -30,14 +32,14 @@ defmodule PowEmailConfirmation.Ecto.ContextTest do
       previously_confirmed_at = DateTime.from_iso8601("2018-01-01 00:00:00")
       user                    = %{@user | email_confirmed_at: previously_confirmed_at}
 
-      assert {:ok, user} = Context.confirm_email(user, @config)
+      assert {:ok, user} = Context.confirm_email(user, @valid_params, @config)
       assert user.email_confirmed_at == previously_confirmed_at
     end
 
     test "changes :email to :unconfirmed_email" do
       user = %{@user | unconfirmed_email: "new@example.com"}
 
-      assert {:ok, user} = Context.confirm_email(user, @config)
+      assert {:ok, user} = Context.confirm_email(user, @valid_params, @config)
       assert user.email == "new@example.com"
       refute user.unconfirmed_email
     end
@@ -45,7 +47,7 @@ defmodule PowEmailConfirmation.Ecto.ContextTest do
     test "handles unique constraint" do
       user = %{@user | unconfirmed_email: "taken@example.com"}
 
-      assert {:error, changeset} = Context.confirm_email(user, @config)
+      assert {:error, changeset} = Context.confirm_email(user, @valid_params, @config)
       assert changeset.errors[:email] == {"has already been taken", constraint: :unique, constraint_name: "users_email_index"}
     end
   end
@@ -62,7 +64,7 @@ defmodule PowEmailConfirmation.Ecto.ContextTest do
 
     updated_user =
       new_user
-      |> Schema.confirm_email_changeset()
+      |> Schema.confirm_email_changeset(%{})
       |> Changeset.apply_changes()
       |> Ecto.put_meta(state: :loaded)
 
@@ -86,7 +88,7 @@ defmodule PowEmailConfirmation.Ecto.ContextTest do
 
     updated_user =
       new_user
-      |> Schema.confirm_email_changeset()
+      |> Schema.confirm_email_changeset(%{})
       |> Changeset.apply_changes()
       |> Ecto.put_meta(state: :loaded)
 

--- a/test/extensions/email_confirmation/ecto/schema_test.exs
+++ b/test/extensions/email_confirmation/ecto/schema_test.exs
@@ -5,8 +5,28 @@ defmodule PowEmailConfirmation.Ecto.SchemaTest do
   alias PowEmailConfirmation.Ecto.Schema
   alias PowEmailConfirmation.Test.{RepoMock, Users.User}
 
-  @password          "secret1234"
-  @valid_params     %{email: "test@example.com", password: @password, password_confirmation: @password, current_password: @password}
+  @password     "secret1234"
+  @valid_params %{email: "test@example.com", password: @password, password_confirmation: @password, current_password: @password}
+
+  defmodule OverridenMethodsUser do
+    @moduledoc false
+    use Ecto.Schema
+    use Pow.Ecto.Schema
+    use Pow.Extension.Ecto.Schema,
+      extensions: [PowEmailConfirmation]
+
+    schema "users" do
+      pow_user_fields()
+
+      timestamps()
+    end
+
+    def confirm_email_changeset(user_or_changeset, params) do
+      user_or_changeset
+      |> pow_current_password_changeset(params)
+      |> pow_confirm_email_changeset(params)
+    end
+  end
 
   test "user_schema/1" do
     user = %User{}
@@ -124,7 +144,7 @@ defmodule PowEmailConfirmation.Ecto.SchemaTest do
     end
 
     test "updates :email_confirmed_at", %{user: user} do
-      changeset = Schema.confirm_email_changeset(user)
+      changeset = Schema.confirm_email_changeset(user, %{})
 
       assert changeset.valid?
       assert changeset.changes.email_confirmed_at
@@ -142,7 +162,7 @@ defmodule PowEmailConfirmation.Ecto.SchemaTest do
 
       {:ok, user} =
         user
-        |> Schema.confirm_email_changeset()
+        |> Schema.confirm_email_changeset(%{})
         |> RepoMock.update([])
 
       assert user.email_confirmed_at
@@ -159,13 +179,28 @@ defmodule PowEmailConfirmation.Ecto.SchemaTest do
 
       {:ok, user} =
         user
-        |> Schema.confirm_email_changeset()
+        |> Schema.confirm_email_changeset(%{})
         |> RepoMock.update([])
 
-      changeset = Schema.confirm_email_changeset(user)
+      changeset = Schema.confirm_email_changeset(user, %{})
 
       assert changeset.valid?
       assert changeset.changes == %{}
+    end
+
+    test "with overridden method" do
+      {:ok, user} =
+        %OverridenMethodsUser{}
+        |> OverridenMethodsUser.changeset(@valid_params)
+        |> RepoMock.insert([])
+
+      changeset = OverridenMethodsUser.confirm_email_changeset(user, %{})
+
+      refute changeset.valid?
+
+      changeset = OverridenMethodsUser.confirm_email_changeset(user, %{"current_password" => @password})
+
+      assert changeset.valid?
     end
   end
 end

--- a/test/extensions/invitation/ecto/schema_test.exs
+++ b/test/extensions/invitation/ecto/schema_test.exs
@@ -6,7 +6,7 @@ defmodule PowInvitation.Ecto.SchemaTest do
   alias PowInvitation.PowEmailConfirmation.Test.Users.User, as: UserEmailConfirmation
   alias PowInvitation.Test.Users.User
 
-  defmodule OverrideInviteChangesetUser do
+  defmodule OverridenMethodsUser do
     @moduledoc false
     use Ecto.Schema
     use Pow.Ecto.Schema
@@ -15,6 +15,7 @@ defmodule PowInvitation.Ecto.SchemaTest do
 
     schema "users" do
       field :organization_id, :integer
+      field :invitation_accepted_ip, :string
 
       pow_user_fields()
 
@@ -25,6 +26,12 @@ defmodule PowInvitation.Ecto.SchemaTest do
       user_or_changeset
       |> pow_invite_changeset(invited_by, params)
       |> Ecto.Changeset.put_change(:organization_id, 1)
+    end
+
+    def accept_invitation_changeset(user_or_changeset, params) do
+      user_or_changeset
+      |> pow_accept_invitation_changeset(params)
+      |> Ecto.Changeset.put_change(:invitation_accepted_ip, "127.0.0.1")
     end
   end
 
@@ -59,7 +66,7 @@ defmodule PowInvitation.Ecto.SchemaTest do
     end
 
     test "with overridden method" do
-      changeset = OverrideInviteChangesetUser.invite_changeset(%OverrideInviteChangesetUser{}, @invited_by, @valid_params)
+      changeset = OverridenMethodsUser.invite_changeset(%OverridenMethodsUser{}, @invited_by, @valid_params)
 
       assert changeset.valid?
       assert changeset.changes.organization_id == 1
@@ -101,6 +108,13 @@ defmodule PowInvitation.Ecto.SchemaTest do
       assert changeset.valid?
       assert changeset.changes[:email_confirmation_token]
       assert changeset.changes[:unconfirmed_email] == "new@example.com"
+    end
+
+    test "with overridden method" do
+      changeset = OverridenMethodsUser.accept_invitation_changeset(%OverridenMethodsUser{}, @valid_params)
+
+      assert changeset.valid?
+      assert changeset.changes.invitation_accepted_ip == "127.0.0.1"
     end
   end
 end

--- a/test/extensions/reset_password/ecto/schema_test.exs
+++ b/test/extensions/reset_password/ecto/schema_test.exs
@@ -1,0 +1,47 @@
+defmodule PowResetPassword.Ecto.SchemaTest do
+  use ExUnit.Case
+  doctest PowResetPassword.Ecto.Schema
+
+  alias PowResetPassword.Ecto.Schema
+  alias PowResetPassword.Test.Users.User
+
+  defmodule OverridenMethodUser do
+    @moduledoc false
+    use Ecto.Schema
+    use Pow.Ecto.Schema
+    use Pow.Extension.Ecto.Schema,
+      extensions: [PowResetPassword]
+
+    schema "users" do
+      field :password_reset_at, :utc_datetime
+
+      pow_user_fields()
+
+      timestamps()
+    end
+
+    def reset_password_changeset(user_or_changeset, params) do
+      user_or_changeset
+      |> pow_reset_password_changeset(params)
+      |> Ecto.Changeset.put_change(:password_reset_at, DateTime.utc_now())
+    end
+  end
+
+  describe "reset_password_changeset/2" do
+    @valid_params %{password: "password", password_confirmation: "password"}
+
+    test "with valid params" do
+      changeset = Schema.reset_password_changeset(%User{}, @valid_params)
+
+      assert changeset.valid?
+      assert changeset.changes.password_hash
+    end
+
+    test "with overridden method" do
+      changeset = OverridenMethodUser.reset_password_changeset(%OverridenMethodUser{}, @valid_params)
+
+      assert changeset.valid?
+      assert changeset.changes.password_reset_at
+    end
+  end
+end


### PR DESCRIPTION
Resolves #444

It makes sense that all extension methods can be overridden to add custom logic. This does exactly that and also streamlines `PowEmailConfirmation.Plug` so it works the same way as `PowResetPassword.Plug` and `PowInvitation.Plug` where the user is first loaded by a plug method and then the context action is called.