### PR TITLE
Make schema assocs/fields require method overridable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [`PowEmailConfirmation.Ecto.Schema`] Added `PowEmailConfirmation.Ecto.Schema.confirm_email_changeset/2`
 * [`PowInvitation.Ecto.Schema`] Added `accept_invitation_changeset/2` and `pow_accept_invitation_changeset/2` to the macro
 * [`PowResetPassword.Ecto.Schema`] Added `reset_password_changeset/2` and `pow_reset_password_changeset/2` to the macro
+* [`Pow.Ecto.Schema`] Custom method can now be used for assocs and fields requirement callback by setting `@pow_require_assocs_callback` and `@pow_require_fields_callback` module attributes
 
 ### Deprecations
 

--- a/test/pow/ecto/schema_test.exs
+++ b/test/pow/ecto/schema_test.exs
@@ -119,4 +119,26 @@ defmodule Pow.Ecto.SchemaTest do
         Module.create(__MODULE__.MissingFieldsUser, contents, __ENV__)
       end
   end
+
+  test "handles custom callback for assocs and field require" do
+    contents =
+      quote do
+        use Ecto.Schema
+        use Pow.Ecto.Schema
+
+        @pow_assocs {:belongs_to, :invited_by, __MODULE__, foreign_key: :user_id}
+        @pow_require_assocs_callback :pow_require_assocs_callback
+        @pow_require_fields_callback :pow_require_fields_callback
+
+        schema "users" do
+          timestamps()
+        end
+
+        def pow_require_assocs_callback(_assocs), do: :ok
+
+        def pow_require_fields_callback(_fields), do: :ok
+      end
+
+    Module.create(__MODULE__.NoRaise, contents, __ENV__)
+  end
 end

--- a/test/pow/ecto/schema_test.exs
+++ b/test/pow/ecto/schema_test.exs
@@ -69,9 +69,9 @@ defmodule Pow.Ecto.SchemaTest do
     assert %{on_delete: :delete_all} = OverrideAssocUser.__schema__(:association, :children)
   end
 
-  module_raised_with =
-    try do
-      defmodule MissingAssocsUser do
+  test "requires assocs defined" do
+    contents =
+      quote do
         use Ecto.Schema
         use Pow.Ecto.Schema
 
@@ -82,23 +82,22 @@ defmodule Pow.Ecto.SchemaTest do
           timestamps()
         end
       end
-    rescue
-      e in Pow.Ecto.Schema.SchemaError -> e.message
-    end
 
-  test "requires assocs defined" do
-    assert unquote(module_raised_with) ==
+    assert_raise Pow.Ecto.Schema.SchemaError,
       """
       Please define the following association(s) in the schema for Pow.Ecto.SchemaTest.MissingAssocsUser:
 
       belongs_to :invited_by, Pow.Ecto.SchemaTest.MissingAssocsUser, [foreign_key: :user_id]
       has_many :invited, Pow.Ecto.SchemaTest.MissingAssocsUser
-      """
+      """,
+      fn ->
+        Module.create(__MODULE__.MissingAssocsUser, contents, __ENV__)
+      end
   end
 
-  module_raised_with =
-    try do
-      defmodule MissingFieldsUser do
+  test "requires fields defined" do
+    contents =
+      quote do
         use Ecto.Schema
         use Pow.Ecto.Schema
 
@@ -106,12 +105,8 @@ defmodule Pow.Ecto.SchemaTest do
           timestamps()
         end
       end
-    rescue
-      e in Pow.Ecto.Schema.SchemaError -> e.message
-    end
 
-  test "requires fields defined" do
-    assert unquote(module_raised_with) ==
+    assert_raise Pow.Ecto.Schema.SchemaError,
       """
       Please define the following field(s) in the schema for Pow.Ecto.SchemaTest.MissingFieldsUser:
 
@@ -119,6 +114,9 @@ defmodule Pow.Ecto.SchemaTest do
       field :password_hash, :string
       field :current_password, :string, [virtual: true]
       field :password, :string, [virtual: true]
-      """
+      """,
+      fn ->
+        Module.create(__MODULE__.MissingFieldsUser, contents, __ENV__)
+      end
   end
 end

--- a/test/pow/phoenix/router_test.exs
+++ b/test/pow/phoenix/router_test.exs
@@ -1,63 +1,83 @@
-module_raised_with =
-  try do
-    defmodule Pow.Test.Phoenix.RouterAliasScope do
-      @moduledoc false
-      use Phoenix.Router
-      use Pow.Phoenix.Router
-
-      scope "/", Test do
-        pow_routes()
-      end
-    end
-  rescue
-    e in ArgumentError -> e.message
-  else
-    _ -> raise "Scope with alias didn't throw any error"
-  end
-
-defmodule Pow.Test.Phoenix.OverriddenRouteRouter do
-  @moduledoc false
-
-  use Phoenix.Router
-  use Pow.Phoenix.Router
-
-  scope "/", Pow.Phoenix, as: "pow" do
-    get "/registration/overridden", RegistrationController, :new
-    resources "/registration/overridden", RegistrationController, only: [:edit], singleton: true
-  end
-
-  scope "/:extra" do
-    pow_routes()
-  end
-
-  scope "/" do
-    pow_routes()
-  end
-
-  def phoenix_routes, do: @phoenix_routes
-end
-
 defmodule Pow.Phoenix.RouterTest do
   use ExUnit.Case
   doctest Pow.Phoenix.Router
 
   alias Phoenix.ConnTest
-  alias Pow.Test.Phoenix.OverriddenRouteRouter.Helpers, as: OverriddenRoutes
-
-  @conn ConnTest.build_conn()
 
   test "validates no aliases" do
-    assert unquote(module_raised_with) =~ "Pow routes should not be defined inside scopes with aliases: Test"
-    assert unquote(module_raised_with) =~ "scope \"/\", Test do"
+    contents =
+      quote do
+        use Phoenix.Router
+        use Pow.Phoenix.Router
+
+        scope "/", Test do
+          pow_routes()
+        end
+      end
+
+    assert_raise ArgumentError,
+      """
+      Pow routes should not be defined inside scopes with aliases: Test
+
+      Please consider separating your scopes:
+
+        scope "/" do
+          pipe_through :browser
+
+          pow_routes()
+        end
+
+        scope "/", Test do
+          pipe_through :browser
+
+          get "/", PageController, :index
+        end
+      """,
+      fn ->
+        Module.create(__MODULE__.RouterAliasScope, contents, __ENV__)
+      end
   end
 
   test "can override routes" do
-    assert unquote(OverriddenRoutes.pow_registration_path(@conn, :new)) == "/registration/overridden"
-    assert unquote(OverriddenRoutes.pow_registration_path(@conn, :new, "test")) == "/test/registration/new"
-    assert Enum.count(Pow.Test.Phoenix.OverriddenRouteRouter.phoenix_routes(), &(&1.plug == Pow.Phoenix.RegistrationController && &1.plug_opts == :new)) == 2
+    contents =
+      quote do
+        use Phoenix.Router
+        use Pow.Phoenix.Router
 
-    assert unquote(OverriddenRoutes.pow_registration_path(@conn, :edit)) == "/registration/overridden/edit"
-    assert unquote(OverriddenRoutes.pow_registration_path(@conn, :edit, "test")) == "/test/registration/edit"
-    assert Enum.count(Pow.Test.Phoenix.OverriddenRouteRouter.phoenix_routes(), &(&1.plug == Pow.Phoenix.RegistrationController && &1.plug_opts == :edit)) == 2
+        scope "/", Pow.Phoenix, as: "pow" do
+          get "/registration/overridden", RegistrationController, :new
+          resources "/registration/overridden", RegistrationController, only: [:edit], singleton: true
+        end
+
+        scope "/:extra" do
+          pow_routes()
+        end
+
+        scope "/" do
+          pow_routes()
+        end
+
+        def phoenix_routes, do: @phoenix_routes
+      end
+
+    Module.create(__MODULE__.OverriddenRouteRouter, contents, __ENV__)
+
+    contents =
+      quote do
+        alias unquote(__MODULE__).OverriddenRouteRouter
+        alias unquote(__MODULE__).OverriddenRouteRouter.Helpers, as: Routes
+
+        @conn ConnTest.build_conn()
+
+        assert Routes.pow_registration_path(@conn, :new) == "/registration/overridden"
+        assert Routes.pow_registration_path(@conn, :new, "test") == "/test/registration/new"
+        assert Enum.count(OverriddenRouteRouter.phoenix_routes(), &(&1.plug == Pow.Phoenix.RegistrationController && &1.plug_opts == :new)) == 2
+
+        assert Routes.pow_registration_path(@conn, :edit) == "/registration/overridden/edit"
+        assert Routes.pow_registration_path(@conn, :edit, "test") == "/test/registration/edit"
+        assert Enum.count(OverriddenRouteRouter.phoenix_routes(), &(&1.plug == Pow.Phoenix.RegistrationController && &1.plug_opts == :edit)) == 2
+      end
+
+    Module.create(__MODULE__.OverriddenRouteRouterTest, contents, __ENV__)
   end
 end


### PR DESCRIPTION
Resolves #445 

This makes it possible to set up custom require logic for assocs/fields like this:

```elixir

defmodule MyApp.Users.User do
  use Ecto.Schema
  use Pow.Ecto.Schema, user_id_field: :email

  @pow_require_assocs_callback :pow_require_assocs_callback
  @pow_require_fields_callback :pow_require_fields_callback

  def pow_require_assocs_callback(assocs) do
    IO.warn "Missing assocs:\n\n\#{Enum.join(assocs, "\n")}"
  end

  def pow_require_fields_callback(fields) do
    IO.warn "Missing fields:\n\n\#{Enum.join(fields, "\n")}"
  end

  # ...
end
```

I'm not completely sure this is the best way to deal with it though. I would like to make it possible to just use private methods so unused warnings can come up if the API changes in the future.