### PR TITLE
Now emits warning instead of raising during compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [`PowEmailConfirmation.Ecto.Schema`] Added `PowEmailConfirmation.Ecto.Schema.confirm_email_changeset/2`
 * [`PowInvitation.Ecto.Schema`] Added `accept_invitation_changeset/2` and `pow_accept_invitation_changeset/2` to the macro
 * [`PowResetPassword.Ecto.Schema`] Added `reset_password_changeset/2` and `pow_reset_password_changeset/2` to the macro
+* [`Pow.Ecto.Schema`] Now emits a warning instead of raising error with missing fields/associations
 
 ### Deprecations
 

--- a/lib/pow/ecto/schema.ex
+++ b/lib/pow/ecto/schema.ex
@@ -94,9 +94,9 @@ defmodule Pow.Ecto.Schema do
         end
       end
 
-  An `@after_compile` callback will raise an error if there are missing fields
-  or associations, so you can forego the `pow_user_fields/0` call, and write
-  out the whole schema instead:
+  An `@after_compile` callback will emit IO warning if there are missing fields
+  or associations. You can forego the `pow_user_fields/0` call, and write out
+  the whole schema instead:
 
       defmodule MyApp.Users.User do
         use Ecto.Schema
@@ -112,6 +112,10 @@ defmodule Pow.Ecto.Schema do
           timestamps()
         end
       end
+
+  If you would like these warnings to be raised during compilation you can add
+  `elixirc_options: [warnings_as_errors: true]` to the project options in
+  `mix.exs`.
 
   ## Customize Pow changeset
 
@@ -347,17 +351,17 @@ defmodule Pow.Ecto.Schema do
     end)
     |> case do
       []         -> :ok
-      assoc_defs -> raise_missing_assocs_error(module, assoc_defs)
+      assoc_defs -> warn_missing_assocs_error(module, assoc_defs)
     end
   end
 
-  defp raise_missing_assocs_error(module, assoc_defs) do
-    raise SchemaError, message:
+  defp warn_missing_assocs_error(module, assoc_defs) do
+    IO.warn(
       """
       Please define the following association(s) in the schema for #{inspect module}:
 
       #{Enum.join(assoc_defs, "\n")}
-      """
+      """)
   end
 
   @doc false
@@ -375,7 +379,7 @@ defmodule Pow.Ecto.Schema do
     end)
     |> case do
       []         -> :ok
-      field_defs -> raise_missing_fields_error(module, field_defs)
+      field_defs -> warn_missing_fields_error(module, field_defs)
     end
   end
 
@@ -391,13 +395,13 @@ defmodule Pow.Ecto.Schema do
     not Enum.member?(existing_fields, {name, type})
   end
 
-  defp raise_missing_fields_error(module, field_defs) do
-    raise SchemaError, message:
+  defp warn_missing_fields_error(module, field_defs) do
+    IO.warn(
       """
       Please define the following field(s) in the schema for #{inspect module}:
 
       #{Enum.join(field_defs, "\n")}
-      """
+      """)
   end
 
   @doc """

--- a/test/pow/ecto/schema_test.exs
+++ b/test/pow/ecto/schema_test.exs
@@ -69,8 +69,11 @@ defmodule Pow.Ecto.SchemaTest do
     assert %{on_delete: :delete_all} = OverrideAssocUser.__schema__(:association, :children)
   end
 
-  module_raised_with =
-    try do
+  import ExUnit.CaptureIO
+  require Logger
+
+  test "warns assocs defined" do
+    assert capture_io(:stderr, fn ->
       defmodule MissingAssocsUser do
         use Ecto.Schema
         use Pow.Ecto.Schema
@@ -82,12 +85,7 @@ defmodule Pow.Ecto.SchemaTest do
           timestamps()
         end
       end
-    rescue
-      e in Pow.Ecto.Schema.SchemaError -> e.message
-    end
-
-  test "requires assocs defined" do
-    assert unquote(module_raised_with) ==
+    end) =~
       """
       Please define the following association(s) in the schema for Pow.Ecto.SchemaTest.MissingAssocsUser:
 
@@ -96,8 +94,8 @@ defmodule Pow.Ecto.SchemaTest do
       """
   end
 
-  module_raised_with =
-    try do
+  test "warns fields defined" do
+    assert capture_io(:stderr, fn ->
       defmodule MissingFieldsUser do
         use Ecto.Schema
         use Pow.Ecto.Schema
@@ -106,12 +104,7 @@ defmodule Pow.Ecto.SchemaTest do
           timestamps()
         end
       end
-    rescue
-      e in Pow.Ecto.Schema.SchemaError -> e.message
-    end
-
-  test "requires fields defined" do
-    assert unquote(module_raised_with) ==
+    end) =~
       """
       Please define the following field(s) in the schema for Pow.Ecto.SchemaTest.MissingFieldsUser:
 


### PR DESCRIPTION
Resolves #445

It makes a lot more sense to just emit a warning instead of raising. Then the dev can just use the `--warnings-as-errors` option to ensure it compiles correctly.

Supersedes #447