### PR TITLE
Set `:pow_reset_password_decoded_token` private key in conn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 * [`Mix.Tasks.Pow.Extension.Phoenix.Gen.Templates`] `mix pow.extension.phoenix.gen.templates` now dynamically loads template list from the extension base module
+* [`PowResetPassword.Plug`] `PowResetPassword.Plug.load_user_by_token/2` now sets a `:pow_reset_password_decoded_token` key in `conn.private` that will be used in `PowResetPassword.Plug.update_user_password/2`
 
 ## v1.0.19 (2020-03-13)
 

--- a/test/extensions/reset_password/plug_test.exs
+++ b/test/extensions/reset_password/plug_test.exs
@@ -1,0 +1,24 @@
+defmodule PowResetPassword.PlugTest do
+  use ExUnit.Case
+  doctest PowResetPassword.Plug
+
+  alias Plug.Conn
+  alias Pow.Plug, as: PowPlug
+  alias PowResetPassword.{Plug, Test, Test.Users.User}
+
+  import ExUnit.CaptureIO
+
+  describe "update_user_password/2" do
+    @valid_params %{"password" => "secret1234", "password_confirmation" => "secret1234"}
+
+    test "without decoded token warns" do
+      assert capture_io(:stderr, fn ->
+        assert {:ok, _user, _conn} =
+          %Conn{}
+          |> PowPlug.put_config(Test.pow_config())
+          |> Conn.assign(:reset_password_user, %User{id: 1})
+          |> Plug.update_user_password(@valid_params)
+      end) =~ "no `:pow_reset_password_decoded_token` key found in `conn.private`, please call `PowResetPassword.Plug.load_user_by_token/2` first"
+    end
+  end
+end


### PR DESCRIPTION
Resolves #463 and #462 

The `PowResetPassword.Plug.load_user_by_token/2` method will not set `:pow_reset_password_decoded_token` in `conn.private` so it can be used in `PowResetPassword.Plug.update_user_password/2` for invalidation instead of relying on `conn.params`. It makes a lot more sense to make these methods ignorant of params. It is something that only should happen in controllers.