### PR TITLE
Cache refactor and better docs

### DIFF
--- a/lib/extensions/persistent_session/plug/cookie.ex
+++ b/lib/extensions/persistent_session/plug/cookie.ex
@@ -230,9 +230,6 @@ defmodule PowPersistentSession.Plug.Cookie do
       user -> {token, {user, metadata}}
     end
   end
-  # TODO: Remove by 1.1.0
-  defp fetch_user({token, user_id}, config),
-    do: fetch_user({token, {user_id, []}}, config)
 
   defp filter_invalid!([id: _value] = clauses), do: clauses
   defp filter_invalid!(clauses), do: raise "Invalid get_by clauses stored: #{inspect clauses}"

--- a/lib/extensions/persistent_session/store/persistent_session_cache.ex
+++ b/lib/extensions/persistent_session/store/persistent_session_cache.ex
@@ -3,4 +3,18 @@ defmodule PowPersistentSession.Store.PersistentSessionCache do
   use Pow.Store.Base,
     ttl: :timer.hours(24) * 30,
     namespace: "persistent_session"
+
+  alias Pow.Store.Base
+
+  # TODO: Remove by 1.1.0
+  @impl true
+  def get(config, id) do
+    config
+    |> Base.get(backend_config(config), id)
+    |> convert_old_value()
+  end
+
+  defp convert_old_value(:not_found), do: :not_found
+  defp convert_old_value({user, metadata}), do: {user, metadata}
+  defp convert_old_value(clauses) when is_list(clauses), do: {clauses, []}
 end

--- a/lib/pow/store/backend/base.ex
+++ b/lib/pow/store/backend/base.ex
@@ -63,12 +63,13 @@ defmodule Pow.Store.Backend.Base do
   """
   alias Pow.Config
 
+  @type config() :: Config.t()
   @type key() :: [binary() | atom()] | binary()
   @type record() :: {key(), any()}
   @type key_match() :: [atom() | binary()]
 
-  @callback put(Config.t(), record() | [record()]) :: :ok
-  @callback delete(Config.t(), key()) :: :ok
-  @callback get(Config.t(), key()) :: any() | :not_found
-  @callback all(Config.t(), key_match()) :: [record()]
+  @callback put(config(), record() | [record()]) :: :ok
+  @callback delete(config(), key()) :: :ok
+  @callback get(config(), key()) :: any() | :not_found
+  @callback all(config(), key_match()) :: [record()]
 end

--- a/lib/pow/store/backend/ets_cache.ex
+++ b/lib/pow/store/backend/ets_cache.ex
@@ -19,7 +19,7 @@ defmodule Pow.Store.Backend.EtsCache do
   @behaviour Base
   @ets_cache_tab __MODULE__
 
-  @spec start_link(Config.t()) :: GenServer.on_start()
+  @spec start_link(Base.config()) :: GenServer.on_start()
   def start_link(config) do
     GenServer.start_link(__MODULE__, config, name: __MODULE__)
   end
@@ -47,7 +47,7 @@ defmodule Pow.Store.Backend.EtsCache do
   # Callbacks
 
   @impl GenServer
-  @spec init(Config.t()) :: {:ok, map()}
+  @spec init(Base.config()) :: {:ok, map()}
   def init(_config) do
     init_table()
 
@@ -55,7 +55,7 @@ defmodule Pow.Store.Backend.EtsCache do
   end
 
   @impl GenServer
-  @spec handle_cast({:cache, Config.t(), Base.record() | [Base.record()]}, map()) :: {:noreply, map()}
+  @spec handle_cast({:cache, Base.config(), Base.record() | [Base.record()]}, map()) :: {:noreply, map()}
   def handle_cast({:cache, config, record_or_records}, %{invalidators: invalidators} = state) do
     invalidators =
       record_or_records
@@ -65,7 +65,7 @@ defmodule Pow.Store.Backend.EtsCache do
     {:noreply, %{state | invalidators: invalidators}}
   end
 
-  @spec handle_cast({:delete, Config.t(), Base.key()}, map()) :: {:noreply, map()}
+  @spec handle_cast({:delete, Base.config(), Base.key()}, map()) :: {:noreply, map()}
   def handle_cast({:delete, config, key}, %{invalidators: invalidators} = state) do
     invalidators =
       key
@@ -76,7 +76,7 @@ defmodule Pow.Store.Backend.EtsCache do
   end
 
   @impl GenServer
-  @spec handle_info({:invalidate, Config.t(), Base.key()}, map()) :: {:noreply, map()}
+  @spec handle_info({:invalidate, Base.config(), Base.key()}, map()) :: {:noreply, map()}
   def handle_info({:invalidate, config, key}, %{invalidators: invalidators} = state) do
     invalidators =
       key

--- a/lib/pow/store/backend/mnesia_cache.ex
+++ b/lib/pow/store/backend/mnesia_cache.ex
@@ -95,7 +95,7 @@ defmodule Pow.Store.Backend.MnesiaCache do
   @behaviour Base
   @mnesia_cache_tab __MODULE__
 
-  @spec start_link(Config.t()) :: GenServer.on_start()
+  @spec start_link(Base.config()) :: GenServer.on_start()
   def start_link(config) do
     # TODO: Remove by 1.1.0
     case Config.get(config, :nodes) do
@@ -131,7 +131,7 @@ defmodule Pow.Store.Backend.MnesiaCache do
   # Callbacks
 
   @impl GenServer
-  @spec init(Config.t()) :: {:ok, map()}
+  @spec init(Base.config()) :: {:ok, map()}
   def init(config) do
     init_mnesia(config)
 
@@ -139,7 +139,7 @@ defmodule Pow.Store.Backend.MnesiaCache do
   end
 
   @impl GenServer
-  @spec handle_cast({:cache, Config.t(), Base.record() | [Base.record()], integer()}, map()) :: {:noreply, map()}
+  @spec handle_cast({:cache, Base.config(), Base.record() | [Base.record()], integer()}, map()) :: {:noreply, map()}
   def handle_cast({:cache, config, record_or_records, ttl}, %{invalidators: invalidators} = state) do
     invalidators =
       record_or_records
@@ -153,7 +153,7 @@ defmodule Pow.Store.Backend.MnesiaCache do
     {:noreply, %{state | invalidators: invalidators}}
   end
 
-  @spec handle_cast({:delete, Config.t(), Base.key() | [Base.key()]}, map()) :: {:noreply, map()}
+  @spec handle_cast({:delete, Base.config(), Base.key() | [Base.key()]}, map()) :: {:noreply, map()}
   def handle_cast({:delete, config, key}, %{invalidators: invalidators} = state) do
     invalidators =
       key
@@ -163,13 +163,13 @@ defmodule Pow.Store.Backend.MnesiaCache do
     {:noreply, %{state | invalidators: invalidators}}
   end
 
-  @spec handle_cast({:refresh_invalidators, Config.t()}, map()) :: {:noreply, map()}
+  @spec handle_cast({:refresh_invalidators, Base.config()}, map()) :: {:noreply, map()}
   def handle_cast({:refresh_invalidators, config}, %{invalidators: invalidators} = state) do
     {:noreply, %{state | invalidators: init_invalidators(config, invalidators)}}
   end
 
   @impl GenServer
-  @spec handle_info({:invalidate, Config.t(), [Base.key()]}, map()) :: {:noreply, map()}
+  @spec handle_info({:invalidate, Base.config(), [Base.key()]}, map()) :: {:noreply, map()}
   def handle_info({:invalidate, config, key}, %{invalidators: invalidators} = state) do
     invalidators = delete_or_reschedule(key, invalidators, config)
 

--- a/lib/pow/store/base.ex
+++ b/lib/pow/store/base.ex
@@ -4,7 +4,7 @@ defmodule Pow.Store.Base do
 
   ## Usage
 
-      defmodule MyApp.CredentialsStore do
+      defmodule MyApp.CustomCache do
         use Pow.Store.Base,
           ttl: :timer.minutes(30),
           namespace: "credentials"

--- a/lib/pow/store/base.ex
+++ b/lib/pow/store/base.ex
@@ -18,14 +18,15 @@ defmodule Pow.Store.Base do
   alias Pow.Config
   alias Pow.Store.Backend.{EtsCache, MnesiaCache, Base}
 
+  @type config :: Config.t()
   @type key :: Base.key()
   @type record :: Base.record()
   @type key_match :: Base.key_match()
 
-  @callback put(Config.t(), key(), any()) :: :ok
-  @callback delete(Config.t(), key()) :: :ok
-  @callback get(Config.t(), key()) :: any() | :not_found
-  @callback all(Config.t(), key_match()) :: [record()]
+  @callback put(config(), key(), any()) :: :ok
+  @callback delete(config(), key()) :: :ok
+  @callback get(config(), key()) :: any() | :not_found
+  @callback all(config(), key_match()) :: [record()]
 
   @doc false
   defmacro __using__(defaults) do
@@ -52,7 +53,7 @@ defmodule Pow.Store.Base do
         unquote(__MODULE__).all(config, backend_config(config), key_match)
       end
 
-      @spec backend_config(Config.t()) :: Config.t()
+      @spec backend_config(unquote(__MODULE__).config()) :: unquote(__MODULE__).config()
       def backend_config(config) do
         [
           ttl: Config.get(config, :ttl, unquote(defaults[:ttl])),
@@ -97,28 +98,28 @@ defmodule Pow.Store.Base do
     end
   end
 
-  @spec put(Config.t(), Config.t(), record() | [record()]) :: :ok
+  @spec put(config(), config(), record() | [record()]) :: :ok
   def put(config, backend_config, record_or_records) do
     # TODO: Update by 1.1.0
     backwards_compatible_call(store(config), :put, [backend_config, record_or_records])
   end
 
   @doc false
-  @spec delete(Config.t(), Config.t(), key()) :: :ok
+  @spec delete(config(), config(), key()) :: :ok
   def delete(config, backend_config, key) do
     # TODO: Update by 1.1.0
     backwards_compatible_call(store(config), :delete, [backend_config, key])
   end
 
   @doc false
-  @spec get(Config.t(), Config.t(), key()) :: any() | :not_found
+  @spec get(config(), config(), key()) :: any() | :not_found
   def get(config, backend_config, key) do
     # TODO: Update by 1.1.0
     backwards_compatible_call(store(config), :get, [backend_config, key])
   end
 
   @doc false
-  @spec all(Config.t(), Config.t(), key_match()) :: [record()]
+  @spec all(config(), config(), key_match()) :: [record()]
   def all(config, backend_config, key_match) do
     # TODO: Update by 1.1.0
     backwards_compatible_call(store(config), :all, [backend_config, key_match])

--- a/lib/pow/store/credentials_cache.ex
+++ b/lib/pow/store/credentials_cache.ex
@@ -14,6 +14,10 @@ defmodule Pow.Store.CredentialsCache do
   """
   alias Pow.{Config, Operations, Store.Base}
 
+  @callback users(Config.t(), module()) :: [any()]
+  @callback sessions(Config.t(), map()) :: [binary()]
+  @callback put(Config.t(), binary(), {map(), list()}) :: :ok
+
   use Base,
     ttl: :timer.minutes(30),
     namespace: "credentials"
@@ -64,7 +68,7 @@ defmodule Pow.Store.CredentialsCache do
   If metadata has `:fingerprint` any active sessions for the user with the same
   `:fingerprint` in metadata will be deleted.
   """
-  @impl true
+  @spec put(Config.t(), binary(), {map(), list()}) :: :ok
   def put(config, session_id, {user, metadata}) do
     {struct, id} = user_to_struct_id!(user, [])
     user_key     = [struct, :user, id]

--- a/lib/pow/store/credentials_cache.ex
+++ b/lib/pow/store/credentials_cache.ex
@@ -11,6 +11,30 @@ defmodule Pow.Store.CredentialsCache do
 
     * `users/2` - to list all current users
     * `sessions/2` - to list all current sessions
+
+  ## Custom credentials cache module
+
+  Pow may use the utility methods in this module. To ensure all required
+  methods has been implemented in a custom credentials cache module, the
+  `@behaviour` of this module should be used:
+
+      defmodule MyApp.CredentialsStore do
+        use Pow.Store.Base,
+          ttl: :timer.minutes(30),
+          namespace: "credentials"
+
+        @behaviour Pow.Store.CredentialsCache
+
+        @impl Pow.Store.CredentialsCache
+        def users(config, struct) do
+          # ...
+        end
+
+        @impl Pow.Store.CredentialsCache
+        def put(config, key, value) do
+          # ...
+        end
+      end
   """
   alias Pow.{Config, Operations, Store.Base}
 

--- a/lib/pow/store/credentials_cache.ex
+++ b/lib/pow/store/credentials_cache.ex
@@ -36,11 +36,11 @@ defmodule Pow.Store.CredentialsCache do
         end
       end
   """
-  alias Pow.{Config, Operations, Store.Base}
+  alias Pow.{Operations, Store.Base}
 
-  @callback users(Config.t(), module()) :: [any()]
-  @callback sessions(Config.t(), map()) :: [binary()]
-  @callback put(Config.t(), binary(), {map(), list()}) :: :ok
+  @callback users(Base.config(), module()) :: [any()]
+  @callback sessions(Base.config(), map()) :: [binary()]
+  @callback put(Base.config(), binary(), {map(), list()}) :: :ok
 
   use Base,
     ttl: :timer.minutes(30),
@@ -51,7 +51,7 @@ defmodule Pow.Store.CredentialsCache do
 
   Sessions for a user can be looked up with `sessions/3`.
   """
-  @spec users(Config.t(), module()) :: [any()]
+  @spec users(Base.config(), module()) :: [any()]
   def users(config, struct) do
     config
     |> Base.all(backend_config(config), [struct, :user, :_])
@@ -63,7 +63,7 @@ defmodule Pow.Store.CredentialsCache do
   @doc """
   List all existing sessions for the user fetched from the backend store.
   """
-  @spec sessions(Config.t(), map()) :: [binary()]
+  @spec sessions(Base.config(), map()) :: [binary()]
   def sessions(config, user), do: fetch_sessions(config, backend_config(config), user)
 
   # TODO: Refactor by 1.1.0
@@ -92,7 +92,7 @@ defmodule Pow.Store.CredentialsCache do
   If metadata has `:fingerprint` any active sessions for the user with the same
   `:fingerprint` in metadata will be deleted.
   """
-  @spec put(Config.t(), binary(), {map(), list()}) :: :ok
+  @spec put(Base.config(), binary(), {map(), list()}) :: :ok
   def put(config, session_id, {user, metadata}) do
     {struct, id} = user_to_struct_id!(user, [])
     user_key     = [struct, :user, id]
@@ -143,7 +143,7 @@ defmodule Pow.Store.CredentialsCache do
   Fetch user credentials from the backend store from session id.
   """
   @impl true
-  @spec get(Config.t(), binary()) :: {map(), list()} | :not_found
+  @spec get(Base.config(), binary()) :: {map(), list()} | :not_found
   def get(config, session_id) do
     backend_config = backend_config(config)
 


### PR DESCRIPTION
This:

* Updates the CredentialsCache with better docs
* Adds callbacks for the custom methods in CredentialsCache
* Adds config type to the cache and cache backend modules to make it more explicit that it's a different config than what's used generally in Pow
* Refactors fallback handling in PowPersistentSession by moving it to the store