### PR TITLE
add conn to mail stuct

### DIFF
--- a/lib/pow/phoenix/mailer/mail.ex
+++ b/lib/pow/phoenix/mailer/mail.ex
@@ -39,7 +39,7 @@ defmodule Pow.Phoenix.Mailer.Mail do
 
   @type t :: %__MODULE__{}
 
-  defstruct [:user, :subject, :text, :html, :assigns]
+  defstruct [:conn, :user, :subject, :text, :html, :assigns]
 
   @doc """
   Returns a populated `%Pow.Phoenix.Mailer.Mail{}` map.
@@ -58,7 +58,7 @@ defmodule Pow.Phoenix.Mailer.Mail do
     text    = render(view_module, template, conn, view_assigns, :text)
     html    = render(view_module, template, conn, view_assigns, :html)
 
-    struct(__MODULE__, user: user, subject: subject, text: text, html: html, assigns: assigns)
+    struct(__MODULE__, conn: conn, user: user, subject: subject, text: text, html: html, assigns: assigns)
   end
 
   defp render_subject(view_module, template, assigns) do

--- a/test/pow/phoenix/mailer/mail_test.exs
+++ b/test/pow/phoenix/mailer/mail_test.exs
@@ -36,6 +36,7 @@ defmodule Pow.Phoenix.Mailer.MailTest do
     assert mail.html =~ "<h3>test HTML</h3>"
     assert mail.text =~ "test text\n"
     assert mail.assigns[:value] == "test"
+    assert mail.conn == conn
   end
 
   test "new/4 with `:web_module`", %{conn: conn} do


### PR DESCRIPTION
Per my conversation in #469 I'd like to have access to the conn used to make the mail so that I can call on Phoenix Routes in my own bamboo templates. 