### PR TITLE
Capture and assert expected deprecation warnings

### DIFF
--- a/lib/pow/store/base.ex
+++ b/lib/pow/store/base.ex
@@ -138,7 +138,7 @@ defmodule Pow.Store.Base do
         apply(store, method, args)
 
       true ->
-        IO.warn("binary key for backend stores is depecated, update `#{store}` to accept erlang terms instead")
+        IO.warn("binary key for backend stores is depecated, update `#{inspect store}` to accept erlang terms instead")
 
         case method do
           :put    -> binary_key_put(store, args)

--- a/test/extensions/reset_password/plug_test.exs
+++ b/test/extensions/reset_password/plug_test.exs
@@ -5,14 +5,13 @@ defmodule PowResetPassword.PlugTest do
   alias Plug.Conn
   alias Pow.Plug, as: PowPlug
   alias PowResetPassword.{Plug, Test, Test.Users.User}
-
-  import ExUnit.CaptureIO
+  alias ExUnit.CaptureIO
 
   describe "update_user_password/2" do
     @valid_params %{"password" => "secret1234", "password_confirmation" => "secret1234"}
 
     test "without decoded token warns" do
-      assert capture_io(:stderr, fn ->
+      assert CaptureIO.capture_io(:stderr, fn ->
         assert {:ok, _user, _conn} =
           %Conn{}
           |> PowPlug.put_config(Test.pow_config())

--- a/test/pow/ecto/schema_test.exs
+++ b/test/pow/ecto/schema_test.exs
@@ -69,10 +69,10 @@ defmodule Pow.Ecto.SchemaTest do
     assert %{on_delete: :delete_all} = OverrideAssocUser.__schema__(:association, :children)
   end
 
-  import ExUnit.CaptureIO
+  alias ExUnit.CaptureIO
 
   test "warns assocs defined" do
-    assert capture_io(:stderr, fn ->
+    assert CaptureIO.capture_io(:stderr, fn ->
       defmodule MissingAssocsUser do
         use Ecto.Schema
         use Pow.Ecto.Schema
@@ -94,7 +94,7 @@ defmodule Pow.Ecto.SchemaTest do
   end
 
   test "warns fields defined" do
-    assert capture_io(:stderr, fn ->
+    assert CaptureIO.capture_io(:stderr, fn ->
       defmodule MissingFieldsUser do
         use Ecto.Schema
         use Pow.Ecto.Schema

--- a/test/pow/store/backend/ets_cache_test.exs
+++ b/test/pow/store/backend/ets_cache_test.exs
@@ -69,8 +69,39 @@ defmodule Pow.Store.Backend.EtsCacheTest do
 
   # TODO: Remove by 1.1.0
   test "backwards compatible" do
-    assert EtsCache.put(@default_config, "key", "value") == :ok
+    assert_capture_io_eval(quote do
+      assert EtsCache.put(unquote(@default_config), "key", "value") == :ok
+    end, "Pow.Store.Backend.EtsCache.put/3 is deprecated. Use `put/2` instead")
+
     :timer.sleep(50)
-    assert EtsCache.keys(@default_config) == [{"key", "value"}]
+
+    assert_capture_io_eval(quote do
+      assert EtsCache.keys(unquote(@default_config)) == [{"key", "value"}]
+    end, "Pow.Store.Backend.EtsCache.keys/1 is deprecated. Use `all/2` instead")
+  end
+
+  alias ExUnit.CaptureIO
+
+  defp assert_capture_io_eval(quoted, message) do
+    System.version()
+    |> Version.match?(">= 1.8.0")
+    |> case do
+      true ->
+        # Due to https://github.com/elixir-lang/elixir/pull/9626 it's necessary to
+        # import `ExUnit.Assertions`
+        pre_elixir_1_10_quoted =
+          quote do
+            import ExUnit.Assertions
+          end
+
+        assert CaptureIO.capture_io(:stderr, fn ->
+          Code.eval_quoted([pre_elixir_1_10_quoted, quoted])
+        end) =~ message
+
+      false ->
+        IO.warn("Please upgrade to Elixir 1.8 to captured and assert IO message: #{inspect message}")
+
+        :ok
+    end
   end
 end

--- a/test/pow/store/backend/mnesia_cache_test.exs
+++ b/test/pow/store/backend/mnesia_cache_test.exs
@@ -115,9 +115,40 @@ defmodule Pow.Store.Backend.MnesiaCacheTest do
 
     # TODO: Remove by 1.1.0
     test "backwards compatible" do
-      assert MnesiaCache.put(@default_config, "key", "value") == :ok
+      assert_capture_io_eval(quote do
+        assert MnesiaCache.put(unquote(@default_config), "key", "value") == :ok
+      end, "Pow.Store.Backend.MnesiaCache.put/3 is deprecated. Use `put/2` instead")
+
       :timer.sleep(50)
-      assert MnesiaCache.keys(@default_config) == [{"key", "value"}]
+
+      assert_capture_io_eval(quote do
+        assert MnesiaCache.keys(unquote(@default_config)) == [{"key", "value"}]
+      end, "Pow.Store.Backend.MnesiaCache.keys/1 is deprecated. Use `all/2` instead")
+    end
+  end
+
+  alias ExUnit.CaptureIO
+
+  defp assert_capture_io_eval(quoted, message) do
+    System.version()
+    |> Version.match?(">= 1.8.0")
+    |> case do
+      true ->
+        # Due to https://github.com/elixir-lang/elixir/pull/9626 it's necessary to
+        # import `ExUnit.Assertions`
+        pre_elixir_1_10_quoted =
+          quote do
+            import ExUnit.Assertions
+          end
+
+        assert CaptureIO.capture_io(:stderr, fn ->
+          Code.eval_quoted([pre_elixir_1_10_quoted, quoted])
+        end) =~ message
+
+      false ->
+        IO.warn("Please upgrade to Elixir 1.8 to captured and assert IO message: #{inspect message}")
+
+        :ok
     end
   end
 

--- a/test/pow/store/backend/mnesia_cache_test.exs
+++ b/test/pow/store/backend/mnesia_cache_test.exs
@@ -346,8 +346,9 @@ defmodule Pow.Store.Backend.MnesiaCacheTest do
       rpc(node, Application, :ensure_all_started, [app_name])
     end
 
-    # Remove logger
+    # Remove logger to prevent double logs and don't log info
     rpc(node, Logger, :remove_backend, [:console])
+    rpc(node, Logger, :configure, [[level: :warn]])
 
     node
   end


### PR DESCRIPTION
Resolves #470

Only handles 1.9.0 and up since 1.8 and 1.6 has different behavior for quote and capture. No assertion and a warning is printed instead for those versions.

The test output is much cleaner now. Thanks for the issue @joshchernoff!