### PR TITLE
Fix test example in Redis Cache guide

### DIFF
--- a/guides/redis_cache_store_backend.md
+++ b/guides/redis_cache_store_backend.md
@@ -210,7 +210,7 @@ defmodule MyAppWeb.Pow.RedisCacheTest do
   use ExUnit.Case
   doctest MyAppWeb.Pow.RedisCache
 
-  alias MyAppWeb.Pow.RedisCache
+  alias MyAppWeb.Pow.RedisCache, as: PowRedisCache
 
   @default_config [namespace: "test", ttl: :timer.hours(1)]
 

--- a/guides/redis_cache_store_backend.md
+++ b/guides/redis_cache_store_backend.md
@@ -215,7 +215,6 @@ defmodule MyAppWeb.Pow.RedisCacheTest do
   @default_config [namespace: "test", ttl: :timer.hours(1)]
 
   setup do
-    start_supervised!({Redix, host: "localhost", port: 6379, name: :redix})
     Redix.command!(:redix, ["FLUSHALL"])
 
     :ok

--- a/guides/redis_cache_store_backend.md
+++ b/guides/redis_cache_store_backend.md
@@ -210,7 +210,7 @@ defmodule MyAppWeb.Pow.RedisCacheTest do
   use ExUnit.Case
   doctest MyAppWeb.Pow.RedisCache
 
-  alias MyAppWeb.Pow.RedisCache, as: PowRedisCache
+  alias MyAppWeb.Pow.RedisCache
 
   @default_config [namespace: "test", ttl: :timer.hours(1)]
 
@@ -222,54 +222,54 @@ defmodule MyAppWeb.Pow.RedisCacheTest do
   end
 
   test "can put, get and delete records" do
-    assert PowRedisCache.get(@default_config, "key") == :not_found
+    assert RedisCache.get(@default_config, "key") == :not_found
 
-    PowRedisCache.put(@default_config, {"key", "value"})
+    RedisCache.put(@default_config, {"key", "value"})
     :timer.sleep(100)
-    assert PowRedisCache.get(@default_config, "key") == "value"
+    assert RedisCache.get(@default_config, "key") == "value"
 
-    PowRedisCache.delete(@default_config, "key")
+    RedisCache.delete(@default_config, "key")
     :timer.sleep(100)
-    assert PowRedisCache.get(@default_config, "key") == :not_found
+    assert RedisCache.get(@default_config, "key") == :not_found
   end
 
   test "can put multiple records at once" do
-    PowRedisCache.put(@default_config, [{"key1", "1"}, {"key2", "2"}])
+    RedisCache.put(@default_config, [{"key1", "1"}, {"key2", "2"}])
     :timer.sleep(100)
-    assert PowRedisCache.get(@default_config, "key1") == "1"
-    assert PowRedisCache.get(@default_config, "key2") == "2"
+    assert RedisCache.get(@default_config, "key1") == "1"
+    assert RedisCache.get(@default_config, "key2") == "2"
   end
 
   test "can match fetch all" do
-    assert PowRedisCache.all(@default_config, :_) == []
+    assert RedisCache.all(@default_config, :_) == []
 
-    for number <- 1..11, do: PowRedisCache.put(@default_config, {"key#{number}", "value"})
+    for number <- 1..11, do: RedisCache.put(@default_config, {"key#{number}", "value"})
     :timer.sleep(100)
-    items = PowRedisCache.all(@default_config, :_)
+    items = RedisCache.all(@default_config, :_)
 
     assert Enum.find(items, fn {key, "value"} -> key == "key1" end)
     assert Enum.find(items, fn {key, "value"} -> key == "key2" end)
     assert length(items) == 11
 
-    PowRedisCache.put(@default_config, {["namespace", "key"], "value"})
+    RedisCache.put(@default_config, {["namespace", "key"], "value"})
     :timer.sleep(100)
 
-    assert PowRedisCache.all(@default_config, ["namespace", :_]) ==  [{["namespace", "key"], "value"}]
+    assert RedisCache.all(@default_config, ["namespace", :_]) ==  [{["namespace", "key"], "value"}]
   end
 
   test "records auto purge" do
     config = Keyword.put(@default_config, :ttl, 100)
 
-    PowRedisCache.put(config, {"key", "value"})
-    PowRedisCache.put(config, [{"key1", "1"}, {"key2", "2"}])
+    RedisCache.put(config, {"key", "value"})
+    RedisCache.put(config, [{"key1", "1"}, {"key2", "2"}])
     :timer.sleep(50)
-    assert PowRedisCache.get(config, "key") == "value"
-    assert PowRedisCache.get(config, "key1") == "1"
-    assert PowRedisCache.get(config, "key2") == "2"
+    assert RedisCache.get(config, "key") == "value"
+    assert RedisCache.get(config, "key1") == "1"
+    assert RedisCache.get(config, "key2") == "2"
     :timer.sleep(100)
-    assert PowRedisCache.get(config, "key") == :not_found
-    assert PowRedisCache.get(config, "key1") == :not_found
-    assert PowRedisCache.get(config, "key2") == :not_found
+    assert RedisCache.get(config, "key") == :not_found
+    assert RedisCache.get(config, "key1") == :not_found
+    assert RedisCache.get(config, "key2") == :not_found
   end
 end
 ```


### PR DESCRIPTION
The alias needed the name that is used later in the tests.

Also, I had to comment out this line in my test suite, as Redix was already started in my app:

`start_supervised!({Redix, host: "localhost", port: 6379, name: :redix})`

Maybe this line can be removed or explained better.