### PR TITLE
Fix invalid example in user roles guide

### DIFF
--- a/guides/user_roles.md
+++ b/guides/user_roles.md
@@ -226,7 +226,7 @@ defmodule MyApp.UsersTest do
   #   assert {:ok, user} = Repo.insert(User.changeset(%User{}, @valid_params))
   #   refute Users.is_admin?(user)
   #
-  #   assert {:ok, admin} = Users.create_admin(@valid_params)
+  #   assert {:ok, admin} = Users.create_admin(%{@valid_params | email: "test2@example.com"})
   #   assert Users.is_admin?(admin)
   # end
 end


### PR DESCRIPTION
As mentioned in https://github.com/danschultzer/pow/commit/d16ea13bdab250cba1ba0ce85bd103162324ec6a#r38463405, the commented tests wouldn't work since the same email is used to create a user twice.