### PR TITLE
Conditional registration link.

### DIFF
--- a/lib/pow/phoenix/templates/session_template.ex
+++ b/lib/pow/phoenix/templates/session_template.ex
@@ -12,6 +12,8 @@ defmodule Pow.Phoenix.SessionTemplate do
   ],
   button_label: "Sign in") %>
 
-  <span><%%= link "Register", to: Routes.<%= Pow.Phoenix.Controller.route_helper(Pow.Phoenix.RegistrationController) %>_path(@conn, :new) %></span>
+  <%%= if Kernel.function_exported?(Routes, :<%= Pow.Phoenix.Controller.route_helper(Pow.Phoenix.RegistrationController) %>_path, 2) do %>
+    <span><%%= link "Register", to: Routes.<%= Pow.Phoenix.Controller.route_helper(Pow.Phoenix.RegistrationController) %>_path(@conn, :new) %></span>
+  <%% end %>
   """
 end


### PR DESCRIPTION
Avoid error:

`function AppWeb.Router.Helpers.pow_registration_path/2 is undefined or private`

when [disable registration](https://github.com/danschultzer/pow/blob/master/guides/disable_registration.md).