### PR TITLE
Move context behaviour out

### DIFF
--- a/lib/pow/context.ex
+++ b/lib/pow/context.ex
@@ -1,0 +1,13 @@
+defmodule Pow.Context do
+  @moduledoc """
+  Used to set up context API.
+  """
+  @type user() :: map()
+  @type changeset() :: map()
+
+  @callback authenticate(map()) :: user() | nil
+  @callback create(map()) :: {:ok, user()} | {:error, changeset()}
+  @callback update(user(), map()) :: {:ok, user()} | {:error, changeset()}
+  @callback delete(user()) :: {:ok, user()} | {:error, changeset()}
+  @callback get_by(Keyword.t() | map()) :: user() | nil
+end

--- a/lib/pow/ecto/context.ex
+++ b/lib/pow/ecto/context.ex
@@ -35,21 +35,15 @@ defmodule Pow.Ecto.Context do
     * `:user` - the user schema module (required)
     * `:repo_opts` - keyword list options for the repo, `:prefix` can be set here
   """
-  alias Pow.{Config, Ecto.Schema, Operations}
+  alias Pow.{Config, Context, Ecto.Schema, Operations}
 
-  @type user :: map()
-  @type changeset :: map()
-
-  @callback authenticate(map()) :: user() | nil
-  @callback create(map()) :: {:ok, user()} | {:error, changeset()}
-  @callback update(user(), map()) :: {:ok, user()} | {:error, changeset()}
-  @callback delete(user()) :: {:ok, user()} | {:error, changeset()}
-  @callback get_by(Keyword.t() | map()) :: user() | nil
+  @type user :: Context.user()
+  @type changeset :: Context.changeset()
 
   @doc false
   defmacro __using__(config) do
     quote do
-      @behaviour unquote(__MODULE__)
+      @behaviour Context
 
       @pow_config unquote(config)
 
@@ -79,7 +73,7 @@ defmodule Pow.Ecto.Context do
         unquote(__MODULE__).get_by(clauses, @pow_config)
       end
 
-      defoverridable unquote(__MODULE__)
+      defoverridable Context
     end
   end
 


### PR DESCRIPTION
Per https://elixirforum.com/t/using-pow-without-ecto-or-an-rdbms/22496/12?u=danschultzer

> We have small project where we are implementing a context based on CubDB. The fact that the Context behaviour is defined by an Ecto related module makes it harder and let us think before that Pow was heavily dependent on Ecto.
> 
> I think that there should be a `Pow.Context` behaviour instead !

This makes a lot of sense. I want to add in a non-Ecto based example in the docs for the behaviour.