### PR TITLE
Merge the config passed in the conn with the new one instead of replacing

### DIFF
--- a/lib/pow/plug.ex
+++ b/lib/pow/plug.ex
@@ -54,7 +54,12 @@ defmodule Pow.Plug do
   """
   @spec put_config(Conn.t(), Config.t()) :: Conn.t()
   def put_config(conn, config) do
-    Conn.put_private(conn, @private_config_key, config)
+    new_config =
+      conn
+      |> Map.get(:private, %{})
+      |> Map.get(@private_config_key, [])
+      |> Config.merge(config)
+    Conn.put_private(conn, @private_config_key, new_config)
   end
 
   @doc """


### PR DESCRIPTION
At the moment, https://github.com/DianaOlympos/pow/blob/f3d935214f46822fda903d0b9dd091f4d374e95d/lib/pow/plug/base.ex#L83 use `Pow.Plug.put_config/2` to overwrite the config stored in the conn. That seems a bit problematic, why even store it in the conn in the case.

This patch merge the config currently in the conn with the one given to the plug, by changing `Pow.Plug.put_config/2`.

There seems to be no test on that behaviour so i did not add any, but if you really want one... all tests pass locally.

Would be nice to get a release after this is merged, it is blocking us from deploying to prod. As we want to be able to inject the config dynamically for all kind of reasons.

Thanks