### PR TITLE
Use existing Pow plug config if no plug opts is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v1.0.21 (TBA)
 
+### Enhancements
+
+* [`Pow.Plug.Base`] Will now use the existing `:pow_config` in the `conn` when no plug options has been set
+
 ### Bug fixes
 
 * [`PowEmailConfirmation.Ecto.Schema`] `PowEmailConfirmation.Ecto.Schema.changeset/3` no longer sets the email to the unconfirmed email when the same email change is set twice

--- a/lib/pow/plug/base.ex
+++ b/lib/pow/plug/base.ex
@@ -69,6 +69,9 @@ defmodule Pow.Plug.Base do
       @doc """
       Configures the connection for Pow, and fetches user.
 
+      If no options have been passed to the plug, the existing configuration
+      will be pulled with `Pow.Plug.fetch_config/1`
+
       `:plug` is appended to the passed configuration, so the current plug will
       be used in any subsequent calls to create, update and delete user
       credentials from the connection. The configuration is then set for the
@@ -78,6 +81,7 @@ defmodule Pow.Plug.Base do
       will be called.
       """
       @impl true
+      def call(conn, []), do: call(conn, Plug.fetch_config(conn))
       def call(conn, config) do
         config = put_plug(config)
         conn   = Plug.put_config(conn, config)

--- a/test/pow/plug/session_test.exs
+++ b/test/pow/plug/session_test.exs
@@ -32,6 +32,21 @@ defmodule Pow.Plug.SessionTest do
     assert conn.private[:pow_config] == expected_config
   end
 
+  test "call/2 uses existing config with no plug options", %{conn: conn} do
+    assert_raise Pow.Config.ConfigError, "Pow configuration not found in connection. Please use a Pow plug that puts the Pow configuration in the plug connection.", fn ->
+      run_plug(conn, [])
+    end
+
+    conn =
+      conn
+      |> Plug.put_config([a: 1])
+      |> run_plug([])
+
+    expected_config = [mod: Session, plug: Session] ++ [a: 1]
+
+    assert conn.private[:pow_config] == expected_config
+  end
+
   test "call/2 with assigned current_user", %{conn: conn} do
     conn =
       conn


### PR DESCRIPTION
Potential solution to what's discussed in https://github.com/danschultzer/pow/pull/510. This permits the dev to configure `:pow_config` before the plug is called.