### PR TITLE
Prevent updating of email when already set as unconfirmed email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.0.21 (TBA)
+
+### Bug fixes
+
+* [`PowEmailConfirmation.Ecto.Schema`] `PowEmailConfirmation.Ecto.Schema.changeset/3` no longer sets the email to the unconfirmed email when the same email change is set twice
+
 ## v1.0.20 (2020-04-22)
 
 Now supports Phoenix 1.5, and requires Elixir 1.7 or higher.

--- a/test/extensions/email_confirmation/ecto/schema_test.exs
+++ b/test/extensions/email_confirmation/ecto/schema_test.exs
@@ -105,6 +105,7 @@ defmodule PowEmailConfirmation.Ecto.SchemaTest do
       changeset = User.changeset(user, params)
 
       assert changeset.valid?
+      refute Ecto.Changeset.get_change(changeset, :email)
       refute Ecto.Changeset.get_change(changeset, :unconfirmed_email)
       refute Ecto.Changeset.get_change(changeset, :email_confirmation_token)
     end


### PR DESCRIPTION
Resolves #512

This prevents an issue where updating the user with the same unconfirmed email twice results it in updating the current email.