### PR TITLE
Fix unsigned token redirect invitation controller bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 * [`Pow.Plug.Base`] Will now use the existing `:pow_config` in the `conn` when no plug options has been set
+* [`PowInvitation.Phoenix.InvitationController`] Fixed bug where user was incorrectly redirected to the show action with unsigned token when user struct has no e-mail
 
 ### Bug fixes
 

--- a/lib/extensions/invitation/phoenix/controllers/invitation_controller.ex
+++ b/lib/extensions/invitation/phoenix/controllers/invitation_controller.ex
@@ -38,7 +38,9 @@ defmodule PowInvitation.Phoenix.InvitationController do
     invitation_sent_redirect(conn)
   end
   def respond_create({:ok, user, conn}) do
-    redirect(conn, to: routes(conn).path_for(conn, __MODULE__, :show, [user.invitation_token]))
+    token = Plug.sign_invitation_token(conn, user)
+
+    redirect(conn, to: routes(conn).path_for(conn, __MODULE__, :show, [token]))
   end
   def respond_create({:error, changeset, conn}) do
     case PowPlug.__prevent_user_enumeration__(conn, changeset) do

--- a/test/extensions/invitation/phoenix/controllers/invitation_controller_test.exs
+++ b/test/extensions/invitation/phoenix/controllers/invitation_controller_test.exs
@@ -115,7 +115,7 @@ defmodule PowInvitation.Phoenix.InvitationControllerTest do
 
       refute_received {:mail_mock, _mail}
 
-      assert redirected_to(conn) == Routes.pow_invitation_invitation_path(conn, :show, "valid")
+      assert redirected_to(conn) == Routes.pow_invitation_invitation_path(conn, :show, sign_token("valid"))
     end
   end
 


### PR DESCRIPTION
Resolves #534

This bug was introduced with the signing logic in #417.