### PR TITLE
Ensure custom users context calls its own `get_by` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * [`PowEmailConfirmation.Ecto.Schema`] `PowEmailConfirmation.Ecto.Schema.changeset/3` no longer sets the email to the unconfirmed email when the same email change is set twice
 * [`Pow.Extension.Phoenix.Messages`] Fixed fallback message dializer warning
+* [`Pow.Ecto.Context`] Fixed bug where the macro didn't add `:users_context` to the Pow config in the module resulting in `Pow.Ecto.Context.get_by/2` being called instead of `get_by/1` in the custom context
 
 ## v1.0.20 (2020-04-22)
 

--- a/lib/pow/ecto/context.ex
+++ b/lib/pow/ecto/context.ex
@@ -45,7 +45,7 @@ defmodule Pow.Ecto.Context do
     quote do
       @behaviour Context
 
-      @pow_config unquote(config)
+      @pow_config Keyword.put_new(unquote(config), :users_context, __MODULE__)
 
       def authenticate(params), do: pow_authenticate(params)
       def create(params), do: pow_create(params)

--- a/test/pow/ecto/context_test.exs
+++ b/test/pow/ecto/context_test.exs
@@ -34,6 +34,8 @@ defmodule Pow.Ecto.ContextTest do
   @username_config [repo: Repo, user: UsernameUser]
 
   defmodule CustomUsers do
+    use Context, repo: Repo, user: User
+
     def get_by([email: :test]), do: %User{email: :ok, password_hash: Password.pbkdf2_hash("secret1234")}
   end
 
@@ -104,6 +106,7 @@ defmodule Pow.Ecto.ContextTest do
       params = Map.put(@valid_params, "email", :test)
 
       assert %User{email: :ok} = Context.authenticate(params, @config ++ [users_context: CustomUsers])
+      assert %User{email: :ok} = CustomUsers.authenticate(params)
     end
 
     test "prevents timing attack" do


### PR DESCRIPTION
Resolves bug in https://github.com/danschultzer/pow/issues/528

This adds `:users_context` (if not already set) to the config for custom users context, to make sure that the custom `get_by/1` gets called when e.g. `authenticate/1` is called.