### PR TITLE
Only warn when using Ecto primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [`Pow.Plug.Base`] Will now use the existing `:pow_config` in the `conn` when no plug options has been set
 * [`PowInvitation.Phoenix.InvitationController`] Fixed bug where user was incorrectly redirected to the show action with unsigned token when user struct has no e-mail
+* [`Pow.Ecto.Schema`] Now only emits warning for primitive Ecto types
 
 ### Bug fixes
 


### PR DESCRIPTION
Resolves #533

There is no need to verify that the right type is used for custom Ecto types as they may very well be able to handle cast and load of the type. This PR will only emit a warning if there's a type mismatch using primitive Ecto types.