### PR TITLE
Don't use no_return for methods that also can return

### DIFF
--- a/guides/redis_cache_store_backend.md
+++ b/guides/redis_cache_store_backend.md
@@ -27,7 +27,7 @@ defmodule MyAppWeb.Pow.RedisCache do
 
   @impl true
   def put(config, record_or_records) do
-    ttl      = Config.get(config, :ttl) || raise_ttl_error()
+    ttl      = Config.get(config, :ttl) || raise_ttl_error!()
     commands =
       record_or_records
       |> List.wrap()
@@ -168,8 +168,8 @@ defmodule MyAppWeb.Pow.RedisCache do
     end)
   end
 
-  @spec raise_ttl_error :: no_return
-  defp raise_ttl_error,
+  @spec raise_ttl_error! :: no_return()
+  defp raise_ttl_error!,
     do: Config.raise_error("`:ttl` configuration option is required for #{inspect(__MODULE__)}")
 end
 ```

--- a/lib/extensions/persistent_session/plug.ex
+++ b/lib/extensions/persistent_session/plug.ex
@@ -26,11 +26,10 @@ defmodule PowPersistentSession.Plug do
   end
 
   defp pow_persistent_session(conn) do
-    conn.private[:pow_persistent_session] || raise_no_plug_error()
+    conn.private[:pow_persistent_session] || raise_no_plug_error!()
   end
 
-  @spec raise_no_plug_error :: no_return
-  defp raise_no_plug_error do
-    Config.raise_error("PowPersistentSession plug module not installed. Please add the PowPersistentSession.Plug.Cookie plug to your endpoint.")
-  end
+  @spec raise_no_plug_error!() :: no_return()
+  defp raise_no_plug_error!,
+    do: Config.raise_error("PowPersistentSession plug module not installed. Please add the PowPersistentSession.Plug.Cookie plug to your endpoint.")
 end

--- a/lib/mix/pow.ex
+++ b/lib/mix/pow.ex
@@ -7,7 +7,7 @@ defmodule Mix.Pow do
   @doc """
   Raises an exception if the project is an umbrella app.
   """
-  @spec no_umbrella!(binary()) :: :ok | no_return
+  @spec no_umbrella!(binary()) :: :ok
   def no_umbrella!(task) do
     if Project.umbrella?() do
       Mix.raise("mix #{task} can only be run inside an application directory")
@@ -19,7 +19,7 @@ defmodule Mix.Pow do
   # TODO: Remove by 1.1.0
   @doc false
   @deprecated "Use `ensure_ecto!` or `ensure_phoenix!` instead"
-  @spec ensure_dep!(binary(), atom(), OptionParser.argv()) :: :ok | no_return
+  @spec ensure_dep!(binary(), atom(), OptionParser.argv()) :: :ok
   def ensure_dep!(task, dep, _args) do
     fetch_deps()
     |> top_level_dep_in_deps?(dep)
@@ -35,7 +35,7 @@ defmodule Mix.Pow do
   @doc """
   Raises an exception if application doesn't have Ecto as dependency.
   """
-  @spec ensure_ecto!(binary(), OptionParser.argv()) :: :ok | no_return
+  @spec ensure_ecto!(binary(), OptionParser.argv()) :: :ok
   def ensure_ecto!(task, _args) do
     deps = fetch_deps()
 
@@ -66,7 +66,7 @@ defmodule Mix.Pow do
   @doc """
   Raises an exception if application doesn't have Phoenix as dependency.
   """
-  @spec ensure_phoenix!(binary(), OptionParser.argv()) :: :ok | no_return
+  @spec ensure_phoenix!(binary(), OptionParser.argv()) :: :ok
   def ensure_phoenix!(task, _args) do
     case top_level_dep_in_deps?(fetch_deps(), :phoenix) do
       true -> :ok
@@ -117,7 +117,7 @@ defmodule Mix.Pow do
   def schema_options_from_args(_any), do: %{schema_name: "Users.User", schema_plural: "users"}
 
   @doc false
-  @spec validate_schema_args!([binary()], binary()) :: map() | no_return()
+  @spec validate_schema_args!([binary()], binary()) :: map()
   def validate_schema_args!([schema, plural | _rest] = args, task) do
     cond do
       not schema_valid?(schema) ->
@@ -150,7 +150,7 @@ defmodule Mix.Pow do
   # TODO: Remove by 1.1.0
   @doc false
   @deprecated "Please use `Pow.Phoenix.parse_structure/1` instead"
-  @spec context_app :: atom() | no_return
+  @spec context_app :: atom()
   def context_app do
     this_app = otp_app()
 
@@ -166,7 +166,7 @@ defmodule Mix.Pow do
   end
 
   @doc false
-  @spec otp_app :: atom() | no_return
+  @spec otp_app :: atom()
   def otp_app do
     Keyword.fetch!(Mix.Project.config(), :app)
   end

--- a/lib/pow/config.ex
+++ b/lib/pow/config.ex
@@ -51,7 +51,7 @@ defmodule Pow.Config do
   @doc """
   Raise a ConfigError exception.
   """
-  @spec raise_error(binary()) :: no_return
+  @spec raise_error(binary()) :: no_return()
   def raise_error(message) do
     raise ConfigError, message: message
   end
@@ -59,7 +59,7 @@ defmodule Pow.Config do
   @doc """
   Retrieves the repo module from the config, or raises an exception.
   """
-  @spec repo!(t()) :: atom() | no_return()
+  @spec repo!(t()) :: atom()
   def repo!(config) do
     get(config, :repo) || raise_error("No `:repo` configuration option found.")
   end
@@ -67,7 +67,7 @@ defmodule Pow.Config do
   @doc """
   Retrieves the user schema module from the config, or raises an exception.
   """
-  @spec user!(t()) :: atom() | no_return()
+  @spec user!(t()) :: atom()
   def user!(config) do
     get(config, :user) || raise_error("No `:user` configuration option found.")
   end

--- a/lib/pow/ecto/schema/password.ex
+++ b/lib/pow/ecto/schema/password.ex
@@ -86,7 +86,7 @@ defmodule Pow.Ecto.Schema.Password do
         [digest, iterations, salt, hash]
 
       _ ->
-        raise_not_valid_password_hash()
+        raise_not_valid_password_hash!()
     end
   end
 
@@ -97,7 +97,7 @@ defmodule Pow.Ecto.Schema.Password do
     Pbkdf2.compare(hash, secret_hash)
   end
 
-  defp raise_not_valid_password_hash do
-    raise ArgumentError, "not a valid encoded password hash"
-  end
+  @spec raise_not_valid_password_hash!() :: no_return()
+  defp raise_not_valid_password_hash!,
+    do: raise ArgumentError, "not a valid encoded password hash"
 end

--- a/lib/pow/extension/ecto/schema.ex
+++ b/lib/pow/extension/ecto/schema.ex
@@ -184,7 +184,7 @@ defmodule Pow.Extension.Ecto.Schema do
   method should either raise an exception, or return `:ok`. Compilation will
   fail when the exception is raised.
   """
-  @spec validate!(Config.t(), atom()) :: :ok | no_return
+  @spec validate!(Config.t(), atom()) :: :ok
   def validate!(config, module) do
     config
     |> schema_modules()
@@ -211,7 +211,7 @@ defmodule Pow.Extension.Ecto.Schema do
 
   If the field doesn't exist, it'll raise an exception.
   """
-  @spec require_schema_field!(atom(), atom(), atom()) :: :ok | no_return
+  @spec require_schema_field!(atom(), atom(), atom()) :: :ok
   def require_schema_field!(module, field, extension) do
     fields = module.__schema__(:fields)
 
@@ -219,11 +219,11 @@ defmodule Pow.Extension.Ecto.Schema do
     |> Enum.member?(field)
     |> case do
       true  -> :ok
-      false -> raise_missing_field_error(module, field, extension)
+      false -> raise_missing_field_error!(module, field, extension)
     end
   end
 
-  defp raise_missing_field_error(module, field, extension) do
-    raise SchemaError, message: "A `#{inspect field}` schema field should be defined in #{inspect module} to use #{inspect extension}"
-  end
+  @spec raise_missing_field_error!(module(), atom(), atom()) :: no_return()
+  defp raise_missing_field_error!(module, field, extension),
+    do: raise SchemaError, message: "A `#{inspect field}` schema field should be defined in #{inspect module} to use #{inspect extension}"
 end

--- a/lib/pow/extension/ecto/schema/base.ex
+++ b/lib/pow/extension/ecto/schema/base.ex
@@ -23,7 +23,7 @@ defmodule Pow.Extension.Ecto.Schema.Base do
   alias Ecto.Changeset
   alias Pow.Config
 
-  @callback validate!(Config.t(), atom()) :: :ok | no_return
+  @callback validate!(Config.t(), atom()) :: :ok
   @callback attrs(Config.t()) :: [tuple()]
   @callback assocs(Config.t()) :: [tuple()]
   @callback indexes(Config.t()) :: [tuple()]

--- a/lib/pow/phoenix/mailer.ex
+++ b/lib/pow/phoenix/mailer.ex
@@ -44,15 +44,14 @@ defmodule Pow.Phoenix.Mailer do
   @spec deliver(Conn.t(), Mail.t()) :: any()
   def deliver(conn, email) do
     config = Plug.fetch_config(conn)
-    mailer = Config.get(config, :mailer_backend) || raise_no_mailer_backend_set()
+    mailer = Config.get(config, :mailer_backend) || raise_no_mailer_backend_set!()
 
     email
     |> mailer.cast()
     |> mailer.process()
   end
 
-  @spec raise_no_mailer_backend_set :: no_return
-  defp raise_no_mailer_backend_set do
-    Config.raise_error("No :mailer_backend configuration option found for plug.")
-  end
+  @spec raise_no_mailer_backend_set!() :: no_return()
+  defp raise_no_mailer_backend_set!,
+    do: Config.raise_error("No :mailer_backend configuration option found for plug.")
 end

--- a/lib/pow/phoenix/router.ex
+++ b/lib/pow/phoenix/router.ex
@@ -230,7 +230,7 @@ defmodule Pow.Phoenix.Router do
     end
   end
 
-  @spec validate_scope!(atom() | [%Phoenix.Router.Scope{}]) :: :ok | no_return
+  @spec validate_scope!(atom() | [%Phoenix.Router.Scope{}]) :: :ok
   def validate_scope!(module) when is_atom(module) do
     module
     |> Module.get_attribute(:phoenix_top_scopes)

--- a/lib/pow/plug.ex
+++ b/lib/pow/plug.ex
@@ -64,7 +64,7 @@ defmodule Pow.Plug do
   """
   @spec fetch_config(Conn.t()) :: Config.t()
   def fetch_config(%{private: private}) do
-    private[@private_config_key] || no_config_error()
+    private[@private_config_key] || no_config_error!()
   end
 
   @doc """
@@ -180,7 +180,7 @@ defmodule Pow.Plug do
 
   @spec get_plug(Config.t()) :: atom()
   def get_plug(config) do
-    config[:plug] || no_plug_error()
+    config[:plug] || no_plug_error!()
   end
 
   @doc """
@@ -201,15 +201,13 @@ defmodule Pow.Plug do
   @spec delete(Conn.t(), Config.t()) :: Conn.t()
   def delete(conn, config), do: get_plug(config).do_delete(conn, config)
 
-  @spec no_config_error :: no_return
-  defp no_config_error do
-    Config.raise_error("Pow configuration not found in connection. Please use a Pow plug that puts the Pow configuration in the plug connection.")
-  end
+  @spec no_config_error!() :: no_return()
+  defp no_config_error!,
+    do: Config.raise_error("Pow configuration not found in connection. Please use a Pow plug that puts the Pow configuration in the plug connection.")
 
-  @spec no_plug_error :: no_return
-  defp no_plug_error do
-    Config.raise_error("Pow plug was not found in config. Please use a Pow plug that puts the `:plug` in the Pow configuration.")
-  end
+  @spec no_plug_error!() :: no_return()
+  defp no_plug_error!,
+    do: Config.raise_error("Pow plug was not found in config. Please use a Pow plug that puts the `:plug` in the Pow configuration.")
 
   @doc false
   @spec __prevent_user_enumeration__(Conn.t(), any()) :: boolean()

--- a/lib/pow/plug/require_authenticated.ex
+++ b/lib/pow/plug/require_authenticated.ex
@@ -16,7 +16,7 @@ defmodule Pow.Plug.RequireAuthenticated do
   @doc false
   @spec init(Config.t()) :: atom()
   def init(config) do
-    Config.get(config, :error_handler) || raise_no_error_handler()
+    Config.get(config, :error_handler) || raise_no_error_handler!()
   end
 
   @doc false
@@ -34,8 +34,7 @@ defmodule Pow.Plug.RequireAuthenticated do
   end
   defp maybe_halt(_user, conn, _handler), do: conn
 
-  @spec raise_no_error_handler :: no_return
-  defp raise_no_error_handler do
-    Config.raise_error("No :error_handler configuration option provided. It's required to set this when using #{inspect __MODULE__}.")
-  end
+  @spec raise_no_error_handler!() :: no_return()
+  defp raise_no_error_handler!,
+    do: Config.raise_error("No :error_handler configuration option provided. It's required to set this when using #{inspect __MODULE__}.")
 end

--- a/lib/pow/plug/require_not_authenticated.ex
+++ b/lib/pow/plug/require_not_authenticated.ex
@@ -16,7 +16,7 @@ defmodule Pow.Plug.RequireNotAuthenticated do
   @doc false
   @spec init(Config.t()) :: atom()
   def init(config) do
-    Config.get(config, :error_handler) || raise_no_error_handler()
+    Config.get(config, :error_handler) || raise_no_error_handler!()
   end
 
   @doc false
@@ -34,8 +34,7 @@ defmodule Pow.Plug.RequireNotAuthenticated do
     |> Conn.halt()
   end
 
-  @spec raise_no_error_handler :: no_return
-  defp raise_no_error_handler do
-    Config.raise_error("No :error_handler configuration option provided. It's required to set this when using #{inspect __MODULE__}.")
-  end
+  @spec raise_no_error_handler!() :: no_return()
+  defp raise_no_error_handler!,
+    do: Config.raise_error("No :error_handler configuration option provided. It's required to set this when using #{inspect __MODULE__}.")
 end

--- a/lib/pow/store/backend/mnesia_cache.ex
+++ b/lib/pow/store/backend/mnesia_cache.ex
@@ -456,11 +456,11 @@ defmodule Pow.Store.Backend.MnesiaCache do
   defp timestamp, do: :os.system_time(:millisecond)
 
   defp ttl!(config) do
-    Config.get(config, :ttl) || raise_ttl_error()
+    Config.get(config, :ttl) || raise_ttl_error!()
   end
 
-  @spec raise_ttl_error :: no_return
-  defp raise_ttl_error,
+  @spec raise_ttl_error!() :: no_return()
+  defp raise_ttl_error!,
     do: Config.raise_error("`:ttl` configuration option is required for #{inspect(__MODULE__)}")
 
   # TODO: Remove by 1.1.0

--- a/lib/pow/store/credentials_cache.ex
+++ b/lib/pow/store/credentials_cache.ex
@@ -169,13 +169,13 @@ defmodule Pow.Store.CredentialsCache do
 
     {mod, key_values}
   end
-  defp user_to_struct_id!(_user, _config), do: raise_error "Only structs can be stored as credentials"
+  defp user_to_struct_id!(_user, _config), do: raise "Only structs can be stored as credentials"
 
   defp fetch_primary_key_values!(user, config) do
     user
     |> Operations.fetch_primary_key_values(config)
     |> case do
-      {:error, error} -> raise_error error
+      {:error, error} -> raise error
       {:ok, clauses}  -> clauses
     end
   end
@@ -199,9 +199,6 @@ defmodule Pow.Store.CredentialsCache do
       end
     end)
   end
-
-  @spec raise_error(binary()) :: no_return()
-  defp raise_error(message), do: raise message
 
   # TODO: Remove by 1.1.0
   @doc false

--- a/test/support/phoenix/controller_assertions.ex
+++ b/test/support/phoenix/controller_assertions.ex
@@ -3,7 +3,7 @@ defmodule Pow.Test.Phoenix.ControllerAssertions do
   alias Phoenix.ConnTest
   alias Pow.Phoenix.{Messages, Routes}
 
-  @spec assert_authenticated_redirect(Plug.Conn.t()) :: no_return
+  @spec assert_authenticated_redirect(Plug.Conn.t()) :: Macro.t()
   defmacro assert_authenticated_redirect(conn) do
     quote do
       routes = Keyword.get(unquote(conn).private.pow_config, :routes_backend, Routes)
@@ -13,7 +13,7 @@ defmodule Pow.Test.Phoenix.ControllerAssertions do
     end
   end
 
-  @spec assert_not_authenticated_redirect(Plug.Conn.t()) :: no_return
+  @spec assert_not_authenticated_redirect(Plug.Conn.t()) :: Macro.t()
   defmacro assert_not_authenticated_redirect(conn) do
     quote bind_quoted: [conn: conn] do
       router = Module.concat([conn.private.phoenix_router, Helpers])


### PR DESCRIPTION
This was triggered by the discussion in https://elixirforum.com/t/pow-robust-modular-extendable-user-authentication-and-management-system/15807/236 and in this PR https://github.com/elixir-lang/elixir/pull/8092 shows that mixed `no_return/0` with return in specs was removed from Elixir.

As Jose writes in https://github.com/elixir-lang/elixir/issues/8631#issuecomment-455109616:

> `no_return` is not correct though because that function can return in some situations. We only use no_return when the function is always fail. So this error is happening because dialyzer thinks something somewhere inside those functions will always fail.