### PR TITLE
Add match spec information to docs

### DIFF
--- a/guides/redis_cache_store_backend.md
+++ b/guides/redis_cache_store_backend.md
@@ -88,8 +88,8 @@ defmodule MyAppWeb.Pow.RedisCache do
   end
 
   @impl true
-  def all(config, match_spec) do
-    compiled_match_spec = :ets.match_spec_compile([{{match_spec, :_}, [], [:"$_"]}])
+  def all(config, key_match) do
+    compiled_match_spec = :ets.match_spec_compile([{{key_match, :_}, [], [:"$_"]}])
 
     Stream.resource(
       fn -> do_scan(config, compiled_match_spec, "0") end,

--- a/test/pow/store/base_test.exs
+++ b/test/pow/store/base_test.exs
@@ -8,7 +8,7 @@ defmodule Pow.Store.BaseTest do
     def get(_config, :backend), do: :mock_backend
     def get(config, :config), do: config
 
-    def all(_config, _match_spec), do: []
+    def all(_config, _key_match), do: []
   end
 
   defmodule BaseMock do


### PR DESCRIPTION
It wasn't really clear how the second argument for the `all/2` callback in `Pow.Store.Backend.Base` module worked. This refactors and add information regarding the erlang match specification.