### PR TITLE
Improve code readability in Pow.Store.Backend

### DIFF
--- a/lib/pow/store/backend/ets_cache.ex
+++ b/lib/pow/store/backend/ets_cache.ex
@@ -88,12 +88,9 @@ defmodule Pow.Store.Backend.EtsCache do
 
   defp table_get(key, config) do
     ets_key = ets_key(config, key)
-
-    @ets_cache_tab
-    |> :ets.lookup(ets_key)
-    |> case do
-      [{^ets_key, value} | _rest] -> value
-      []                          -> :not_found
+    case :ets.lookup(@ets_cache_tab, ets_key) do
+      [{^ets_key, value}] -> value
+      []                  -> :not_found
     end
   end
 

--- a/lib/pow/store/backend/mnesia_cache/unsplit.ex
+++ b/lib/pow/store/backend/mnesia_cache/unsplit.ex
@@ -124,7 +124,7 @@ defmodule Pow.Store.Backend.MnesiaCache.Unsplit do
     |> List.delete(:schema)
     |> List.foldl([], fn table, acc ->
       nodes     = get_all_nodes_for_table(table)
-      is_shared = Enum.member?(nodes, node) && Enum.member?(nodes, node())
+      is_shared = node in nodes && node() in nodes
 
       case is_shared do
         true  -> [table | acc]
@@ -188,8 +188,8 @@ defmodule Pow.Store.Backend.MnesiaCache.Unsplit do
     all_nodes    = get_all_nodes_for_table(@mnesia_cache_tab)
     island_nodes = Enum.concat(island_a, island_b)
 
-    oldest_node = all_nodes |> Enum.reverse() |> Enum.find(&Enum.member?(island_nodes, &1))
+    oldest_node = all_nodes |> Enum.reverse() |> Enum.find(&(&1 in island_nodes))
 
-    Enum.member?(island_a, oldest_node)
+    oldest_node in island_a
   end
 end


### PR DESCRIPTION
This PR, tries to improve the code readability and restrict some pattern match, to make it more clear that only one value is expected from `:ets.lookup` or `:mnesia.dirty_read` for a given key.