### PR TITLE
Improve Redis cache performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Now supports Phoenix 1.6.x, and `phoenix_html` 3.x.x.
 ### Documentation
 
 * Updated [redis guide](guides/redis_cache_store_backend.md) to use synchronous writes unless `writes: :async` is passed in config options
+* Updated [redis guide](guides/redis_cache_store_backend.md) to use optimized lookups with sorted keys
 
 ## v1.0.24 (2021-05-27)
 

--- a/guides/redis_cache_store_backend.md
+++ b/guides/redis_cache_store_backend.md
@@ -20,7 +20,26 @@ Now set up your `WEB_PATH/pow/redis_cache.ex` like so:
 # lib/my_app_web/pow/redis_cache.ex
 defmodule MyAppWeb.Pow.RedisCache do
   @moduledoc """
-  Redis based key value store with auto expiration.
+  Redis cache with optimized lookup.
+
+  To keep lookups performant the key is split up into n - 1 prefixes, where n
+  is the number of items in the key array. Each prefix will be combined with
+  all previous prefixes (if any) into a sorted set key. The rest of the key
+  will be combined into a member of this sorted set. The member of the sorted
+  set will have the expiration timestamp set as the score.
+
+  The sorted set will be set to expire with the provided `ttl`. When new
+  records are inserted any members of any of these prefix sorted sets with a
+  score score lower than the current timestamp will be removed.
+
+  When records are queried with `all/2`, the first matching `:_` wildcard in
+  the key match will define what prefix sorted set to use to find the keys. All
+  members with a lower score than the current timestamp will be removed, and
+  the sorted set for that prefix will be scanned. The resulting list is then
+  checked against the key match spec.
+
+  Any part of the key and value will be encoded with `:erlang.term_to_binary/1`
+  and `Base.url_encode64/2` when stored.
 
   ## Configuration options
 
@@ -32,6 +51,7 @@ defmodule MyAppWeb.Pow.RedisCache do
     * `:writes` - set to `:async` to do asynchronous writes. Defauts to
       `:sync`.
   """
+
   @behaviour Pow.Store.Backend.Base
 
   alias Pow.Config
@@ -55,12 +75,11 @@ defmodule MyAppWeb.Pow.RedisCache do
     maybe_async(config, fn ->
       @redix_instance_name
       |> Redix.pipeline!(commands)
-      |> Enum.map(fn
-        "OK"  -> nil
-        1     -> nil
-        error -> error
+      |> Enum.zip(commands)
+      |> Enum.reject(fn
+        {n, _cmd} when is_number(n) or n == "OK" -> true
+        _any -> false
       end)
-      |> Enum.reject(&is_nil/1)
       |> case do
         []     -> :ok
         errors -> raise "Redix received unexpected response #{inspect errors}"
@@ -77,14 +96,22 @@ defmodule MyAppWeb.Pow.RedisCache do
     ["SET", key, value, "PX", ttl]
   end
   defp put_command({prefix, key}, _value, ttl) do
-    prefix = to_binary_redis_key(prefix)
-    key    = to_binary_redis_key(key)
+    key       = to_binary_redis_key(key)
+    timestamp = current_timestamp()
+
+    index_key =
+      prefix
+      |> to_binary_redis_key()
+      |> to_index_key()
 
     [
-      ["SADD", prefix, key],
-      ["PEXPIRE", prefix, ttl]
+      ["ZREMRANGEBYSCORE", index_key, "-inf", timestamp],
+      ["ZADD", index_key, timestamp + ttl, key],
+      ["PEXPIRE", index_key, ttl]
     ]
   end
+
+  defp current_timestamp(), do: DateTime.to_unix(DateTime.utc_now(), :millisecond)
 
   defp command_builder(key, method) do
     count = Enum.count(key)
@@ -130,10 +157,14 @@ defmodule MyAppWeb.Pow.RedisCache do
     ["DEL", prefix]
   end
   def delete_command({prefix, key}) do
-    prefix = to_binary_redis_key(prefix)
-    key    = to_binary_redis_key(key)
+    index_key =
+      prefix
+      |> to_binary_redis_key()
+      |> to_index_key()
 
-    ["SREM", prefix, key]
+    key = to_binary_redis_key(key)
+
+    ["ZREM", index_key, key]
   end
 
   @impl true
@@ -154,11 +185,21 @@ defmodule MyAppWeb.Pow.RedisCache do
     compiled_match_spec = :ets.match_spec_compile([{{key_match, :_}, [], [:"$_"]}])
     key_match           = redis_key(config, key_match)
 
-    {prefix, _match} =
-      case Enum.find_index(key_match, & &1 == :_) do
+    prefix =
+      key_match
+      |> Enum.find_index(& &1 == :_)
+      |> case do
         nil -> {redis_key(config, []), key_match}
         i   -> Enum.split(key_match, i)
       end
+      |> elem(0)
+
+    index_key =
+      prefix
+      |> to_binary_redis_key()
+      |> to_index_key()
+
+    Redix.command!(@redix_instance_name, ["ZREMRANGEBYSCORE", index_key, "-inf", current_timestamp()])
 
     Stream.resource(
       fn -> do_scan(config, prefix, compiled_match_spec, "0") end,
@@ -166,6 +207,8 @@ defmodule MyAppWeb.Pow.RedisCache do
       fn _ -> :ok end)
     |> Enum.to_list()
   end
+
+  defp to_index_key(key), do: "_index:#{key}"
 
   defp stream_scan(_config, _prefix, _compiled_match_spec, {[], "0"}), do: {:halt, nil}
   defp stream_scan(config, prefix, compiled_match_spec, {[], iterator}) do
@@ -176,18 +219,20 @@ defmodule MyAppWeb.Pow.RedisCache do
   defp stream_scan(_config, _prefix, _compiled_match_spec, {keys, iterator}), do: {keys, {[], iterator}}
 
   defp do_scan(config, prefix, compiled_match_spec, iterator) do
-    prefix = to_binary_redis_key(prefix)
+    prefix    = to_binary_redis_key(prefix)
+    index_key = to_index_key(prefix)
 
-    [iterator, res] = Redix.command!(@redix_instance_name, ["SSCAN", prefix, iterator])
+    [iterator, res] = Redix.command!(@redix_instance_name, ["ZSCAN", index_key, iterator])
 
-    {filter_or_load_value(compiled_match_spec, prefix, res, config), iterator}
+    keys = Enum.take_every(res, 2)
+
+    {filter_or_load_value(compiled_match_spec, prefix, keys, config), iterator}
   end
 
   defp filter_or_load_value(compiled_match_spec, prefix, keys, config) do
     keys
     |> Enum.map(&"#{prefix}:#{&1}")
     |> Enum.map(&convert_key/1)
-    |> Enum.sort()
     |> :ets.match_spec_run(compiled_match_spec)
     |> populate_values(config)
   end
@@ -211,7 +256,10 @@ defmodule MyAppWeb.Pow.RedisCache do
     values =
       @redix_instance_name
       |> Redix.command!(["MGET"] ++ binary_keys)
-      |> Enum.map(&:erlang.binary_to_term/1)
+      |> Enum.map(fn
+        nil   -> nil
+        value -> :erlang.binary_to_term(value)
+      end)
 
     records
     |> zip_values(values)
@@ -349,10 +397,10 @@ defmodule MyAppWeb.Pow.RedisCacheTest do
   test "delete removes from redis sets" do
     RedisCache.put(@default_config, {["namespace", "key1"], "value"})
     RedisCache.put(@default_config, {["namespace", "key2"], "value"})
-    assert redix_smembers_decoded("namespace") == ["key1", "key2"]
+    assert redix_zmembers_decoded("namespace") == ["key1", "key2"]
 
     RedisCache.delete(@default_config, ["namespace", "key1"])
-    assert redix_smembers_decoded("namespace") == ["key2"]
+    assert redix_zmembers_decoded("namespace") == ["key2"]
   end
 
   describe "with redis errors" do
@@ -367,7 +415,7 @@ defmodule MyAppWeb.Pow.RedisCacheTest do
     end
 
     test "raises error" do
-      assert_raise(RuntimeError, "Redix failed SET because of [%Redix.Error{message: \"OOM command not allowed when used memory > 'maxmemory'.\"}]", fn ->
+      assert_raise(RuntimeError, ~r/#{Regex.escape("Redix received unexpected response [{%Redix.Error{message: \"OOM command not allowed when used memory > 'maxmemory'.\"}, ")}/, fn ->
         RedisCache.put(@default_config, {"key", "value"})
       end)
     end
@@ -390,7 +438,8 @@ defmodule MyAppWeb.Pow.RedisCacheTest do
     assert length(items) == 11
 
     RedisCache.put(@default_config, {["namespace", "key"], "value"})
-    assert RedisCache.all(@default_config, ["namespace", :_]) ==  [{["namespace", "key"], "value"}]
+    RedisCache.put(@default_config, {["namespace", "key", "key2"], "value"})
+    assert RedisCache.all(@default_config, ["namespace", :_]) == [{["namespace", "key"], "value"}]
   end
 
   test "records auto purge" do
@@ -401,21 +450,23 @@ defmodule MyAppWeb.Pow.RedisCacheTest do
     assert RedisCache.get(config, "key") == "value"
     assert RedisCache.get(config, "key1") == "1"
     assert RedisCache.get(config, ["namespace", "key2"]) == "2"
-    assert redix_smembers_decoded("namespace") == ["key2"]
+    assert redix_zmembers_decoded("namespace") == ["key2"]
     RedisCache.put(Keyword.put(@default_config, :ttl, 200), [{["namespace", "key3"], "3"}])
-    assert redix_smembers_decoded("namespace") == ["key3", "key2"]
-    :timer.sleep(50)
+    assert redix_zmembers_decoded("namespace") == ["key2", "key3"]
+    :timer.sleep(100)
     assert RedisCache.get(config, "key") == :not_found
     assert RedisCache.get(config, "key1") == :not_found
     assert RedisCache.get(config, ["namespace", "key2"]) == :not_found
     assert RedisCache.get(config, ["namespace", "key3"]) == "3"
-    assert redix_smembers_decoded("namespace") == ["key3"]
+    RedisCache.put(Keyword.put(@default_config, :ttl, 100), [{["namespace", "key4"], "4"}])
+    assert redix_zmembers_decoded("namespace") == ["key3", "key4"]
     :timer.sleep(100)
     assert RedisCache.get(config, ["namespace", "key3"]) == :not_found
-    assert redix_smembers_decoded("namespace") == []
+    assert RedisCache.all(config, ["namespace", :_]) ==  []
+    assert redix_zmembers_decoded("namespace") == []
   end
 
-  defp redix_smembers_decoded(key) do
+  defp redix_zmembers_decoded(key) do
     encoded_prefix =
       [@default_config[:namespace]]
       |> Kernel.++(List.wrap(key))
@@ -427,7 +478,7 @@ defmodule MyAppWeb.Pow.RedisCacheTest do
       |> Enum.join(":")
 
     :redix
-    |> Redix.command!(["SMEMBERS", encoded_prefix])
+    |> Redix.command!(["ZRANGEBYSCORE", "_index:#{encoded_prefix}", "-inf", "+inf"])
     |> Enum.map(fn encoded_key ->
       encoded_key
       |> String.split(":")


### PR DESCRIPTION
Resolves #561

The Redis performance was atrocious with large databases, because it uses `SCAN` for each `put` call. This PR attempts to use sets for indexing to improve performance greatly.

Here's the benchee test script (simulating sign in) and results:

```elixir
create_test_fun =
  fn config ->
    plug_config =
      [
        otp_app: :my_app,
        persistent_session_store: {PowPersistentSession.Store.PersistentSessionCache, config},
        credentials_cache_store: {Pow.Store.CredentialsCache, config}
      ]

    {
      fn _sessions ->
        user = %MyApp.Users.User{id: 900}
        session_init = Pow.Plug.Session.init(plug_config)
        persistent_init = PowPersistentSession.Plug.Cookie.init(plug_config)

        Phoenix.ConnTest.build_conn()
        |> Phoenix.ConnTest.init_test_session(%{})
        |> Map.put(:secret_key_base, "this is a very very very very very very very long secret string!")
        |> Pow.Plug.Session.call(session_init)
        |> Pow.Plug.create(user)
        |> PowPersistentSession.Plug.Cookie.call(persistent_init)
        |> PowPersistentSession.Plug.create(user)
        |> Plug.Conn.send_resp(200, "OK")
      end,
      before_scenario: fn sessions ->
        for i <- sessions do
          user = %MyApp.Users.User{id: i}
          Pow.Store.CredentialsCache.put(config, "key_#{i}", {user, []})
          PowPersistentSession.Store.PersistentSessionCache.put(config, "key_#{i}", {user, []})
        end
      end
    }
  end

Benchee.run(
  %{
    "scan" => create_test_fun.([backend: MyAppWeb.Pow.RedisCacheScan]),
    "sorted_sets" => create_test_fun.([backend: MyAppWeb.Pow.RedisCache])
  },
  time: 30,
  after_scenario: fn _input -> Redix.command!(:redix, ["FLUSHALL"]) end,
  inputs: %{
    "small" => Enum.to_list(1..1_000),
    "large" => Enum.to_list(1..10_000),
    "huge" => Enum.to_list(1..100_000)
  }
)
```

```
Benchmarking scan with input huge...
Benchmarking scan with input large...
Benchmarking scan with input small...
Benchmarking sorted_sets with input huge...
Benchmarking sorted_sets with input large...
Benchmarking sorted_sets with input small...

##### With input huge #####
Name                  ips        average  deviation         median         99th %
sorted_sets         18.97       0.0527 s    ±42.81%       0.0489 s        0.123 s
scan                 0.21         4.72 s    ±12.69%         4.48 s         5.58 s

Comparison: 
sorted_sets         18.97
scan                 0.21 - 89.45x slower +4.66 s

##### With input large #####
Name                  ips        average  deviation         median         99th %
sorted_sets         19.03       52.55 ms    ±39.51%       50.68 ms      118.45 ms
scan                 1.59      627.47 ms    ±18.12%      592.82 ms      983.74 ms

Comparison: 
sorted_sets         19.03
scan                 1.59 - 11.94x slower +574.91 ms

##### With input small #####
Name                  ips        average  deviation         median         99th %
sorted_sets         17.17       58.23 ms    ±42.92%       52.31 ms      125.17 ms
scan                 9.10      109.94 ms    ±20.05%      108.75 ms      185.18 ms

Comparison: 
sorted_sets         17.17
scan                 9.10 - 1.89x slower +51.71 ms
```

It takes perf from O(n) to O(1) 🥳 