### PR TITLE
Fixed incorrect file path in readme

### DIFF
--- a/guides/user_roles.md
+++ b/guides/user_roles.md
@@ -155,7 +155,7 @@ end
 You may wish to render certain sections in your layout for certain roles. First let's add a helper method to the users context:
 
 ```elixir
-# lib/my_app/users/user.ex
+# lib/my_app/users.ex
 defmodule MyApp.Users do
   alias MyApp.{Repo, Users.User}
 


### PR DESCRIPTION
This PR fixes the incorrect path used in the readme for user roles. The description says it should be put into User context but the path above was saying it's in the User schema.