### PR TITLE
Add test for PowPersistentSession.Store.PersistentSessionCache and update API guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v1.0.22 (TBA)
 
+This release introduces a breaking change for the API guide. Please check migration section below.
+
 ### Enhancements
 
 * [`PowPersistentSession.Plug.Cookie`] Now stores the user struct instead of clauses
@@ -11,6 +13,16 @@
 * [`Pow.Operations`] Added `Pow.Operations.reload/2` to reload structs
 * [`PowPersistentSession.Store.PersistentSessionCache`] Update `PowPersistentSession.Store.PersistentSessionCache.get/2` to reload the user using `Pow.Operations.reload/2`
 * [`Pow.Store.CredentialsCache`] Now support `reload: true` configuration so once fetched from the cache the user object will be reloaded through the context module
+
+### Documentation
+
+* Updated the [API guide](guides/api.md) as it's no longer necessary to load the user struct
+
+### Migration
+
+If you've used an API setup for previous version, you'll see ``(RuntimeError) No `:pow_config` value found in the store config.`` errors raised. It's recommended to replace your `APIAuthPlug` with the updated version in the API guide.
+
+The larger refactor of cache setup in Pow `v1.0.22` means that user struct is always expected to be passed in and returned by the stores, so it is no longer necessary to load the user in the API plug. The `PowPersistentSession.Store.PersistentSessionCache` has fallback logic to handle the deprecated clauses keyword list, and will load the user correctly.
 
 ## v1.0.21 (2020-09-13)
 

--- a/guides/api.md
+++ b/guides/api.md
@@ -182,7 +182,7 @@ defmodule MyAppWeb.APIAuthPlug do
   defp store_config(config) do
     backend = Config.get(config, :cache_store_backend, Pow.Store.Backend.EtsCache)
 
-    [backend: backend]
+    [backend: backend, pow_config: config]
   end
 end
 ```

--- a/guides/api.md
+++ b/guides/api.md
@@ -152,21 +152,14 @@ defmodule MyAppWeb.APIAuthPlug do
 
     with {:ok, signed_token} <- fetch_access_token(conn),
          {:ok, token}        <- verify_token(conn, signed_token, config),
-         {clauses, metadata} <- PersistentSessionCache.get(store_config, token) do
+         {user, metadata}    <- PersistentSessionCache.get(store_config, token) do
 
       CredentialsCache.delete(store_config, metadata[:access_token])
       PersistentSessionCache.delete(store_config, token)
 
-      load_and_create_session(conn, {clauses, metadata}, config)
+      create(conn, user, config)
     else
       _any -> {conn, nil}
-    end
-  end
-
-  defp load_and_create_session(conn, {clauses, _metadata}, config) do
-    case Pow.Operations.get_by(clauses, config) do
-      nil  -> {conn, nil}
-      user -> create(conn, user, config)
     end
   end
 

--- a/test/extensions/persistent_session/plug/cookie_test.exs
+++ b/test/extensions/persistent_session/plug/cookie_test.exs
@@ -217,36 +217,6 @@ defmodule PowPersistentSession.Plug.CookieTest do
    end
 
   # TODO: Remove by 1.1.0
-  test "call/2 is backwards-compatible with user fetch clause", %{conn: conn, user: user} do
-    id   = store_in_cache(conn, "test", {[id: user.id], []})
-    conn =
-      conn
-      |> persistent_cookie(@cookie_key, id)
-      |> run_plug()
-
-    assert Plug.current_user(conn) == user
-    assert %{value: new_id, max_age: @max_age, path: "/"} = conn.resp_cookies[@cookie_key]
-    refute new_id == id
-    assert get_from_cache(conn, id) == :not_found
-    assert get_from_cache(conn, new_id) == {user, []}
-  end
-
-  # TODO: Remove by 1.1.0
-  test "call/2 is backwards-compatible with just user fetch clause", %{conn: conn, user: user} do
-    id   = store_in_cache(conn, "test", [id: user.id])
-    conn =
-      conn
-      |> persistent_cookie(@cookie_key, id)
-      |> run_plug()
-
-    assert Plug.current_user(conn) == user
-    assert %{value: new_id, max_age: @max_age, path: "/"} = conn.resp_cookies[@cookie_key]
-    refute new_id == id
-    assert get_from_cache(conn, id) == :not_found
-    assert get_from_cache(conn, new_id) == {user, []}
-  end
-
-  # TODO: Remove by 1.1.0
   test "call/2 is backwards-compatible with `:session_fingerprint` metadata", %{conn: conn, user: user} do
     id   = store_in_cache(conn, "test", {user, session_fingerprint: "fingerprint"})
     conn =

--- a/test/extensions/persistent_session/store/persistent_session_cache_test.exs
+++ b/test/extensions/persistent_session/store/persistent_session_cache_test.exs
@@ -1,0 +1,57 @@
+defmodule PowPersistentSession.Store.PersistentSessionCacheTest do
+  use ExUnit.Case
+  doctest PowPersistentSession.Store.PersistentSessionCache
+
+  alias PowPersistentSession.Store.PersistentSessionCache
+  alias Pow.Test.Ecto.Users.User
+  alias Pow.Test.EtsCacheMock
+
+  defmodule ContextMock do
+    def get_by([id: :missing]), do: nil
+    def get_by([id: id]), do: %User{id: {:loaded, id}}
+  end
+
+  @config [backend: EtsCacheMock, pow_config: [users_context: ContextMock]]
+  @backend_config [namespace: "persistent_session"]
+
+  setup do
+    EtsCacheMock.init()
+
+    {:ok, ets: EtsCacheMock}
+  end
+
+  test "stores persistent sessions", %{ets: ets} do
+    user_1 = %User{id: 1}
+    user_2 = %User{id: 2}
+
+    PersistentSessionCache.put(@config, "key_1", {user_1, a: 1})
+    PersistentSessionCache.put(@config, "key_2", {user_1, a: 2})
+    PersistentSessionCache.put(@config, "key_3", {user_2, a: 3})
+    PersistentSessionCache.put(@config, "key_4", {%User{id: :missing}, a: 4})
+
+    assert PersistentSessionCache.get(@config, "key_1") == {%User{id: {:loaded, 1}}, a: 1}
+    assert PersistentSessionCache.get(@config, "key_2") == {%User{id: {:loaded, 1}}, a: 2}
+    assert PersistentSessionCache.get(@config, "key_3") == {%User{id: {:loaded, 2}}, a: 3}
+    refute PersistentSessionCache.get(@config, "key_4")
+
+    assert PersistentSessionCache.delete(@config, "key_1") == :ok
+    assert PersistentSessionCache.get(@config, "key_1") == :not_found
+    assert ets.get(@backend_config, "key_1") == :not_found
+  end
+
+  # TODO: Remove by 1.1.0
+  test "get/2 is backwards-compatible with user fetch clause", %{ets: ets} do
+    ets.put(@backend_config, {"token", {[id: 1], [a: 1]}})
+    assert PersistentSessionCache.get(@config, "token") == {%User{id: {:loaded, 1}}, [a: 1]}
+
+    ets.put(@backend_config, {"token", {[id: :missing], [a: 1]}})
+    refute PersistentSessionCache.get(@config, "token")
+  end
+
+  # TODO: Remove by 1.1.0
+  test "get/2 is backwards-compatible with just user fetch clause", %{ets: ets} do
+    ets.put(@backend_config, {"token", id: 1})
+
+    assert PersistentSessionCache.get(@config, "token") == {%User{id: {:loaded, 1}}, []}
+  end
+end


### PR DESCRIPTION
#392 introduces breaking changes to the API guide, so had to update the guide. The test should hopefully catch the issue for any users, so I don't see this as too problematic.

This also adds test for `PowPersistentSession.Store.PersistentSessionCache` since there is more logic there now to handle the stored value.