### PR TITLE
Fixes warning with elixir 1.11

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -12,6 +12,7 @@ defmodule Pow.MixProject do
       start_permanent: Mix.env() == :prod,
       compilers: [:phoenix] ++ Mix.compilers(),
       deps: deps(),
+      xref: xref(),
 
       # Hex
       description: "Robust user authentication solution",
@@ -31,7 +32,9 @@ defmodule Pow.MixProject do
   end
 
   defp extra_applications(:test), do: [:ecto, :logger, :mnesia]
-  defp extra_applications(_), do: [:logger, :mnesia]
+  defp extra_applications(_), do: [:logger]
+
+  defp xref, do: [xref: [exclude: :mnesia]]
 
   defp deps do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule Pow.MixProject do
   end
 
   defp extra_applications(:test), do: [:ecto, :logger, :mnesia]
-  defp extra_applications(_), do: [:logger]
+  defp extra_applications(_), do: [:logger, :mnesia]
 
   defp deps do
     [


### PR DESCRIPTION
This PR fixes a new warning in Elixir 1.11 due to `:mnesia` not being in `extra_applications` list.

This is the warning:
```elixir
warning: :mnesia.write/1 defined in application :mnesia is used by the current application but the current application does not directly depend on :mnesia. To fix this, you must do one of:

  1. If :mnesia is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :mnesia is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :mnesia, you may optionally skip this warning by adding [xref: [exclude: :mnesia]] to your "def project" in mix.exs
```