### PR TITLE
Fix dialyzer error when using messages

### DIFF
--- a/lib/pow/ecto/schema.ex
+++ b/lib/pow/ecto/schema.ex
@@ -166,10 +166,8 @@ defmodule Pow.Ecto.Schema do
       @behaviour unquote(__MODULE__)
       @pow_config unquote(config)
 
-      @spec changeset(Ecto.Schema.t() | Changeset.t(), map()) :: Changeset.t()
       def changeset(user_or_changeset, attrs), do: pow_changeset(user_or_changeset, attrs)
 
-      @spec verify_password(Ecto.Schema.t(), binary()) :: boolean()
       def verify_password(user, password), do: pow_verify_password(user, password)
 
       defoverridable unquote(__MODULE__)
@@ -191,7 +189,6 @@ defmodule Pow.Ecto.Schema do
         pow_method_name = String.to_atom("pow_#{method}")
 
         quote do
-          @spec unquote(pow_method_name)(Ecto.Schema.t() | Changeset.t(), map()) :: Changeset.t()
           def unquote(pow_method_name)(user_or_changeset, attrs) do
             unquote(__MODULE__).Changeset.unquote(method)(user_or_changeset, attrs, @pow_config)
           end
@@ -201,7 +198,6 @@ defmodule Pow.Ecto.Schema do
     quote do
       import unquote(__MODULE__), only: [pow_user_fields: 0]
 
-      @spec pow_changeset(Ecto.Schema.t() | Changeset.t(), map()) :: Changeset.t()
       def pow_changeset(user_or_changeset, attrs) do
         user_or_changeset
         |> pow_user_id_field_changeset(attrs)
@@ -211,7 +207,6 @@ defmodule Pow.Ecto.Schema do
 
       unquote(quoted_changeset_methods)
 
-      @spec pow_verify_password(Ecto.Schema.t(), binary()) :: boolean()
       def pow_verify_password(user, password) do
         unquote(__MODULE__).Changeset.verify_password(user, password, @pow_config)
       end

--- a/lib/pow/extension/ecto/schema.ex
+++ b/lib/pow/extension/ecto/schema.ex
@@ -89,7 +89,6 @@ defmodule Pow.Extension.Ecto.Schema do
   @doc false
   defmacro __pow_extension_methods__ do
     quote do
-      @spec pow_extension_changeset(Changeset.t(), map()) :: Changeset.t()
       def pow_extension_changeset(changeset, attrs) do
         unquote(__MODULE__).changeset(changeset, attrs, @pow_extension_config)
       end

--- a/lib/pow/extension/phoenix/controllers/controller_callbacks/base.ex
+++ b/lib/pow/extension/phoenix/controllers/controller_callbacks/base.ex
@@ -38,7 +38,6 @@ defmodule Pow.Extension.Phoenix.ControllerCallbacks.Base do
     for hook <- [:before_process, :before_respond] do
       quote do
         @impl true
-        @spec unquote(hook)(atom(), atom(), any(), Config.t()) :: any()
         def unquote(hook)(_controller, _action, res, _config), do: res
       end
     end

--- a/lib/pow/extension/phoenix/messages.ex
+++ b/lib/pow/extension/phoenix/messages.ex
@@ -22,9 +22,7 @@ defmodule Pow.Extension.Phoenix.Messages do
 
   Remember to update configuration with `messages_backend: MyAppWeb.Pow.Messages`.
   """
-  alias Plug.Conn
   alias Pow.Extension
-  alias Pow.Phoenix.Messages
 
   @doc false
   defmacro __using__(config) do
@@ -60,7 +58,6 @@ defmodule Pow.Extension.Phoenix.Messages do
   @doc false
   defmacro __define_message_method__(extension, method_name, fallback_method) do
     quote bind_quoted: [extension: extension, method_name: method_name, fallback_method: fallback_method] do
-      @spec unquote(method_name)(Conn.t()) :: Messages.message()
       def unquote(method_name)(conn) do
         unquote(extension).unquote(fallback_method)(conn)
       end
@@ -77,7 +74,6 @@ defmodule Pow.Extension.Phoenix.Messages do
         method_name = unquote(__MODULE__).method_name(unquote(extension), method)
 
         quote do
-          @spec unquote(method)(Conn.t()) :: Messages.message()
           def unquote(method)(conn) do
             unquote(__MODULE__).unquote(method_name)(conn)
           end

--- a/lib/pow/extension/phoenix/messages.ex
+++ b/lib/pow/extension/phoenix/messages.ex
@@ -22,7 +22,9 @@ defmodule Pow.Extension.Phoenix.Messages do
 
   Remember to update configuration with `messages_backend: MyAppWeb.Pow.Messages`.
   """
+  alias Plug.Conn
   alias Pow.Extension
+  alias Pow.Phoenix.Messages
 
   @doc false
   defmacro __using__(config) do

--- a/lib/pow/phoenix/controllers/controller.ex
+++ b/lib/pow/phoenix/controllers/controller.ex
@@ -40,13 +40,7 @@ defmodule Pow.Phoenix.Controller do
 
       plug :pow_layout, unquote(config)
 
-      @doc """
-      See `Pow.Phoenix.Controller.action/3` for more.
-      """
-      @spec action(Conn.t(), Keyword.t()) :: Conn.t()
-      def action(conn, _opts) do
-        unquote(__MODULE__).action(__MODULE__, conn, conn.params)
-      end
+      def action(conn, _opts), do: unquote(__MODULE__).action(__MODULE__, conn, conn.params)
 
       defp pow_layout(conn, _config), do: ViewHelpers.layout(conn)
 
@@ -57,25 +51,9 @@ defmodule Pow.Phoenix.Controller do
   @doc false
   defmacro __define_helper_methods__ do
     quote do
-      @doc """
-      See `Pow.Phoenix.Controller.messages/2` for more.
+      def messages(conn), do: unquote(__MODULE__).messages(conn, Messages)
 
-      `Pow.Phoenix.Messages` is used as fallback.
-      """
-      @spec messages(Conn.t()) :: atom()
-      def messages(conn) do
-        unquote(__MODULE__).messages(conn, Messages)
-      end
-
-      @doc """
-      See `Pow.Phoenix.Controller.routes/2` for more.
-
-      `Pow.Phoenix.Routes` is used as fallback.
-      """
-      @spec routes(Conn.t()) :: atom()
-      def routes(conn) do
-        unquote(__MODULE__).routes(conn, Routes)
-      end
+      def routes(conn), do: unquote(__MODULE__).routes(conn, Routes)
 
       defoverridable messages: 1, routes: 1
     end

--- a/lib/pow/plug/base.ex
+++ b/lib/pow/plug/base.ex
@@ -113,7 +113,6 @@ defmodule Pow.Plug.Base do
 
       The user is assigned to the conn with `Pow.Plug.assign_current_user/3`.
       """
-      @spec do_fetch(Conn.t(), Config.t()) :: Conn.t()
       def do_fetch(conn, config) do
         conn
         |> fetch(config)
@@ -125,7 +124,6 @@ defmodule Pow.Plug.Base do
 
       The user is assigned to the conn with `Pow.Plug.assign_current_user/3`.
       """
-      @spec do_create(Conn.t(), map(), Config.t()) :: Conn.t()
       def do_create(conn, user, config) do
         conn
         |> create(user, config)
@@ -138,7 +136,6 @@ defmodule Pow.Plug.Base do
       The user assigned is removed from the conn with
       `Pow.Plug.assign_current_user/3`.
       """
-      @spec do_delete(Conn.t(), Config.t()) :: Conn.t()
       def do_delete(conn, config) do
         conn
         |> delete(config)

--- a/lib/pow/store/base.ex
+++ b/lib/pow/store/base.ex
@@ -53,7 +53,6 @@ defmodule Pow.Store.Base do
         unquote(__MODULE__).all(config, backend_config(config), key_match)
       end
 
-      @spec backend_config(unquote(__MODULE__).config()) :: unquote(__MODULE__).config()
       def backend_config(config) do
         [
           ttl: Config.get(config, :ttl, unquote(defaults[:ttl])),


### PR DESCRIPTION
When I used `Pow.Extension.Phoenix.Messages` in one project that is using dialyzer, I got unknown types `Conn.t()` and `Messages.message()`, there were missing aliases