### PR TITLE
Add missing aliases for specs used in phoenix messages

### DIFF
--- a/lib/pow/extension/phoenix/messages.ex
+++ b/lib/pow/extension/phoenix/messages.ex
@@ -22,7 +22,9 @@ defmodule Pow.Extension.Phoenix.Messages do
 
   Remember to update configuration with `messages_backend: MyAppWeb.Pow.Messages`.
   """
+  alias Plug.Conn
   alias Pow.Extension
+  alias Pow.Phoenix.Messages
 
   @doc false
   defmacro __using__(config) do

--- a/mix.exs
+++ b/mix.exs
@@ -12,6 +12,7 @@ defmodule Pow.MixProject do
       start_permanent: Mix.env() == :prod,
       compilers: [:phoenix] ++ Mix.compilers(),
       deps: deps(),
+      xref: xref(),
 
       # Hex
       description: "Robust user authentication solution",
@@ -32,6 +33,8 @@ defmodule Pow.MixProject do
 
   defp extra_applications(:test), do: [:ecto, :logger, :mnesia]
   defp extra_applications(_), do: [:logger]
+
+  defp xref, do: [xref: [exclude: :mnesia]]
 
   defp deps do
     [


### PR DESCRIPTION
There are some missing type aliases used in phoenix messages, after using messages dialyzer reported
```
:0:unknown_type
Unknown type: Conn.t/0.
________________________________________________________________________________
:0:unknown_type
Unknown type: Messages.message/0.
________________________________________________________________________________
done (warnings were emitted)
Halting VM with exit status 2
```