### PR TITLE
Add backwards compatibility to the persistent session cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v1.0.22 (TBA)
 
-This release introduces a breaking change for the API guide. Please check migration section below.
+This release introduces a deprecation for the default API guide implementation. Please check migration section below.
 
 ### Enhancements
 
@@ -20,7 +20,7 @@ This release introduces a breaking change for the API guide. Please check migrat
 
 ### Migration
 
-If you've used an API setup for previous version, you'll see ``(RuntimeError) No `:pow_config` value found in the store config.`` errors raised. It's recommended to replace your `APIAuthPlug` with the updated version in the API guide.
+If you've used an API setup for previous version, you'll see the warning ``PowPersistentSession.Store.PersistentSessionCache.get/2 call without `:pow_config` in second argument is deprecated, refer to the API guide.``. It's recommended to replace your `APIAuthPlug` with the updated version in the API guide.
 
 The larger refactor of cache setup in Pow `v1.0.22` means that user struct is always expected to be passed in and returned by the stores, so it is no longer necessary to load the user in the API plug. The `PowPersistentSession.Store.PersistentSessionCache` has fallback logic to handle the deprecated clauses keyword list, and will load the user correctly.
 

--- a/lib/extensions/persistent_session/store/persistent_session_cache.ex
+++ b/lib/extensions/persistent_session/store/persistent_session_cache.ex
@@ -27,8 +27,21 @@ defmodule PowPersistentSession.Store.PersistentSessionCache do
   defp convert_old_value(clauses) when is_list(clauses), do: {clauses, []}
 
   defp reload(:not_found, _config), do: :not_found
+  defp reload(value, config) do
+    case Keyword.has_key?(config, :pow_config) do
+      true ->
+        do_reload(value, config)
+
+      # TODO: Remove by 1.1.0
+      false ->
+        IO.warn("#{inspect __MODULE__}.get/2 call without `:pow_config` in second argument is deprecated, find the migration step in the changelog.")
+
+        value
+    end
+  end
+
   # TODO: Remove by 1.1.0
-  defp reload({clauses, metadata}, config) when is_list(clauses) do
+  defp do_reload({clauses, metadata}, config) when is_list(clauses) do
     pow_config = fetch_pow_config!(config)
 
     case Operations.get_by(clauses, pow_config) do
@@ -36,7 +49,7 @@ defmodule PowPersistentSession.Store.PersistentSessionCache do
       user -> {user, metadata}
     end
   end
-  defp reload({user, metadata}, config) do
+  defp do_reload({user, metadata}, config) do
     pow_config = fetch_pow_config!(config)
 
     case Operations.reload(user, pow_config) do


### PR DESCRIPTION
#392 introduced breaking change, but this PR helps smooth the migration by just letting it be a deprecated change.