### PR TITLE
Don't reload the struct on repo.insert and repo.update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.0.23 (TBA)
+
+### Enhancements
+
+* [`Pow.Ecto.Context`] No longer automatically reloads the struct after insert or update
+
 ## v1.0.22 (2021-01-27)
 
 This release introduces a deprecation for the default API guide implementation. Please check migration section below.

--- a/lib/pow/ecto/context.ex
+++ b/lib/pow/ecto/context.ex
@@ -192,10 +192,9 @@ defmodule Pow.Ecto.Context do
   @spec do_insert(changeset(), Config.t()) :: {:ok, user()} | {:error, changeset()}
   def do_insert(changeset, config) do
     opts = repo_opts(config, [:prefix])
+    repo = Config.repo!(config)
 
-    changeset
-    |> Config.repo!(config).insert(opts)
-    |> reload_after_write(config)
+    repo.insert(changeset, opts)
   end
 
   @doc """
@@ -206,19 +205,9 @@ defmodule Pow.Ecto.Context do
   @spec do_update(changeset(), Config.t()) :: {:ok, user()} | {:error, changeset()}
   def do_update(changeset, config) do
     opts = repo_opts(config, [:prefix])
+    repo = Config.repo!(config)
 
-    changeset
-    |> Config.repo!(config).update(opts)
-    |> reload_after_write(config)
-  end
-
-  defp reload_after_write({:error, changeset}, _config), do: {:error, changeset}
-  defp reload_after_write({:ok, struct}, config) do
-    # When ecto updates/inserts, has_many :through associations are set to nil.
-    # So we'll just reload when writes happen.
-    struct  = Operations.reload(struct, config) || raise "Record does not exist: #{inspect struct}"
-
-    {:ok, struct}
+    repo.update(changeset, opts)
   end
 
   # TODO: Remove by 1.1.0

--- a/lib/pow/ecto/schema/changeset.ex
+++ b/lib/pow/ecto/schema/changeset.ex
@@ -87,6 +87,7 @@ defmodule Pow.Ecto.Schema.Changeset do
     |> maybe_validate_password(config)
     |> maybe_put_password_hash(config)
     |> maybe_validate_password_hash()
+    |> Changeset.prepare_changes(&Changeset.delete_change(&1, :password))
   end
 
   # TODO: Remove `confirm_password` support by 1.1.0
@@ -153,6 +154,7 @@ defmodule Pow.Ecto.Schema.Changeset do
     |> reset_current_password_field()
     |> Changeset.cast(params, [:current_password])
     |> maybe_validate_current_password(config)
+    |> Changeset.prepare_changes(&Changeset.delete_change(&1, :current_password))
   end
 
   defp reset_current_password_field(%{data: user} = changeset) do

--- a/test/pow/ecto/context_test.exs
+++ b/test/pow/ecto/context_test.exs
@@ -39,12 +39,6 @@ defmodule Pow.Ecto.ContextTest do
     def get_by([email: :test]), do: %User{email: :ok, password_hash: Password.pbkdf2_hash("secret1234")}
   end
 
-  defmodule ReloadErrorUsers do
-    use Context, repo: Repo, user: User
-
-    def get_by([id: _any]), do: nil
-  end
-
   describe "authenticate/2" do
     @password "secret1234"
     @valid_params %{"email" => "test@example.com", "password" => @password}
@@ -149,12 +143,6 @@ defmodule Pow.Ecto.ContextTest do
 
       assert Users.create(:test_macro) == :ok
     end
-
-    test "when can't be reloaded after write" do
-      assert_raise RuntimeError, ~r/Record does not exist: %Pow.Test.Ecto.Users.User{/, fn ->
-        Context.create(@valid_params, @config ++ [users_context: ReloadErrorUsers])
-      end
-    end
   end
 
   describe "update/2" do
@@ -188,12 +176,6 @@ defmodule Pow.Ecto.ContextTest do
       refute user.password
 
       assert Users.update(user, :test_macro) == :ok
-    end
-
-    test "when can't be reloaded after write", %{user: user} do
-      assert_raise RuntimeError, ~r/Record does not exist: %Pow.Test.Ecto.Users.User{/, fn ->
-        Context.update(user, @valid_params, @config ++ [users_context: ReloadErrorUsers])
-      end
     end
   end
 


### PR DESCRIPTION
I can't remember why this logic was created in the first place, but this eliminate the need to reload the struct. Instead we'll reset the sensitive fields.