### PR TITLE
Update `:crypto.mac` handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [`Pow.Ecto.Context`] No longer automatically reloads the struct after insert or update
 * [`PowInvitation.Ecto.Schema`] Added `PowInvitation.Ecto.Schema.invitation_token_changeset/1`
 * [`PowInvitation.Ecto.Schema`] Added `PowInvitation.Ecto.Schema.invited_by_changeset/2`
+* [`Pow.Ecto.Schema.Password.Pbkdf2`] Now uses `:crypto.mac/4` if available to support OTP 24
 
 ## v1.0.22 (2021-01-27)
 

--- a/lib/pow/ecto/schema/password/pbkdf2.ex
+++ b/lib/pow/ecto/schema/password/pbkdf2.ex
@@ -1,7 +1,7 @@
 defmodule Pow.Ecto.Schema.Password.Pbkdf2 do
   @moduledoc """
   The Pbkdf2 hash generation code is pulled from
-  [Plug.Crypto.KeyGenerator](https://github.com/elixir-plug/plug/blob/v1.6.1/lib/plug/crypto/key_generator.ex#L1)
+  [Plug.Crypto.KeyGenerator](https://github.com/elixir-plug/plug_crypto/blob/v1.2.1/lib/plug/crypto/key_generator.ex)
   and is under Apache 2 license.
   """
   use Bitwise
@@ -10,17 +10,17 @@ defmodule Pow.Ecto.Schema.Password.Pbkdf2 do
   Compares the two binaries in constant-time to avoid timing attacks.
   """
   @spec compare(binary(), binary()) :: boolean()
-  def compare(left, right) when byte_size(left) == byte_size(right) do
-    compare(left, right, 0) == 0
+  def compare(left, right) when is_binary(left) and is_binary(right) do
+    byte_size(left) == byte_size(right) and compare(left, right, 0)
   end
-  def compare(_hash, _secret_hash), do: false
 
   defp compare(<<x, left::binary>>, <<y, right::binary>>, acc) do
     xorred = x ^^^ y
     compare(left, right, acc ||| xorred)
   end
+
   defp compare(<<>>, <<>>, acc) do
-    acc
+    acc === 0
   end
 
   @max_length bsl(1, 32) - 1
@@ -30,11 +30,28 @@ defmodule Pow.Ecto.Schema.Password.Pbkdf2 do
   """
   @spec generate(binary(), binary(), integer(), integer(), atom()) :: binary()
   def generate(secret, salt, iterations, length, digest) do
-    if length > @max_length do
-      raise ArgumentError, "length must be less than or equal to #{@max_length}"
-    else
-      generate(mac_fun(digest, secret), salt, iterations, length, 1, [], 0)
+    cond do
+      not is_integer(iterations) or iterations < 1 ->
+        raise ArgumentError, "iterations must be an integer >= 1"
+
+      length > @max_length ->
+        raise ArgumentError, "length must be less than or equal to #{@max_length}"
+
+      true ->
+        generate(mac_fun(digest, secret), salt, iterations, length, 1, [], 0)
     end
+  rescue
+    e ->
+      stacktrace =
+        case __STACKTRACE__ do
+          [{mod, fun, [_ | _] = args, info} | rest] ->
+            [{mod, fun, length(args), info} | rest]
+
+          stacktrace ->
+            stacktrace
+        end
+
+      reraise e, stacktrace
   end
 
   defp generate(_fun, _salt, _iterations, max_length, _block_index, acc, length)
@@ -47,6 +64,7 @@ defmodule Pow.Ecto.Schema.Password.Pbkdf2 do
   defp generate(fun, salt, iterations, max_length, block_index, acc, length) do
     initial = fun.(<<salt::binary, block_index::integer-size(32)>>)
     block = iterate(fun, iterations - 1, initial, initial)
+    length = byte_size(block) + length
 
     generate(
       fun,
@@ -55,7 +73,7 @@ defmodule Pow.Ecto.Schema.Password.Pbkdf2 do
       max_length,
       block_index + 1,
       [acc | block],
-      byte_size(block) + length
+      length
     )
   end
 
@@ -66,7 +84,10 @@ defmodule Pow.Ecto.Schema.Password.Pbkdf2 do
     iterate(fun, iteration - 1, next, :crypto.exor(next, acc))
   end
 
-  defp mac_fun(digest, secret) do
-    &:crypto.hmac(digest, secret, &1)
+  # TODO: Remove when OTP 22.1 is required
+  if Code.ensure_loaded?(:crypto) and function_exported?(:crypto, :mac, 4) do
+    defp mac_fun(digest, secret), do: &:crypto.mac(:hmac, digest, secret, &1)
+  else
+    defp mac_fun(digest, secret), do: &:crypto.hmac(digest, secret, &1)
   end
 end

--- a/test/pow/ecto/schema/password/pbkdf2_test.exs
+++ b/test/pow/ecto/schema/password/pbkdf2_test.exs
@@ -1,0 +1,45 @@
+defmodule Pow.Ecto.Schema.Password.Pbkdf2Test do
+  use ExUnit.Case
+  use Bitwise
+
+  alias Pow.Ecto.Schema.Password.Pbkdf2
+
+  test "compare/2" do
+    assert Pbkdf2.compare(<<>>, <<>>)
+    assert Pbkdf2.compare(<<0>>, <<0>>)
+
+    refute Pbkdf2.compare(<<>>, <<1>>)
+    refute Pbkdf2.compare(<<1>>, <<>>)
+    refute Pbkdf2.compare(<<0>>, <<1>>)
+  end
+
+  describe "generate/5" do
+    @secret "secret"
+    @salt "salt"
+    @iterations 64
+    @length 20
+    @digest :sha512
+
+    @max_length bsl(1, 32) - 1
+
+    test "when length longer than max length" do
+      assert_raise ArgumentError, ~r/length must be less than or equal/, fn ->
+        Pbkdf2.generate(@secret, @salt, @iterations, @max_length + 1, @digest)
+      end
+    end
+
+    test "when iterations is invalid" do
+      for i <- [32.0, -1, nil, "many", :lots] do
+        assert_raise ArgumentError, "iterations must be an integer >= 1", fn ->
+          Pbkdf2.generate(@secret, @salt, i, @length, @digest)
+        end
+      end
+    end
+
+    test "generates hash" do
+      key = Pbkdf2.generate(@secret, @salt, @iterations, @length, @digest)
+      assert byte_size(key) == @length
+      assert key == <<168, 236, 50, 221, 154, 138, 163, 60, 82, 206, 193, 197, 48, 48, 74, 247, 200, 9, 195, 135>>
+    end
+  end
+end


### PR DESCRIPTION
Resolves #601 

Now uses the `:crypto.mac` instead of `:crypto.hmac` if available.