### PR TITLE
Fix deprecation Code.ensure_compiled?/1 to Code.ensure_compiled/1

### DIFF
--- a/lib/pow/extension/base.ex
+++ b/lib/pow/extension/base.ex
@@ -73,9 +73,11 @@ defmodule Pow.Extension.Base do
         [extension]
         |> Kernel.++(module_list)
         |> Module.concat()
-        |> Code.ensure_compiled?()
+        |> ensure_compiled?()
     end
   end
+
+  defp ensure_compiled?(module), do: match?({:module, ^module}, Code.ensure_compiled(module))
 
   defp has_extension_module?(extension, ["Ecto", "Schema"]), do: extension.ecto_schema?()
   defp has_extension_module?(extension, ["Phoenix", "ControllerCallbacks"]), do: extension.phoenix_controller_callbacks?()


### PR DESCRIPTION
On `mix do clean, compile`

```
==> pow
Compiling 117 files (.ex)
warning: Code.ensure_compiled?/1 is deprecated. Use Code.ensure_compiled/1 instead (see the proper disclaimers in its docs)
  lib/pow/extension/base.ex:76: Pow.Extension.Base.has?/2
```