### PR TITLE
Make it possible to fetch nodes on MnesiaCache start up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v1.0.24 (TBA)
 
-* [`Pow.Store.Backend.MnesiaCache`] Now accepts `extra_db_nodes: :all` to automatically connect to all visible nodes
+* [`Pow.Store.Backend.MnesiaCache`] Now accepts `extra_db_nodes: :all` and `extra_db_nodes: {module, function, arguments}` to automatically connect to all visible nodes
 
 
 ## v1.0.23 (2021-03-22)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.0.24 (TBA)
+
+* [`Pow.Store.Backend.MnesiaCache`] Now accepts `extra_db_nodes: :all` to automatically connect to all visible nodes
+
+
 ## v1.0.23 (2021-03-22)
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## v1.0.24 (TBA)
 
-* [`Pow.Store.Backend.MnesiaCache`] Now accepts `extra_db_nodes: :all` and `extra_db_nodes: {module, function, arguments}` to automatically connect to all visible nodes
-
+* [`Pow.Store.Backend.MnesiaCache`] Now accepts `extra_db_nodes: {module, function, arguments}` to fetch nodes when MnesiaCache starts up
 
 ## v1.0.23 (2021-03-22)
 

--- a/lib/pow/store/backend/mnesia_cache.ex
+++ b/lib/pow/store/backend/mnesia_cache.ex
@@ -22,10 +22,9 @@ defmodule Pow.Store.Backend.MnesiaCache do
   The MnesiaCache is built to handle multi-node setup.
 
   If you initialize with `extra_db_nodes: Node.list()`, it will automatically
-  connect to the cluster. If you use `extra_db_nodes: :all`, it will
-  automatically connect to all visible nodes at MnesiaCache runtime. This is
-  useful for when nodes are dynamically connected somewhere before in the
-  supervision tree. MFA is also accepted: `extra_db_nodes: {Node, :list, []}`.
+  connect to the cluster. You can also use MFA:
+  `extra_db_nodes: {Node, :list, []}`. This is useful for when nodes are
+  dynamically connected before MnesiaCache startup in the supervision tree.
 
   If there is no other nodes available, the data persisted to disk will be
   loaded, but if a cluster is running, the data in the existing cluster nodes
@@ -76,8 +75,8 @@ defmodule Pow.Store.Backend.MnesiaCache do
 
   ## Initialization options
 
-    * `:extra_db_nodes` - list of nodes in cluster to connect to. Use `:all` to
-      automatically connect to all visible nodes.
+    * `:extra_db_nodes` - list of nodes or MFA returning a list of nodes in
+      cluster to connect to.
 
     * `:table_opts` - options to add to table definition. This value defaults
       to `[disc_copies: [node()]]`.
@@ -297,7 +296,6 @@ defmodule Pow.Store.Backend.MnesiaCache do
 
     db_nodes =
       case db_nodes do
-        :all -> visible_nodes
         {mod, fun, args} -> apply(mod, fun, args)
         nodes -> nodes
       end

--- a/test/pow/store/backend/mnesia_cache_test.exs
+++ b/test/pow/store/backend/mnesia_cache_test.exs
@@ -324,18 +324,35 @@ defmodule Pow.Store.Backend.MnesiaCacheTest do
       {:ok, _pid} = :rpc.call(node_a, Supervisor, :start_child, [Pow.Supervisor, {MnesiaCache, @default_config}])
       assert :rpc.call(node_a, :mnesia, :system_info, [:extra_db_nodes]) == []
       assert :rpc.call(node_a, :mnesia, :system_info, [:running_db_nodes]) == [node_a]
-      assert :rpc.call(node_a, :mnesia, :system_info, [:is_running])
 
       # Join cluster with node b
       node_b = spawn_node("b")
       assert :rpc.call(node_b, Node, :connect, [node_a])
       config = @default_config ++ [extra_db_nodes: :all]
       {:ok, _pid} = :rpc.call(node_b, Supervisor, :start_child, [Pow.Supervisor, {MnesiaCache, config}])
-      assert :rpc.call(node_b, :mnesia, :table_info, [MnesiaCache, :storage_type]) == :disc_copies
+      assert :rpc.call(node_b, :mnesia, :system_info, [:extra_db_nodes]) == [node_a]
+      assert :rpc.call(node_b, :mnesia, :system_info, [:running_db_nodes]) == [node_a, node_b]
+    end
+
+    test "handles `extra_db_nodes: {module, function, arguments}`" do
+      :mnesia.kill()
+
+      # Init node a and write to it
+      node_a = spawn_node("a")
+      {:ok, _pid} = :rpc.call(node_a, Supervisor, :start_child, [Pow.Supervisor, {MnesiaCache, @default_config}])
+      assert :rpc.call(node_a, :mnesia, :system_info, [:extra_db_nodes]) == []
+      assert :rpc.call(node_a, :mnesia, :system_info, [:running_db_nodes]) == [node_a]
+
+      # Join cluster with node b
+      node_b = spawn_node("b")
+      config = @default_config ++ [extra_db_nodes: {Node, :list, []}]
+      {:ok, _pid} = :rpc.call(node_b, Supervisor, :start_child, [Pow.Supervisor, {MnesiaCache, config}])
       assert :rpc.call(node_b, :mnesia, :system_info, [:extra_db_nodes]) == [node_a]
       assert :rpc.call(node_b, :mnesia, :system_info, [:running_db_nodes]) == [node_a, node_b]
     end
   end
+
+  def extra_nodes_fun(nodes), do: nodes
 
   defp spawn_node(sname) do
     fn -> init_node(sname) end

--- a/test/pow/store/backend/mnesia_cache_test.exs
+++ b/test/pow/store/backend/mnesia_cache_test.exs
@@ -315,6 +315,26 @@ defmodule Pow.Store.Backend.MnesiaCacheTest do
       :rpc.call(node_a, MnesiaCache.Unsplit, :__heal__, [node_b, [flush_tables: :all]])
       assert :rpc.call(node_a, :mnesia, :system_info, [:running_db_nodes]) == [node_b, node_a]
     end
+
+    test "finds all visible nodes with `extra_db_nodes: :all`" do
+      :mnesia.kill()
+
+      # Init node a and write to it
+      node_a = spawn_node("a")
+      {:ok, _pid} = :rpc.call(node_a, Supervisor, :start_child, [Pow.Supervisor, {MnesiaCache, @default_config}])
+      assert :rpc.call(node_a, :mnesia, :system_info, [:extra_db_nodes]) == []
+      assert :rpc.call(node_a, :mnesia, :system_info, [:running_db_nodes]) == [node_a]
+      assert :rpc.call(node_a, :mnesia, :system_info, [:is_running])
+
+      # Join cluster with node b
+      node_b = spawn_node("b")
+      assert :rpc.call(node_b, Node, :connect, [node_a])
+      config = @default_config ++ [extra_db_nodes: :all]
+      {:ok, _pid} = :rpc.call(node_b, Supervisor, :start_child, [Pow.Supervisor, {MnesiaCache, config}])
+      assert :rpc.call(node_b, :mnesia, :table_info, [MnesiaCache, :storage_type]) == :disc_copies
+      assert :rpc.call(node_b, :mnesia, :system_info, [:extra_db_nodes]) == [node_a]
+      assert :rpc.call(node_b, :mnesia, :system_info, [:running_db_nodes]) == [node_a, node_b]
+    end
   end
 
   defp spawn_node(sname) do

--- a/test/pow/store/backend/mnesia_cache_test.exs
+++ b/test/pow/store/backend/mnesia_cache_test.exs
@@ -316,24 +316,6 @@ defmodule Pow.Store.Backend.MnesiaCacheTest do
       assert :rpc.call(node_a, :mnesia, :system_info, [:running_db_nodes]) == [node_b, node_a]
     end
 
-    test "finds all visible nodes with `extra_db_nodes: :all`" do
-      :mnesia.kill()
-
-      # Init node a and write to it
-      node_a = spawn_node("a")
-      {:ok, _pid} = :rpc.call(node_a, Supervisor, :start_child, [Pow.Supervisor, {MnesiaCache, @default_config}])
-      assert :rpc.call(node_a, :mnesia, :system_info, [:extra_db_nodes]) == []
-      assert :rpc.call(node_a, :mnesia, :system_info, [:running_db_nodes]) == [node_a]
-
-      # Join cluster with node b
-      node_b = spawn_node("b")
-      assert :rpc.call(node_b, Node, :connect, [node_a])
-      config = @default_config ++ [extra_db_nodes: :all]
-      {:ok, _pid} = :rpc.call(node_b, Supervisor, :start_child, [Pow.Supervisor, {MnesiaCache, config}])
-      assert :rpc.call(node_b, :mnesia, :system_info, [:extra_db_nodes]) == [node_a]
-      assert :rpc.call(node_b, :mnesia, :system_info, [:running_db_nodes]) == [node_a, node_b]
-    end
-
     test "handles `extra_db_nodes: {module, function, arguments}`" do
       :mnesia.kill()
 
@@ -351,8 +333,6 @@ defmodule Pow.Store.Backend.MnesiaCacheTest do
       assert :rpc.call(node_b, :mnesia, :system_info, [:running_db_nodes]) == [node_a, node_b]
     end
   end
-
-  def extra_nodes_fun(nodes), do: nodes
 
   defp spawn_node(sname) do
     fn -> init_node(sname) end


### PR DESCRIPTION
This greatly helps in situations like https://github.com/pow-auth/pow_site/issues/10 so instead of setting up a supervisor to dynamically fetch `Node.list()`, you can just set the `extra_db_nodes: {Node, :list, []}` to fetch the nodes when `Pow.Store.Backend.MnesiaCache` starts.