### PR TITLE
Handle mnesia initialization errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## v1.0.24 (TBA)
 
+### Enhancements
+
 * [`Pow.Store.Backend.MnesiaCache`] Now accepts `extra_db_nodes: {module, function, arguments}` to fetch nodes when MnesiaCache starts up
+
+### Bug fixes
+
+* [`Pow.Store.Backend.MnesiaCache`] Now handles initialization errors
 
 ## v1.0.23 (2021-03-22)
 
@@ -14,7 +20,7 @@
 * [`Pow.Ecto.Schema.Password.Pbkdf2`] Now uses `:crypto.mac/4` if available to support OTP 24
 * [`PowEmailConfirmation.Phoenix.ControllerCallbacks`] Now returns `:info` instead of `:error` message for when the user has to confirm their email
 
-## Bug fixes
+### Bug fixes
 
 * [`Pow.Store.Backend.MnesiaCache`] No longer triggers Elixir 1.11 dependency warnings
 

--- a/lib/pow/store/backend/mnesia_cache.ex
+++ b/lib/pow/store/backend/mnesia_cache.ex
@@ -135,11 +135,15 @@ defmodule Pow.Store.Backend.MnesiaCache do
   # Callbacks
 
   @impl GenServer
-  @spec init(Base.config()) :: {:ok, map()}
+  @spec init(Base.config()) :: {:ok, map()} | {:stop, any()}
   def init(config) do
-    init_mnesia(config)
+    case init_mnesia(config) do
+      :ok ->
+        {:ok, %{invalidators: init_invalidators(config)}}
 
-    {:ok, %{invalidators: init_invalidators(config)}}
+      {:error, error} ->
+        {:stop, error}
+    end
   end
 
   @impl GenServer
@@ -312,6 +316,8 @@ defmodule Pow.Store.Backend.MnesiaCache do
          :ok <- wait_for_table(config) do
 
       Logger.info("[#{inspect __MODULE__}] Mnesia cluster initiated on #{inspect node()}")
+
+      :ok
     else
       {:error, reason} ->
         Logger.error("[#{inspect __MODULE__}] Couldn't initialize mnesia cluster because: #{inspect reason}")

--- a/test/pow/store/backend/mnesia_cache_test.exs
+++ b/test/pow/store/backend/mnesia_cache_test.exs
@@ -316,6 +316,19 @@ defmodule Pow.Store.Backend.MnesiaCacheTest do
       assert :rpc.call(node_a, :mnesia, :system_info, [:running_db_nodes]) == [node_b, node_a]
     end
 
+    test "when init fails" do
+      :mnesia.kill()
+
+      # Start Mnesia on node a uninitialized
+      node_a = spawn_node("a")
+      :ok = :rpc.call(node_a, :mnesia, :start, [])
+
+      # Join cluster with node b
+      node_b = spawn_node("b")
+      config = @default_config ++ [extra_db_nodes: {Node, :list, []}]
+      {:error, {{:aborted, {:no_exists, {Pow.Store.Backend.MnesiaCache, :cstruct}}}, _}} = :rpc.call(node_b, Supervisor, :start_child, [Pow.Supervisor, {MnesiaCache, config}])
+    end
+
     test "handles `extra_db_nodes: {module, function, arguments}`" do
       :mnesia.kill()
 


### PR DESCRIPTION
The MnesiaCache init error handling was not tested properly. This ensures we test it, and it's handled properly.