### PR TITLE
Add invalid token message to PowEmailConfirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 * [`Pow.Store.Backend.MnesiaCache`] Now accepts `extra_db_nodes: {module, function, arguments}` to fetch nodes when MnesiaCache starts up
+* [`PowEmailConfirmation.Phoenix.Messages`] Added `PowEmailConfirmation.Phoenix.Messages.invalid_token/1`
 
 ### Bug fixes
 

--- a/lib/extensions/email_confirmation/phoenix/controllers/confirmation_controller.ex
+++ b/lib/extensions/email_confirmation/phoenix/controllers/confirmation_controller.ex
@@ -33,7 +33,7 @@ defmodule PowEmailConfirmation.Phoenix.ConfirmationController do
     case Plug.load_user_by_token(conn, token) do
       {:error, conn} ->
         conn
-        |> put_flash(:error, extension_messages(conn).email_confirmation_failed(conn))
+        |> put_flash(:error, extension_messages(conn).invalid_token(conn))
         |> redirect(to: redirect_to(conn))
         |> halt()
 

--- a/lib/extensions/email_confirmation/phoenix/messages.ex
+++ b/lib/extensions/email_confirmation/phoenix/messages.ex
@@ -15,6 +15,12 @@ defmodule PowEmailConfirmation.Phoenix.Messages do
   """
   def email_confirmation_failed(_conn), do: "The email address couldn't be confirmed."
 
+
+  @doc """
+  Flash message to show when a invalid confirmation link is used.
+  """
+  def invalid_token(_conn), do: "The confirmation token is invalid or has expired."
+
   @doc """
   Flash message to show when user is signs in or registers but e-mail is yet
   to be confirmed.

--- a/test/extensions/email_confirmation/phoenix/controllers/confirmation_controller_test.exs
+++ b/test/extensions/email_confirmation/phoenix/controllers/confirmation_controller_test.exs
@@ -47,7 +47,7 @@ defmodule PowEmailConfirmation.Phoenix.ConfirmationControllerTest do
       conn = get(conn, Routes.pow_email_confirmation_confirmation_path(conn, :show, sign_token("invalid")))
 
       assert redirected_to(conn) == Routes.pow_session_path(conn, :new)
-      assert get_flash(conn, :error) == "The email address couldn't be confirmed."
+      assert get_flash(conn, :error) == "The confirmation token is invalid or has expired."
 
       refute Process.get({:user, 1})
     end
@@ -56,7 +56,7 @@ defmodule PowEmailConfirmation.Phoenix.ConfirmationControllerTest do
       conn = get(conn, Routes.pow_email_confirmation_confirmation_path(conn, :show, "valid"))
 
       assert redirected_to(conn) == Routes.pow_session_path(conn, :new)
-      assert get_flash(conn, :error) == "The email address couldn't be confirmed."
+      assert get_flash(conn, :error) == "The confirmation token is invalid or has expired."
 
       refute Process.get({:user, 1})
     end


### PR DESCRIPTION
This resolves https://github.com/danschultzer/pow/issues/583, by adding an explicit message for when the token is invalid or doesn't exist.