### PR TITLE
Add IO warning for high ttl values in CredentialsCache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [`Pow.Store.Backend.MnesiaCache`] Now accepts `extra_db_nodes: {module, function, arguments}` to fetch nodes when MnesiaCache starts up
 * [`PowEmailConfirmation.Phoenix.Messages`] Added `PowEmailConfirmation.Phoenix.Messages.invalid_token/1`
+* [`Pow.Store.CredentialsCache`] Now outputs an IO warning when a `:ttl` longer than 30 minutes is used
 
 ### Bug fixes
 

--- a/test/pow/store/credentials_cache_test.exs
+++ b/test/pow/store/credentials_cache_test.exs
@@ -2,6 +2,7 @@ defmodule Pow.Store.CredentialsCacheTest do
   use ExUnit.Case
   doctest Pow.Store.CredentialsCache
 
+  alias ExUnit.CaptureIO
   alias Pow.Store.{Backend.EtsCache, CredentialsCache}
   alias Pow.Test.Ecto.Users.{User, UsernameUser}
   alias Pow.Test.EtsCacheMock
@@ -58,6 +59,14 @@ defmodule Pow.Store.CredentialsCacheTest do
     assert ets.get(@backend_config, "key_1") == :not_found
     assert ets.get(@backend_config, [User, :user, 1]) == %{user_1 | email: :updated}
     assert ets.get(@backend_config, [User, :user, 1, :session, "key_1"]) == :not_found
+  end
+
+  test "when using unsafe session ttl" do
+    config = @config ++ [ttl: :timer.minutes(30) + 1]
+
+    assert CaptureIO.capture_io(:stderr, fn ->
+      CredentialsCache.put(config, "key_1", {%User{id: 1}, a: 1})
+    end) =~ "warning: `:ttl` value for sessions should be no longer than 30 minutes to prevent session hijack, please consider lowering the value"
   end
 
   test "get/2 when reload: true without :pow_config" do


### PR DESCRIPTION
Resolves #475 by printing IO warning whenever the `:ttl` is longer than 30 minutes per OWASP: https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#session-expiration