### PR TITLE
Allow halt from before process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Now supports Phoenix 1.6.x, and `phoenix_html` 3.x.x.
 ### Enhancements
 
 * [`Pow.Ecto.Schema.Fields`] The `:password_hash`, `:current_password`, and `:password` fields now have `redact: true` option set
+* [`Pow.Phoenix.Controller`] `Pow.Phoenix.Controller.action/3` now properly handles `{:halt, conn}` returned in the `before_process` callback
 
 ### Bug fixes
 

--- a/lib/pow/phoenix/controllers/controller.ex
+++ b/lib/pow/phoenix/controllers/controller.ex
@@ -80,7 +80,6 @@ defmodule Pow.Phoenix.Controller do
   end
 
   defp process_action({:halt, conn}, _controller, _action, _params), do: {:halt, conn}
-
   defp process_action(conn, controller, action, params) do
     apply(controller, String.to_atom("process_#{action}"), [conn, params])
   end

--- a/lib/pow/phoenix/controllers/controller.ex
+++ b/lib/pow/phoenix/controllers/controller.ex
@@ -68,8 +68,8 @@ defmodule Pow.Phoenix.Controller do
   """
   @spec action(atom(), Conn.t(), map()) :: Conn.t()
   def action(controller, %{private: private} = conn, params) do
-    action    = private.phoenix_action
-    config    = Plug.fetch_config(conn)
+    action = private.phoenix_action
+    config = Plug.fetch_config(conn)
     callbacks = Config.get(config, :controller_callbacks)
 
     conn
@@ -78,6 +78,8 @@ defmodule Pow.Phoenix.Controller do
     |> maybe_callback(callbacks, :before_respond, controller, action, config)
     |> respond_action(controller, action)
   end
+
+  defp process_action({:halt, conn}, _controller, _action, _params), do: {:halt, conn}
 
   defp process_action(conn, controller, action, params) do
     apply(controller, String.to_atom("process_#{action}"), [conn, params])
@@ -88,6 +90,8 @@ defmodule Pow.Phoenix.Controller do
     apply(controller, String.to_atom("respond_#{action}"), [results])
   end
 
+  defp maybe_callback({:halt, conn}, _callbacks, _hook, _controller, _action, _config),
+    do: {:halt, conn}
   defp maybe_callback(results, nil, _hook, _controller, _action, _config), do: results
   defp maybe_callback(results, callbacks, hook, controller, action, config) do
     apply(callbacks, hook, [controller, action, results, config])

--- a/test/pow/phoenix/controllers/controller_test.exs
+++ b/test/pow/phoenix/controllers/controller_test.exs
@@ -23,34 +23,16 @@ defmodule Pow.Phoenix.ControllerTest do
       assert html =~ ":web_module new session"
     end
 
-    test "{:halt, conn} from before_respond", %{conn: conn} do
-      defmodule HaltsBeforeRespond do
-        use Pow.Extension.Phoenix.ControllerCallbacks.Base
-
-        def before_respond(SessionController, :new, {:ok, _changeset, conn}, _config) do
-          {:halt, conn |> Conn.put_private(:test_info, "HALTED!")}
-        end
-      end
-
-      conn =
-        conn
-        |> Conn.put_private(:pow_config, user: User, controller_callbacks: HaltsBeforeRespond)
-        |> Conn.put_private(:phoenix_action, :new)
-
-      conn = Controller.action(SessionController, conn, %{})
-      assert conn.private[:test_info] == "HALTED!"
-    end
-
-    test "{:halt, conn} from before_process", %{conn: conn} do
+    test "with halt {:halt, conn} from before_process", %{conn: conn} do
       defmodule HaltsBeforeProcess do
         use Pow.Extension.Phoenix.ControllerCallbacks.Base
 
         def before_process(SessionController, :new, conn, _config) do
-          {:halt, conn |> Conn.put_private(:test_info, "HALTED!")}
+          {:halt, Conn.halt(conn)}
         end
 
         def before_respond(SessionController, :new, _, _config) do
-          raise "Should not be called."
+          raise "Should not be called"
         end
       end
 
@@ -60,7 +42,27 @@ defmodule Pow.Phoenix.ControllerTest do
         |> Conn.put_private(:phoenix_action, :new)
 
       conn = Controller.action(SessionController, conn, %{})
-      assert conn.private[:test_info] == "HALTED!"
+
+      assert conn.halted
+    end
+
+    test "{:halt, conn} from before_respond", %{conn: conn} do
+      defmodule HaltsBeforeRespond do
+        use Pow.Extension.Phoenix.ControllerCallbacks.Base
+
+        def before_respond(SessionController, :new, {:ok, _changeset, conn}, _config) do
+          {:halt, Conn.halt(conn)}
+        end
+      end
+
+      conn =
+        conn
+        |> Conn.put_private(:pow_config, user: User, controller_callbacks: HaltsBeforeRespond)
+        |> Conn.put_private(:phoenix_action, :new)
+
+      conn = Controller.action(SessionController, conn, %{})
+
+      assert conn.halted
     end
   end
 end

--- a/test/pow/phoenix/controllers/controller_test.exs
+++ b/test/pow/phoenix/controllers/controller_test.exs
@@ -42,10 +42,10 @@ defmodule Pow.Phoenix.ControllerTest do
     end
 
     test "{:halt, conn} from before_process", %{conn: conn} do
-      defmodule HaltsBeforeRespond do
+      defmodule HaltsBeforeProcess do
         use Pow.Extension.Phoenix.ControllerCallbacks.Base
 
-        def before_process(SessionController, :new, {:ok, _changeset, conn}, _config) do
+        def before_process(SessionController, :new, conn, _config) do
           {:halt, conn |> Conn.put_private(:test_info, "HALTED!")}
         end
 
@@ -56,7 +56,7 @@ defmodule Pow.Phoenix.ControllerTest do
 
       conn =
         conn
-        |> Conn.put_private(:pow_config, user: User, controller_callbacks: HaltsBeforeRespond)
+        |> Conn.put_private(:pow_config, user: User, controller_callbacks: HaltsBeforeProcess)
         |> Conn.put_private(:phoenix_action, :new)
 
       conn = Controller.action(SessionController, conn, %{})


### PR DESCRIPTION
Fixes #630.

To recap: This allows extensions to terminate the action processing from `before_process` *as well as* `before_respond`, where it previously just worked from `before_respond`.

Feel free to make edits as you see fit. Thanks for the great library!