### PR TITLE
Redact Password Fields?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v1.0.25 (TBA)
 
+### Enhancements
+
+* [`Pow.Ecto.Schema.Fields`] The `:password_hash`, `:current_password`, and `:password` fields now have `redact: true` option set
+
 ### Bug fixes
 
 * [`Pow.Operations`] `Pow.Operations.fetch_primary_key_values/2` now ensures that module exists and is loaded before deriving primary keys

--- a/lib/pow/ecto/schema/fields.ex
+++ b/lib/pow/ecto/schema/fields.ex
@@ -5,9 +5,9 @@ defmodule Pow.Ecto.Schema.Fields do
   alias Pow.{Config, Ecto.Schema}
 
   @attrs [
-    {:password_hash, :string},
-    {:current_password, :string, virtual: true},
-    {:password, :string, virtual: true}
+    {:password_hash, :string, redact: true},
+    {:current_password, :string, virtual: true, redact: true},
+    {:password, :string, virtual: true, redact: true}
   ]
 
   @doc """

--- a/test/extensions/email_confirmation/ecto/schema_test.exs
+++ b/test/extensions/email_confirmation/ecto/schema_test.exs
@@ -15,6 +15,8 @@ defmodule PowEmailConfirmation.Ecto.SchemaTest do
     use Pow.Extension.Ecto.Schema,
       extensions: [PowEmailConfirmation]
 
+    @ecto_derive_inspect_for_redacted_fields false
+
     schema "users" do
       pow_user_fields()
 

--- a/test/extensions/invitation/ecto/schema_test.exs
+++ b/test/extensions/invitation/ecto/schema_test.exs
@@ -13,6 +13,8 @@ defmodule PowInvitation.Ecto.SchemaTest do
     use Pow.Extension.Ecto.Schema,
       extensions: [PowInvitation]
 
+    @ecto_derive_inspect_for_redacted_fields false
+
     schema "users" do
       field :organization_id, :integer
       field :invitation_accepted_ip, :string

--- a/test/extensions/reset_password/ecto/schema_test.exs
+++ b/test/extensions/reset_password/ecto/schema_test.exs
@@ -12,6 +12,8 @@ defmodule PowResetPassword.Ecto.SchemaTest do
     use Pow.Extension.Ecto.Schema,
       extensions: [PowResetPassword]
 
+    @ecto_derive_inspect_for_redacted_fields false
+
     schema "users" do
       field :password_reset_at, :utc_datetime
 

--- a/test/pow/ecto/context_test.exs
+++ b/test/pow/ecto/context_test.exs
@@ -7,6 +7,8 @@ defmodule Pow.Ecto.ContextTest do
     use Ecto.Schema
     use Pow.Ecto.Schema, password_hash_methods: {&__MODULE__.send_hash_password/1, &__MODULE__.send_verify_password/2}
 
+    @ecto_derive_inspect_for_redacted_fields false
+
     alias Pow.Ecto.Schema.Password
 
     schema "users" do

--- a/test/pow/ecto/schema_test.exs
+++ b/test/pow/ecto/schema_test.exs
@@ -26,6 +26,8 @@ defmodule Pow.Ecto.SchemaTest do
     use Ecto.Schema
     use Pow.Ecto.Schema
 
+    @ecto_derive_inspect_for_redacted_fields false
+
     schema "users" do
       field :password_hash, :string, source: :encrypted_password
 
@@ -46,6 +48,8 @@ defmodule Pow.Ecto.SchemaTest do
     @moduledoc false
     use Ecto.Schema
     use Pow.Ecto.Schema
+
+    @ecto_derive_inspect_for_redacted_fields false
 
     @pow_assocs {:has_many, :users, __MODULE__}
 
@@ -108,9 +112,9 @@ defmodule Pow.Ecto.SchemaTest do
       Please define the following field(s) in the schema for Pow.Ecto.SchemaTest.MissingFieldsUser:
 
       field :email, :string, [null: false]
-      field :password_hash, :string
-      field :current_password, :string, [virtual: true]
-      field :password, :string, [virtual: true]
+      field :password_hash, :string, [redact: true]
+      field :current_password, :string, [virtual: true, redact: true]
+      field :password, :string, [virtual: true, redact: true]
       """
   end
 
@@ -122,9 +126,9 @@ defmodule Pow.Ecto.SchemaTest do
 
         schema "users" do
           field :email, :utc_datetime
-          field :password_hash, :string
-          field :current_password, :string, virtual: true
-          field :password, :string, virtual: true
+          field :password_hash, :string, redact: true
+          field :current_password, :string, virtual: true, redact: true
+          field :password, :string, virtual: true, redact: true
 
           timestamps()
         end
@@ -155,11 +159,13 @@ defmodule Pow.Ecto.SchemaTest do
         use Ecto.Schema
         use Pow.Ecto.Schema
 
+        @ecto_derive_inspect_for_redacted_fields false
+
         schema "users" do
           field :email, CustomType
-          field :password_hash, :string
-          field :current_password, :string, virtual: true
-          field :password, :string, virtual: true
+          field :password_hash, :string, redact: true
+          field :current_password, :string, virtual: true, redact: true
+          field :password, :string, virtual: true, redact: true
 
           timestamps()
         end

--- a/test/pow/extension/ecto/schema_test.exs
+++ b/test/pow/extension/ecto/schema_test.exs
@@ -59,6 +59,8 @@ defmodule Pow.Extension.Ecto.SchemaTest do
     use Pow.Extension.Ecto.Schema,
       extensions: [Pow.Extension.Ecto.SchemaTest.ExtensionMock]
 
+    @ecto_derive_inspect_for_redacted_fields false
+
     schema "users" do
       pow_user_fields()
 
@@ -80,6 +82,8 @@ defmodule Pow.Extension.Ecto.SchemaTest do
           user_id_field: :username
         use Pow.Extension.Ecto.Schema,
           extensions: [Pow.Extension.Ecto.SchemaTest.ExtensionMock]
+
+        @ecto_derive_inspect_for_redacted_fields false
 
         schema "users" do
           pow_user_fields()


### PR DESCRIPTION
From the [Ecto Documentation](https://hexdocs.pm/ecto/Ecto.Schema.html#module-redacting-fields):

> A field marked with redact: true will display a value of **redacted** when inspected in changes inside a Ecto.Changeset and be excluded from inspect on the schema unless the schema module is tagged with the option @ecto_derive_inspect_for_redacted_fields false.

Does it make sense for Pow to be redacting password fields?

Thanks!