### PR TITLE
Remove IO warning on ttl > 30 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Removed
+
+* [`Pow.Store.CredentialsCache`] Remove IO warning when a `:ttl` longer than 30 minutes is used.
+
 ## v1.0.24 (2021-05-27)
 
 ### Enhancements

--- a/lib/pow/store/credentials_cache.ex
+++ b/lib/pow/store/credentials_cache.ex
@@ -14,7 +14,6 @@ defmodule Pow.Store.CredentialsCache do
 
   The `:ttl` should be maximum 30 minutes per
   [OWASP recommendations](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#session-expiration).
-  A warning will be output for any sessions created with a longer TTL.
 
   ## Custom credentials cache module
 
@@ -46,14 +45,11 @@ defmodule Pow.Store.CredentialsCache do
       from the context. Defaults false.
 
   """
-  alias Pow.{Config, Operations, Store.Base}
+  alias Pow.{Operations, Store.Base}
 
   @callback users(Base.config(), module()) :: [any()]
   @callback sessions(Base.config(), map()) :: [binary()]
   @callback put(Base.config(), binary(), {map(), list()}) :: :ok
-
-  # Per https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#session-expiration
-  @recommended_max_idle_timeout :timer.minutes(30)
 
   use Base,
     ttl: :timer.minutes(30),
@@ -121,20 +117,8 @@ defmodule Pow.Store.CredentialsCache do
     backend_config =
       config
       |> backend_config()
-      |> warn_maximum_timeout()
 
     Base.put(config, backend_config, records)
-  end
-
-  defp warn_maximum_timeout(config) do
-    if Config.get(config, :ttl, 0) > @recommended_max_idle_timeout do
-      IO.warn(
-        """
-        warning: `:ttl` value for sessions should be no longer than #{round(@recommended_max_idle_timeout / 1_000 / 60)} minutes to prevent session hijack, please consider lowering the value
-        """)
-    end
-
-    config
   end
 
   @doc """

--- a/test/pow/store/credentials_cache_test.exs
+++ b/test/pow/store/credentials_cache_test.exs
@@ -2,7 +2,6 @@ defmodule Pow.Store.CredentialsCacheTest do
   use ExUnit.Case
   doctest Pow.Store.CredentialsCache
 
-  alias ExUnit.CaptureIO
   alias Pow.Store.{Backend.EtsCache, CredentialsCache}
   alias Pow.Test.Ecto.Users.{User, UsernameUser}
   alias Pow.Test.EtsCacheMock
@@ -59,14 +58,6 @@ defmodule Pow.Store.CredentialsCacheTest do
     assert ets.get(@backend_config, "key_1") == :not_found
     assert ets.get(@backend_config, [User, :user, 1]) == %{user_1 | email: :updated}
     assert ets.get(@backend_config, [User, :user, 1, :session, "key_1"]) == :not_found
-  end
-
-  test "when using unsafe session ttl" do
-    config = @config ++ [ttl: :timer.minutes(30) + 1]
-
-    assert CaptureIO.capture_io(:stderr, fn ->
-      CredentialsCache.put(config, "key_1", {%User{id: 1}, a: 1})
-    end) =~ "warning: `:ttl` value for sessions should be no longer than 30 minutes to prevent session hijack, please consider lowering the value"
   end
 
   test "get/2 when reload: true without :pow_config" do


### PR DESCRIPTION
I wish to request the removal of a warning via direct IO for session durations greater than 30 minutes.  The IO warning, which bypasses logger abstractions, will impact production logging for use cases that are valid to have a longer TTL.

In principle, I agree with helping developers fall into the pit of success.  In this case, I would ask that safe defaults and documentation would suffice and the use of `IO.warn` be reconsidered when contributors wish to alert engineers especially in instances where it is not a critical issue or threat vector.

A longer session TTL does relatively increase the chance of a successful session hijack attempt but there are a great many use cases whereby users will be interacting with an application without making active HTTP requests for longer than 30 minutes e.g. video sites, direct web rtc based interaction etc.

Thanks

