### PR TITLE
Ensure that the module exists and is loaded before accessing primary keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.0.25 (TBA)
+
+### Bug fixes
+
+* [`Pow.Operations`] `Pow.Operations.fetch_primary_key_values/2` now ensures that module exists and is loaded before deriving primary keys
+
 ## v1.0.24 (2021-05-27)
 
 ### Enhancements

--- a/test/pow/operations_test.exs
+++ b/test/pow/operations_test.exs
@@ -55,5 +55,9 @@ defmodule Pow.OperationsTest do
       assert Operations.fetch_primary_key_values(%CompositePrimaryFieldsUser{some_id: 1, another_id: 2}, @config) == {:ok, some_id: 1, another_id: 2}
       assert Operations.fetch_primary_key_values(%NonEctoUser{id: 1}, @config) == {:ok, id: 1}
     end
+
+    test "requires module exists" do
+      assert Operations.fetch_primary_key_values(%{__struct__: Invalid}, @config) == {:error, "The module Invalid does not exist"}
+    end
   end
 end


### PR DESCRIPTION
When using other primary keys that `:id` restarting nodes at times made it so the module was not loaded before attempting to fetch primary keys. This resolves the issue.