### PR TITLE
Remove unnecessary :timer.sleep calls

### DIFF
--- a/guides/api.md
+++ b/guides/api.md
@@ -340,20 +340,15 @@ defmodule MyAppWeb.APIAuthPlugTest do
     assert {%{private: %{api_access_token: access_token, api_renewal_token: renewal_token}}, ^user} =
         APIAuthPlug.create(conn, user, @pow_config)
 
-    :timer.sleep(100)
-
     assert {_conn, ^user} = APIAuthPlug.fetch(with_auth_header(conn, access_token), @pow_config)
     assert {%{private: %{api_access_token: renewed_access_token, api_renewal_token: renewed_renewal_token}}, ^user} =
       APIAuthPlug.renew(with_auth_header(conn, renewal_token), @pow_config)
-
-    :timer.sleep(100)
 
     assert {_conn, nil} = APIAuthPlug.fetch(with_auth_header(conn, access_token), @pow_config)
     assert {_conn, nil} = APIAuthPlug.renew(with_auth_header(conn, renewal_token), @pow_config)
     assert {_conn, ^user} = APIAuthPlug.fetch(with_auth_header(conn, renewed_access_token), @pow_config)
 
     APIAuthPlug.delete(with_auth_header(conn, renewed_access_token), @pow_config)
-    :timer.sleep(100)
 
     assert {_conn, nil} = APIAuthPlug.fetch(with_auth_header(conn, renewed_access_token), @pow_config)
     assert {_conn, nil} = APIAuthPlug.renew(with_auth_header(conn, renewed_renewal_token), @pow_config)
@@ -437,7 +432,6 @@ defmodule MyAppWeb.API.V1.SessionControllerTest do
   describe "renew/2" do
     setup %{conn: conn} do
       authed_conn = post(conn, Routes.api_v1_session_path(conn, :create, @valid_params))
-      :timer.sleep(100)
 
       {:ok, renewal_token: authed_conn.private[:api_renewal_token]}
     end
@@ -468,7 +462,6 @@ defmodule MyAppWeb.API.V1.SessionControllerTest do
   describe "delete/2" do
     setup %{conn: conn} do
       authed_conn = post(conn, Routes.api_v1_session_path(conn, :create, @valid_params))
-      :timer.sleep(100)
 
       {:ok, access_token: authed_conn.private[:api_access_token]}
     end

--- a/guides/lock_users.md
+++ b/guides/lock_users.md
@@ -407,8 +407,6 @@ defmodule MyAppWeb.ResetPasswordControllerTest do
       |> Pow.Plug.fetch_config()
       |> Pow.Config.get(:cache_store_backend, Pow.Store.Backend.EtsCache)
 
-    :timer.sleep(100)
-
     [backend: backend]
     |> ResetTokenCache.all([:_])
     |> Enum.filter(fn {_key, %{id: id}} -> id == user.id end)

--- a/test/pow/plug/session_test.exs
+++ b/test/pow/plug/session_test.exs
@@ -415,8 +415,6 @@ defmodule Pow.Plug.SessionTest do
       timestamp  = :os.system_time(:millisecond)
       session_id = store_in_cache("credentials_cache_test", {@user, inserted_at: timestamp}, [])
 
-      :timer.sleep(100)
-
       conn =
         conn
         |> Conn.fetch_session()

--- a/test/pow/store/base_test.exs
+++ b/test/pow/store/base_test.exs
@@ -32,15 +32,13 @@ defmodule Pow.Store.BaseTest do
 
   test "preset config can be overridden" do
     default_config  = []
-    override_config = [ttl: 100, namespace: "overridden_namespace"]
+    override_config = [ttl: 50, namespace: "overridden_namespace"]
 
     assert BaseMock.get(default_config, :test) == :not_found
     assert BaseMock.get(override_config, :test) == :not_found
 
     BaseMock.put(default_config, :test, :value)
     BaseMock.put(override_config, :test, :value)
-    :timer.sleep(50)
-
     assert BaseMock.get(default_config, :test) == :value
     assert BaseMock.get(override_config, :test) == :value
     :timer.sleep(50)

--- a/test/pow/store/credentials_cache_test.exs
+++ b/test/pow/store/credentials_cache_test.exs
@@ -201,11 +201,8 @@ defmodule Pow.Store.CredentialsCacheTest do
       user_1 = %User{id: 1}
       config = [backend: EtsCache]
 
-      CredentialsCache.put(config ++ [ttl: 150], "key_1", {user_1, a: 1})
-      :timer.sleep(50)
-      CredentialsCache.put(config ++ [ttl: 200], "key_2", {user_1, a: 2})
-      :timer.sleep(50)
-
+      CredentialsCache.put(config ++ [ttl: 50], "key_1", {user_1, a: 1})
+      CredentialsCache.put(config ++ [ttl: 100], "key_2", {user_1, a: 2})
       assert CredentialsCache.get(config, "key_1") == {user_1, a: 1}
       assert CredentialsCache.get(config, "key_2") == {user_1, a: 2}
       assert CredentialsCache.sessions(config, user_1) == ["key_1", "key_2"]


### PR DESCRIPTION
Follow up to #650 removing all unnecessary `:timer.sleep/1` calls.