### PR TITLE
Add auto initialization of mnesia cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v1.0.26 (TBA)
 
+### Enhancemnets
+
+* [`Pow.Store.Backend.MnesiaCache.Unsplit`] The unsplit module will now initialize the Mnesia cluster when nodes are connected lazily by resetting the Mnesia schema
+
 ### Bug fixes
 
 * [`Pow.Store.Backend.MnesiaCache`] Now properly handles Mnesia application start errors


### PR DESCRIPTION
Resolves #653 

I realized that in most cases you would want the Mnesia cache to just automatically connect whenever a node is discovered. This is very useful for a libcluster setup where the nodes list is not immediately available.

~~If possible it would be best to use the same healing strategy as with network partitioning. I'll see if that's possible or otherwise this hard reset should be good enough for most.~~

It seems to be impossible to heal a cluster that has not previously been connected as per https://www.erlang.org/doc/apps/mnesia/mnesia_chap5#more-about-schema-management:

> The function call mnesia:del_table_copy(schema, mynode@host) deletes node mynode@host from the Mnesia system. The call fails if Mnesia is running on mynode@host. The other Mnesia nodes never try to connect to that node again. Notice that if there is a disc resident schema on node mynode@host, the entire Mnesia directory is to be deleted. This is done with the function mnesia:delete_schema/1. If Mnesia is started again on node mynode@host and the directory has not been cleared, the behavior of Mnesia is undefined.