### PR TITLE
Add support for Ecto v3.8.0

### DIFF
--- a/guides/user_roles.md
+++ b/guides/user_roles.md
@@ -13,7 +13,7 @@ defmodule MyApp.Users.User do
   use Pow.Ecto.Schema
 
   schema "users" do
-    field :role, :string, null: false, default: "user"
+    field :role, :string, default: "user"
 
     pow_user_fields()
 

--- a/lib/pow/ecto/schema.ex
+++ b/lib/pow/ecto/schema.ex
@@ -105,7 +105,7 @@ defmodule Pow.Ecto.Schema do
         use Pow.Ecto.Schema, user_id_field: :email
 
         schema "users" do
-          field :email,            :string, null: false
+          field :email,            :string
           field :password_hash,    :string
           field :current_password, :string, virtual: true
           field :password,         :string, virtual: true

--- a/lib/pow/ecto/schema/fields.ex
+++ b/lib/pow/ecto/schema/fields.ex
@@ -17,7 +17,7 @@ defmodule Pow.Ecto.Schema.Fields do
   def attrs(config) do
     user_id_field = Schema.user_id_field(config)
 
-    [{user_id_field, :string, []}] ++ @attrs
+    [{user_id_field, :string}] ++ @attrs
   end
 
   @doc """

--- a/lib/pow/ecto/schema/fields.ex
+++ b/lib/pow/ecto/schema/fields.ex
@@ -17,7 +17,7 @@ defmodule Pow.Ecto.Schema.Fields do
   def attrs(config) do
     user_id_field = Schema.user_id_field(config)
 
-    [{user_id_field, :string, null: false}] ++ @attrs
+    [{user_id_field, :string}] ++ @attrs
   end
 
   @doc """

--- a/lib/pow/ecto/schema/fields.ex
+++ b/lib/pow/ecto/schema/fields.ex
@@ -17,7 +17,7 @@ defmodule Pow.Ecto.Schema.Fields do
   def attrs(config) do
     user_id_field = Schema.user_id_field(config)
 
-    [{user_id_field, :string}] ++ @attrs
+    [{user_id_field, :string, []}] ++ @attrs
   end
 
   @doc """

--- a/test/pow/ecto/schema_test.exs
+++ b/test/pow/ecto/schema_test.exs
@@ -111,7 +111,7 @@ defmodule Pow.Ecto.SchemaTest do
       """
       Please define the following field(s) in the schema for Pow.Ecto.SchemaTest.MissingFieldsUser:
 
-      field :email, :string, [null: false]
+      field :email, :string
       field :password_hash, :string, [redact: true]
       field :current_password, :string, [virtual: true, redact: true]
       field :password, :string, [virtual: true, redact: true]
@@ -137,7 +137,7 @@ defmodule Pow.Ecto.SchemaTest do
       """
       Please define the following field(s) in the schema for Pow.Ecto.SchemaTest.InvalidFieldUser:
 
-      field :email, :string, [null: false]
+      field :email, :string
       """
   end
 


### PR DESCRIPTION
Ecto v3.8.0 throws an error when it encounters unsupported options.
It turns out that :null isn't a valid field option.