### PR TITLE
Merge `:generators` options with default options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.0.28 (TBA)
+
+### Enhancements
+
+* [`Mix.Pow`] `Mix.Pow.parse_options/3` now merges option defaults with `:otp_app, :generators` configuration
+
 ## v1.0.27 (2022-04-27)
 
 Now supports `ecto_sql` 3.8.x and requires Elixir 1.11+.

--- a/lib/mix/pow.ex
+++ b/lib/mix/pow.ex
@@ -73,15 +73,22 @@ defmodule Mix.Pow do
   """
   @spec parse_options(OptionParser.argv(), Keyword.t(), Keyword.t()) :: {map(), OptionParser.argv(), OptionParser.errors()}
   def parse_options(args, switches, default_opts) do
+    generator_opts = parse_context_app(Application.get_env(otp_app(), :generators, []))
+    default_opts   = Keyword.merge(default_opts, generator_opts)
+
     {opts, parsed, invalid} = OptionParser.parse(args, switches: switches)
     default_opts            = to_map(default_opts)
-    opts                    = to_map(opts)
-    config                  =
-      default_opts
-      |> Map.merge(opts)
-      |> context_app_to_atom()
+    opts                    = context_app_to_atom(to_map(opts))
+    config                  = Map.merge(default_opts, opts)
 
     {config, parsed, invalid}
+  end
+
+  defp parse_context_app(options) do
+    case options[:context_app] do
+      {context_app, _path} -> Keyword.put(options, :context_app, context_app)
+      _context_app         -> options
+    end
   end
 
   defp to_map(keyword) do

--- a/test/mix/tasks/ecto/pow.ecto.gen.migration_test.exs
+++ b/test/mix/tasks/ecto/pow.ecto.gen.migration_test.exs
@@ -42,13 +42,31 @@ defmodule Mix.Tasks.Pow.Ecto.Gen.MigrationTest do
     end)
   end
 
-  test "generates with binary_id" do
+  test "generates with `:binary_id`" do
     options = @options ++ ~w(--binary-id)
     File.cd!(@tmp_path, fn ->
       Migration.run(options)
 
       assert [migration_file] = File.ls!(@migrations_path)
       assert String.match?(migration_file, ~r/^\d{14}_create_users\.exs$/)
+
+      file = @migrations_path |> Path.join(migration_file) |> File.read!()
+
+      assert file =~ "create table(:users, primary_key: false)"
+      assert file =~ "add :id, :binary_id, primary_key: true"
+    end)
+  end
+
+  test "generates with `:generators` config" do
+    Application.put_env(:pow, :generators, binary_id: true)
+    on_exit(fn ->
+      Application.delete_env(:pow, :generators)
+    end)
+
+    File.cd!(@tmp_path, fn ->
+      Migration.run(@options)
+
+      assert [migration_file] = File.ls!(@migrations_path)
 
       file = @migrations_path |> Path.join(migration_file) |> File.read!()
 

--- a/test/mix/tasks/ecto/pow.ecto.gen.schema_test.exs
+++ b/test/mix/tasks/ecto/pow.ecto.gen.schema_test.exs
@@ -24,8 +24,8 @@ defmodule Mix.Tasks.Pow.Ecto.Gen.SchemaTest do
     end)
   end
 
-  test "generates with `:binary_id`" do
-    options = ~w(--binary-id)
+  test "generates with `:binary_id` and `:context_app`" do
+    options = ~w(--binary-id --context-app pow)
 
     File.cd!(@tmp_path, fn ->
       Schema.run(options)
@@ -45,6 +45,25 @@ defmodule Mix.Tasks.Pow.Ecto.Gen.SchemaTest do
       assert_raise Mix.Error, "schema file can't be created, there is already a schema file in lib/pow/users/user.ex.", fn ->
         Schema.run([])
       end
+    end)
+  end
+
+  test "generates with `:generators` config" do
+    Application.put_env(:pow, :generators, binary_id: true, context_app: {:my_app, "my_app"})
+    on_exit(fn ->
+      Application.delete_env(:pow, :generators)
+    end)
+
+    file = Path.join(["my_app", "lib", "my_app", "users", "user.ex"])
+
+    File.cd!(@tmp_path, fn ->
+      Schema.run([])
+
+      assert File.exists?(file)
+      file = File.read!(file)
+
+      assert file =~ "@primary_key {:id, :binary_id, autogenerate: true}"
+      assert file =~ "@foreign_key_type :binary_id"
     end)
   end
 end

--- a/test/mix/tasks/phoenix/pow.phoenix.gen.templates_test.exs
+++ b/test/mix/tasks/phoenix/pow.phoenix.gen.templates_test.exs
@@ -43,6 +43,8 @@ defmodule Mix.Tasks.Pow.Phoenix.Gen.TemplatesTest do
 
       assert_received {:mix_shell, :info, [@expected_msg <> msg]}
       assert msg =~ "config :pow, :pow,"
+      assert msg =~ "user: Pow.Users.User,"
+      assert msg =~ "repo: Pow.Repo,"
       assert msg =~ "web_module: PowWeb"
     end)
   end
@@ -62,6 +64,35 @@ defmodule Mix.Tasks.Pow.Phoenix.Gen.TemplatesTest do
         refute_received {:mix_shell, :info, [@expected_msg <> _msg]}
       end)
     end
+  end
+
+  test "generates with `:context_app`" do
+    options = ~w(--context-app my_app)
+
+    File.cd!(@tmp_path, fn ->
+      Templates.run(options)
+
+      assert_received {:mix_shell, :info, [@expected_msg <> msg]}
+      assert msg =~ "config :pow, :pow,"
+      assert msg =~ "user: MyApp.Users.User,"
+      assert msg =~ "repo: MyApp.Repo,"
+    end)
+  end
+
+  test "generates with `:generators` config" do
+    Application.put_env(:pow, :generators, context_app: {:my_app, "my_app"})
+    on_exit(fn ->
+      Application.delete_env(:pow, :generators)
+    end)
+
+    File.cd!(@tmp_path, fn ->
+      Templates.run([])
+
+      assert_received {:mix_shell, :info, [@expected_msg <> msg]}
+      assert msg =~ "config :pow, :pow,"
+      assert msg =~ "user: MyApp.Users.User,"
+      assert msg =~ "repo: MyApp.Repo,"
+    end)
   end
 
   defp ls(path), do: path |> File.ls!() |> Enum.sort()

--- a/test/mix/tasks/phoenix/pow.phoenix.install_test.exs
+++ b/test/mix/tasks/phoenix/pow.phoenix.install_test.exs
@@ -73,6 +73,20 @@ defmodule Mix.Tasks.Pow.Phoenix.InstallTest do
     end)
   end
 
+  test "generates with `:generators` config" do
+    Application.put_env(:pow, :generators, context_app: {:my_app, "my_app"})
+    on_exit(fn ->
+      Application.delete_env(:pow, :generators)
+    end)
+
+    File.cd!(@tmp_path, fn ->
+      Install.run(@options)
+
+      assert_received {:mix_shell, :info, [@expected_msg <> msg]}
+      assert msg =~ "user: MyApp.Users.User,"
+    end)
+  end
+
   test "raises error in app with no top level phoenix dep" do
     File.cd!(@tmp_path, fn ->
       File.write!("mix.exs", """


### PR DESCRIPTION
Resolves https://github.com/danschultzer/pow/issues/502#issuecomment-1111510484

The options for the generators will now leverage `config :otp_app, :generators` configuration for defaults, so if you e.g. generate a phoenix project with binary id, it'll reuse that configuration.