### PR TITLE
Fix naming in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,9 +288,9 @@ The generated view files contain the subject lines for the emails.
 
 ## Configuration
 
-Pow is built to be modular, and easy to configure. The configuration is passed to method calls as well as plug options, and they will take priority over any environment configuration. It's ideal in case you got an umbrella app with multiple separate user domains.
+Pow is built to be modular, and easy to configure. The configuration is passed to function calls as well as plug options, and they will take priority over any environment configuration. It's ideal in case you got an umbrella app with multiple separate user domains.
 
-The easiest way to use Pow with Phoenix is to use a `:otp_app` in method calls and set the app environment configuration. It will keep a persistent fallback configuration that you configure in one place.
+The easiest way to use Pow with Phoenix is to use a `:otp_app` in function calls and set the app environment configuration. It will keep a persistent fallback configuration that you configure in one place.
 
 ### Module groups
 
@@ -298,7 +298,7 @@ Pow has three main groups of modules that each can be used individually, or in c
 
 #### Pow.Plug
 
-This group will handle the plug connection. The configuration will be assigned to `conn.private[:pow_config]` and passed through the controller to the users' context module. The Plug module has methods to authenticate, create, update, and delete users, and will generate/renew the session automatically.
+This group will handle the plug connection. The configuration will be assigned to `conn.private[:pow_config]` and passed through the controller to the users' context module. The Plug module has functions to authenticate, create, update, and delete users, and will generate/renew the session automatically.
 
 #### Pow.Ecto
 
@@ -376,7 +376,7 @@ end
 
 ### Ecto changeset
 
-The user module has a fallback `changeset/2` method. If you want to add custom validations, you can use the `pow_changeset/2` method like so:
+The user module has a fallback `changeset/2` function. If you want to add custom validations, you can use the `pow_changeset/2` function like so:
 
 ```elixir
 defmodule MyApp.Users.User do
@@ -402,7 +402,7 @@ end
 
 ### Phoenix controllers
 
-Controllers in Pow are very slim and consists of just one `Pow.Plug` method call with response methods. If you wish to change the flow of the `Pow.Phoenix.RegistrationController` and `Pow.Phoenix.SessionController`, the best way is to create your own and modify `router.ex`.
+Controllers in Pow are very slim and consists of just one `Pow.Plug` function call with response functions. If you wish to change the flow of the `Pow.Phoenix.RegistrationController` and `Pow.Phoenix.SessionController`, the best way is to create your own and modify `router.ex`.
 
 However, to make it easier to integrate extension, you can add callbacks to the controllers that do some light pre/post-processing of the request:
 
@@ -418,7 +418,7 @@ defmodule MyCustomExtension.Phoenix.ControllerCallbacks do
 end
 ```
 
-You can add methods for `before_process/4` (before the action happens) and `before_respond/4` (before parsing the results from the action).
+You can add functions for `before_process/4` (before the action happens) and `before_respond/4` (before parsing the results from the action).
 
 #### Testing with authenticated users
 
@@ -449,8 +449,8 @@ defmodule MyAppWeb.Pow.Messages do
 
   def user_not_authenticated(_conn), do: gettext("You need to sign in to see this page.")
 
-  # Message methods for extensions has to be prepended with the snake cased
-  # extension name. So the `email_has_been_sent/1` method from
+  # Message fucntions for extensions has to be prepended with the snake cased
+  # extension name. So the `email_has_been_sent/1` function from
   # `PowResetPassword` is written as `pow_reset_password_email_has_been_sent/1`
   # in your messages module.
   def pow_reset_password_email_has_been_sent(_conn), do: gettext("An email with reset instructions has been sent to you. Please check your inbox.")

--- a/guides/api.md
+++ b/guides/api.md
@@ -1,6 +1,6 @@
 # How to use Pow in an API
 
-Pow comes with plug n' play support for Phoenix as HTML web interface. API's work differently, and the developer should have full control over the flow in a proper built API. Therefore Pow encourages that you build custom controllers, and use the plug methods for API integration.
+Pow comes with plug n' play support for Phoenix as HTML web interface. API's work differently, and the developer should have full control over the flow in a proper built API. Therefore Pow encourages that you build custom controllers, and use the plug functions for API integration.
 
 To get you started, here's the first steps to build a Pow enabled API interface.
 
@@ -18,7 +18,7 @@ defmodule MyAppWeb.Router do
   use MyAppWeb, :router
 
   # # If you wish to also use Pow in your HTML frontend with session, then you
-  # # should set the `Pow.Plug.Session method here rather than in the endpoint:
+  # # should set the `Pow.Plug.Session` plug here rather than in the endpoint:
   # pipeline :browser do
   #   plug :accepts, ["html"]
   #   plug :fetch_session
@@ -307,7 +307,7 @@ That's it!
 
 You can now set up your client to connect to your API and generate session tokens. The session and renewal token should be send with the `authorization` header. When you receive a 401 error, you should renew the session with the renewal token and then try again.
 
-You can run the following curl methods to test it out:
+You can run the following curl commands to test it out:
 
 ```bash
 $ curl -X POST -d "user[email]=test@example.com&user[password]=secret1234&user[password_confirmation]=secret1234" http://localhost:4000/api/v1/registration

--- a/guides/coherence_migration.md
+++ b/guides/coherence_migration.md
@@ -6,7 +6,7 @@ First, we'll remove coherence.
 
   1. Remove `:coherence` config from `config/config.exs` (also any coherence config in `config/dev.exs`, `config/prod.exs` and `config/test.exs`)
   2. Delete `coherence_messages.ex`, `coherence_web.ex`, `coherence/redirects.ex`, `emails/coherence`, `templates/coherence`, and `views/coherence`.
-  3. Remove coherence from `user.ex`. This includes the coherence specific changeset method `def changeset(model, params, :password)`, and the `:email` field in schema.
+  3. Remove coherence from `user.ex`. This includes the coherence specific changeset function `def changeset(model, params, :password)`, and the `:email` field in schema.
   4. Remove coherence from `router.ex`. Pipeline `:public` can be removed entirely if it's only used for coherence, as well as scopes that only contains coherence routes.
   5. Remove `:coherence` from `mix.exs` and run `mix deps.unlock coherence`
 

--- a/guides/custom_controllers.md
+++ b/guides/custom_controllers.md
@@ -189,7 +189,7 @@ Remember to create the view files `WEB_PATH/views/registration_view.ex` and `WEB
 
 That's all you need to do to have custom controllers with Pow! From here on you can customize your flow.
 
-You may want to utilize some of the extensions, but since you have created a custom controller, it's highly recommended that you do not rely on any controller methods in the extensions. Instead, you should implement the logic yourself to keep your controllers as explicit as possible. This is only an example:
+You may want to utilize some of the extensions, but since you have created a custom controller, it's highly recommended that you do not rely on any controller actions in the extensions. Instead, you should implement the logic yourself to keep your controllers as explicit as possible. This is only an example:
 
 ```elixir
 defmodule MyAppWeb.SessionController do

--- a/guides/lock_users.md
+++ b/guides/lock_users.md
@@ -4,7 +4,7 @@ Locking users is trivial, and you won't need an extension for this. It can be do
 
 ## Update your schema
 
-Add a `locked_at` column to your user schema, and a `lock_changeset/1` method to lock the account:
+Add a `locked_at` column to your user schema, and a `lock_changeset/1` function to lock the account:
 
 ```elixir
 # lib/my_app/users/user.ex
@@ -216,7 +216,7 @@ defmodule MyAppWeb.ResetPasswordController do
 end
 ```
 
-To make the code simpler for us we're leveraging the methods from `PowResetPassword.Phoenix.ResetPasswordController` here.
+To make the code simpler for us we're leveraging the functions from `PowResetPassword.Phoenix.ResetPasswordController` here.
 
 Now all we got to do is to catch the route before the `pow_extension_routes/0` call:
 

--- a/guides/multitenancy.md
+++ b/guides/multitenancy.md
@@ -1,6 +1,6 @@
 # Multitenancy with Pow
 
-You can pass repo options to the methods used in `Pow.Ecto.Context` by using the `:repo_opts` configuration option. This makes it possible to pass on the prefix option used in multitenancy apps, so you can do the following:
+You can pass repo options to the functions used in `Pow.Ecto.Context` by using the `:repo_opts` configuration option. This makes it possible to pass on the prefix option used in multitenancy apps, so you can do the following:
 
 ```elixir
 config :my_app, :pow,

--- a/guides/redis_cache_store_backend.md
+++ b/guides/redis_cache_store_backend.md
@@ -113,14 +113,14 @@ defmodule MyAppWeb.Pow.RedisCache do
 
   defp current_timestamp, do: DateTime.to_unix(DateTime.utc_now(), :millisecond)
 
-  defp command_builder(key, method) do
+  defp command_builder(key, fun) do
     count = Enum.count(key)
 
     1..count
     |> Enum.map(fn i ->
       key
       |> Enum.split(i)
-      |> method.()
+      |> fun.()
     end)
     |> Enum.reduce([], &flatten/2)
   end

--- a/guides/sync_user.md
+++ b/guides/sync_user.md
@@ -76,7 +76,7 @@ end
 
 ## Update user in the credentials cache
 
-Let's say that you want to show the user `plan` on most pages. In this case, we can safely rely on the cached credentials since we don't need to know the actual value in the database. The worst case is that a different plan may be shown if you haven't ensured that all plan update actions use the below method.
+Let's say that you want to show the user `plan` on most pages. In this case, we can safely rely on the cached credentials since we don't need to know the actual value in the database. The worst case is that a different plan may be shown if you haven't ensured that all plan update actions use the below function.
 
 We can use `Pow.Plug.create/2` to call the plug and update the cached credentials.
 
@@ -136,4 +136,4 @@ As you can see in the above, the cached user credentials will be updated after a
 
 Another thing to note is that if you're using `Pow.Plug.Session`, then the session id will also be regenerated this way. This is ideal for authorization level change (what the above `plan` change action maybe).
 
-You may also update the `plan` field in a background task. In this case, you won't have access to any current session, and you would have to use the `Pow.Store.CredentialsCache.put/3` to update the credentials cache. However, since there are some caveats to this, it's instead recommended to find an alternative solution with the above methods.
+You may also update the `plan` field in a background task. In this case, you won't have access to any current session, and you would have to use the `Pow.Store.CredentialsCache.put/3` to update the credentials cache. However, since there are some caveats to this, it's instead recommended to find an alternative solution with the above functions.

--- a/guides/user_roles.md
+++ b/guides/user_roles.md
@@ -4,7 +4,7 @@ Adding user roles is very simple, and you won't need an extension for this. This
 
 ## Update your schema
 
-Add a `role` column to your user schema. In our example, we'll set the default role to `user` and add a `changeset_role/2` method that ensures the role can only be `user` or `admin`.
+Add a `role` column to your user schema. In our example, we'll set the default role to `user` and add a `changeset_role/2` function that ensures the role can only be `user` or `admin`.
 
 ```elixir
 # lib/my_app/users/user.ex
@@ -29,7 +29,7 @@ defmodule MyApp.Users.User do
 end
 ```
 
-To keep your app secure you shouldn't allow any direct calls to `changeset_role/2` with params provided by the user. Instead you should set up methods in your users context module to either create an admin user or update the role of an existing user:
+To keep your app secure you shouldn't allow any direct calls to `changeset_role/2` with params provided by the user. Instead you should set up functions in your users context module to either create an admin user or update the role of an existing user:
 
 ```elixir
 # lib/my_app/users.ex
@@ -152,7 +152,7 @@ end
 
 ## Using role permissions with layout
 
-You may wish to render certain sections in your layout for certain roles. First let's add a helper method to the users context:
+You may wish to render certain sections in your layout for certain roles. First let's add a helper function to the users context:
 
 ```elixir
 # lib/my_app/users.ex
@@ -227,7 +227,7 @@ defmodule MyApp.UsersTest do
     assert user.role == "admin"
   end
 
-  # Uncomment if you added this method to your users context
+  # Uncomment if you added this function to your users context
   # test "is_admin?/1" do
   #   refute Users.is_admin?(nil)
   #

--- a/guides/why_pow.md
+++ b/guides/why_pow.md
@@ -8,7 +8,7 @@ No global configuration!
 
 Unlike most alternative user management libraries, Pow is built to be a functional component in your app. You can have numerous separate Pow setups in the same app, e.g., a super admin backend and a regular user login.
 
-Configuration can be passed to nearly all methods in runtime or compile time.
+Configuration can be passed to nearly all functions in runtime or compile time.
 
 ## Modular
 

--- a/lib/extensions/email_confirmation/plug.ex
+++ b/lib/extensions/email_confirmation/plug.ex
@@ -1,6 +1,6 @@
 defmodule PowEmailConfirmation.Plug do
   @moduledoc """
-  Plug helper methods.
+  Plug helper functions.
   """
   alias Plug.Conn
   alias Pow.{Operations, Plug}

--- a/lib/extensions/invitation/ecto/schema.ex
+++ b/lib/extensions/invitation/ecto/schema.ex
@@ -29,7 +29,7 @@ defmodule PowInvitation.Ecto.Schema do
 
   ## Customize PowInvitation changeset
 
-  You can extract individual changeset methods to modify the changeset flow
+  You can extract individual changeset functions to modify the changeset flow
   entirely. As an example, this is how you can invite a user through email
   while using `username` as the user id field:
 
@@ -101,9 +101,9 @@ defmodule PowInvitation.Ecto.Schema do
   Invites user.
 
   It's important to note that this changeset should not include the changeset
-  method in the user schema module if `PowEmailConfirmation` has been enabled.
-  This is because the e-mail is assumed confirmed already if the user can
-  accept the invitation.
+  function in the user schema module if `PowEmailConfirmation` has been
+  enabled. This is because the e-mail is assumed confirmed already if the user
+  can accept the invitation.
 
   A unique `:invitation_token` will be generated, and `invited_by` association
   will be set. Only the user id will be set, and the persisted user won't have
@@ -152,7 +152,7 @@ defmodule PowInvitation.Ecto.Schema do
   @doc """
   Accepts an invitation.
 
-  The changeset method in user schema module is called, and
+  The changeset function in user schema module is called, and
   `:invitation_accepted_at` will be updated. The password can be set, and the
   user id updated.
   """

--- a/lib/extensions/invitation/plug.ex
+++ b/lib/extensions/invitation/plug.ex
@@ -1,6 +1,6 @@
 defmodule PowInvitation.Plug do
   @moduledoc """
-  Plug helper methods.
+  Plug helper functions.
   """
   alias Plug.Conn
   alias Pow.{Config, Plug}

--- a/lib/extensions/persistent_session/plug.ex
+++ b/lib/extensions/persistent_session/plug.ex
@@ -1,6 +1,6 @@
 defmodule PowPersistentSession.Plug do
   @moduledoc """
-  Plug helper methods.
+  Plug helper functions.
   """
   alias Plug.Conn
   alias Pow.Config

--- a/lib/extensions/persistent_session/plug/base.ex
+++ b/lib/extensions/persistent_session/plug/base.ex
@@ -4,7 +4,7 @@ defmodule PowPersistentSession.Plug.Base do
 
   Any writes to backend store or client should occur in `:before_send` callback
   as defined in `Plug.Conn`. To ensure that the callbacks are called in the
-  order they were set, a `register_before_send/2` method is used to set
+  order they were set, a `register_before_send/2` function is used to set
   callbacks instead of `Plug.Conn.register_before_send/2`.
 
   See `PowPersistentSession.Plug.Cookie` for an implementation example.

--- a/lib/extensions/persistent_session/plug/cookie.ex
+++ b/lib/extensions/persistent_session/plug/cookie.ex
@@ -183,8 +183,8 @@ defmodule PowPersistentSession.Plug.Cookie do
   `:pow_session_metadata` key in the conn.
 
   If the persistent session cache returns a `nil` value the persistent session
-  will be deleted as it means the context method could not find the associated
-  user.
+  will be deleted as it means the context function could not find the
+  associated user.
 
   The persistent session token will be decoded and verified with
   `Pow.Plug.verify_token/4`.

--- a/lib/extensions/reset_password/plug.ex
+++ b/lib/extensions/reset_password/plug.ex
@@ -1,6 +1,6 @@
 defmodule PowResetPassword.Plug do
   @moduledoc """
-  Plug helper methods.
+  Plug helper functions.
   """
   alias Plug.Conn
   alias Pow.{Config, Plug, Store.Backend.EtsCache, UUID}

--- a/lib/mix/pow/phoenix/mailer.ex
+++ b/lib/mix/pow/phoenix/mailer.ex
@@ -9,7 +9,7 @@ defmodule Mix.Pow.Phoenix.Mailer do
   """
   @spec create_view_file(atom(), binary(), atom(), binary(), [binary()]) :: :ok
   def create_view_file(module, name, web_mod, web_prefix, mails) do
-    subjects = subjects_methods(module, name, mails)
+    subjects = subject_functions(module, name, mails)
     path     = Path.join([web_prefix, "views", Macro.underscore(module), "#{name}_view.ex"])
     content  = """
     defmodule #{inspect(web_mod)}.#{inspect(module)}.#{Macro.camelize(name)}View do
@@ -44,7 +44,7 @@ defmodule Mix.Pow.Phoenix.Mailer do
 
   defp template_module(module, name), do: Module.concat([module, Phoenix, "#{Macro.camelize(name)}Template"])
 
-  defp subjects_methods(module, name, mails) do
+  defp subject_functions(module, name, mails) do
     template_module = template_module(module, name)
 
     Enum.map(mails, fn mail ->

--- a/lib/pow/config.ex
+++ b/lib/pow/config.ex
@@ -1,6 +1,6 @@
 defmodule Pow.Config do
   @moduledoc """
-  Methods to parse and modify configurations.
+  Functions to parse and modify configurations.
   """
   @type t :: Keyword.t()
   defmodule ConfigError do

--- a/lib/pow/ecto/context.ex
+++ b/lib/pow/ecto/context.ex
@@ -5,7 +5,7 @@ defmodule Pow.Ecto.Context do
   ## Usage
 
   This module will be used by pow by default. If you
-  wish to have control over context methods, you can
+  wish to have control over context functions, you can
   do configure `lib/my_project/users/users.ex`
   the following way:
 
@@ -21,7 +21,7 @@ defmodule Pow.Ecto.Context do
 
   Remember to update configuration with `users_context: MyApp.Users`.
 
-  The following Pow methods can be accessed:
+  The following Pow functions can be accessed:
 
     * `pow_authenticate/1`
     * `pow_create/1`
@@ -83,10 +83,10 @@ defmodule Pow.Ecto.Context do
   User schema module and repo module will be fetched from the config. The user
   id field is fetched from the user schema module.
 
-  The method will return nil if either the fetched user, or password is nil.
+  The function will return nil if either the fetched user or password is nil.
 
   To prevent timing attacks, a blank user struct will be passed to the
-  `verify_password/2` method for the user schema module to ensure that the
+  `verify_password/2` function for the user schema module to ensure that the
   the response time will be equal as when a password is verified.
   """
   @spec authenticate(map(), Config.t()) :: user() | nil

--- a/lib/pow/ecto/schema.ex
+++ b/lib/pow/ecto/schema.ex
@@ -8,10 +8,10 @@ defmodule Pow.Ecto.Schema do
   `pow_user_fields/0` macro will use these attributes to create fields and
   associations in the ecto schema.
 
-  The macro will add two overridable methods to your module; `changeset/2`
+  The macro will add two overridable functions to your module; `changeset/2`
   and `verify_password/2`. See the customization section below for more.
 
-  The following helper methods are added for changeset customization:
+  The following helper functions are added for changeset customization:
 
     - `pow_changeset/2`,
     - `pow_verify_password/2`
@@ -19,7 +19,7 @@ defmodule Pow.Ecto.Schema do
     - `pow_password_changeset/2`,
     - `pow_current_password_changeset/2`,
 
-  Finally `pow_user_id_field/0` method is added to the module that is used to
+  Finally `pow_user_id_field/0` function is added to the module that is used to
   fetch the user id field name.
 
   A `@pow_config` module attribute is created containing the options that were
@@ -124,9 +124,9 @@ defmodule Pow.Ecto.Schema do
 
   ## Customize Pow changeset
 
-  You can extract individual changeset methods to modify the changeset flow
+  You can extract individual changeset functions to modify the changeset flow
   entirely. As an example, this is how you can remove the validation check for
-  confirm password in the changeset method:
+  confirm password in the changeset function:
 
       defmodule MyApp.Users.User do
         use Ecto.Schema
@@ -144,7 +144,7 @@ defmodule Pow.Ecto.Schema do
         end
       end
 
-  Note that the changeset methods in `Pow.Ecto.Schema.Changeset` require the
+  Note that the changeset functions in `Pow.Ecto.Schema.Changeset` require the
   Pow ecto module configuration that is passed to the
   `use Pow.Ecto.Schema, ...` call. This can be fetched by using the
   `@pow_config` module attribute.
@@ -172,7 +172,7 @@ defmodule Pow.Ecto.Schema do
 
       defoverridable unquote(__MODULE__)
 
-      unquote(__MODULE__).__pow_methods__()
+      unquote(__MODULE__).__pow_functions__()
       unquote(__MODULE__).__register_fields__()
       unquote(__MODULE__).__register_assocs__()
       unquote(__MODULE__).__register_user_id_field__()
@@ -180,17 +180,17 @@ defmodule Pow.Ecto.Schema do
     end
   end
 
-  @changeset_methods [:user_id_field_changeset, :password_changeset, :current_password_changeset]
+  @changeset_functions [:user_id_field_changeset, :password_changeset, :current_password_changeset]
 
   @doc false
-  defmacro __pow_methods__ do
-    quoted_changeset_methods =
-      for method <- @changeset_methods do
-        pow_method_name = String.to_atom("pow_#{method}")
+  defmacro __pow_functions__ do
+    quoted_changeset_functions =
+      for changeset_function <- @changeset_functions do
+        pow_function_name = String.to_atom("pow_#{changeset_function}")
 
         quote do
-          def unquote(pow_method_name)(user_or_changeset, attrs) do
-            unquote(__MODULE__).Changeset.unquote(method)(user_or_changeset, attrs, @pow_config)
+          def unquote(pow_function_name)(user_or_changeset, attrs) do
+            unquote(__MODULE__).Changeset.unquote(changeset_function)(user_or_changeset, attrs, @pow_config)
           end
         end
       end
@@ -205,7 +205,7 @@ defmodule Pow.Ecto.Schema do
         |> pow_password_changeset(attrs)
       end
 
-      unquote(quoted_changeset_methods)
+      unquote(quoted_changeset_functions)
 
       def pow_verify_password(user, password) do
         unquote(__MODULE__).Changeset.verify_password(user, password, @pow_config)
@@ -277,7 +277,7 @@ defmodule Pow.Ecto.Schema do
   end
 
   # TODO: Remove by 1.1.0
-  @deprecated "No longer public method"
+  @deprecated "No longer public function"
   def filter_new_fields(fields, existing_fields), do: __filter_new_fields__(fields, existing_fields)
 
   @doc false

--- a/lib/pow/extension/config.ex
+++ b/lib/pow/extension/config.ex
@@ -38,7 +38,7 @@ defmodule Pow.Extension.Config do
   @doc """
   Returns a binary of the extension atom.
 
-  This is usually used to create extension namespaces for methods to be used
+  This is usually used to create extension namespaces for functions to be used
   in shared modules.
   """
   @deprecated "Create the namespace directly in your module"

--- a/lib/pow/extension/ecto/context/base.ex
+++ b/lib/pow/extension/ecto/context/base.ex
@@ -6,7 +6,7 @@ defmodule Pow.Extension.Ecto.Context.Base do
   @doc false
   defmacro __using__(_opts) do
     quote do
-      IO.warn("use #{unquote(__MODULE__)} is deprecated, please use methods in #{Context} instead")
+      IO.warn("use #{unquote(__MODULE__)} is deprecated, please use functions in #{Context} instead")
 
       defdelegate user_schema_mod(config), to: Context
       defdelegate repo(config), to: Context

--- a/lib/pow/extension/ecto/schema.ex
+++ b/lib/pow/extension/ecto/schema.ex
@@ -4,7 +4,7 @@ defmodule Pow.Extension.Ecto.Schema do
 
   The macro will append fields to the `@pow_fields` module attribute using the
   attributes from `[Pow Extension].Ecto.Schema.attrs/1`, so they can be used in
-  the `Pow.Ecto.Schema.pow_user_fields/0` method call.
+  the `Pow.Ecto.Schema.pow_user_fields/0` function call.
 
   After module compilation `[Pow Extension].Ecto.Schema.validate!/2` will run.
 
@@ -48,7 +48,7 @@ defmodule Pow.Extension.Ecto.Schema do
 
       unquote(__MODULE__).__register_extension_fields__()
       unquote(__MODULE__).__register_extension_assocs__()
-      unquote(__MODULE__).__pow_extension_methods__()
+      unquote(__MODULE__).__pow_extension_functions__()
       unquote(__MODULE__).__register_after_compile_validation__()
     end
   end
@@ -87,7 +87,7 @@ defmodule Pow.Extension.Ecto.Schema do
   end
 
   @doc false
-  defmacro __pow_extension_methods__ do
+  defmacro __pow_extension_functions__ do
     quote do
       def pow_extension_changeset(changeset, attrs) do
         unquote(__MODULE__).changeset(changeset, attrs, @pow_extension_config)
@@ -190,7 +190,7 @@ defmodule Pow.Extension.Ecto.Schema do
   This will run `validate!/2` on all extension ecto schema modules.
 
   It's used to ensure certain fields are available, e.g. an `:email` field. The
-  method should either raise an exception, or return `:ok`. Compilation will
+  function should either raise an exception, or return `:ok`. Compilation will
   fail when the exception is raised.
   """
   @spec validate!(Config.t(), atom()) :: :ok

--- a/lib/pow/extension/ecto/schema/base.ex
+++ b/lib/pow/extension/ecto/schema/base.ex
@@ -2,7 +2,7 @@ defmodule Pow.Extension.Ecto.Schema.Base do
   @moduledoc """
   Used for extensions to extend user schemas.
 
-  The macro will add fallback methods to the module, that can be overridden.
+  The macro will add fallback functions to the module, that can be overridden.
 
   ## Usage
 

--- a/lib/pow/extension/phoenix/controllers/controller/base.ex
+++ b/lib/pow/extension/phoenix/controllers/controller/base.ex
@@ -17,12 +17,12 @@ defmodule Pow.Extension.Phoenix.Controller.Base do
     quote do
       use Controller, unquote(config)
 
-      unquote(__MODULE__).__define_helper_methods__(unquote(config))
+      unquote(__MODULE__).__define_helper_functions__(unquote(config))
     end
   end
 
   @doc false
-  defmacro __define_helper_methods__(config) do
+  defmacro __define_helper_functions__(config) do
     quote do
       @messages_fallback unquote(__MODULE__).__messages_fallback__(unquote(config), __MODULE__, __ENV__)
 

--- a/lib/pow/extension/phoenix/controllers/controller_callbacks/base.ex
+++ b/lib/pow/extension/phoenix/controllers/controller_callbacks/base.ex
@@ -26,8 +26,8 @@ defmodule Pow.Extension.Phoenix.ControllerCallbacks.Base do
       require Base
       require Controller
 
-      Base.__define_helper_methods__(unquote(config))
-      Controller.__define_helper_methods__()
+      Base.__define_helper_functions__(unquote(config))
+      Controller.__define_helper_functions__()
 
       @before_compile unquote(__MODULE__)
     end

--- a/lib/pow/extension/phoenix/router.ex
+++ b/lib/pow/extension/phoenix/router.ex
@@ -72,7 +72,7 @@ defmodule Pow.Extension.Phoenix.Router do
   end
 
   @doc """
-  A macro that will call the router method in all extension router modules.
+  A macro that will call the routes function in all extension router modules.
   """
   defmacro pow_extension_routes do
     router_module(__CALLER__.module).routes()

--- a/lib/pow/extension/phoenix/router/base.ex
+++ b/lib/pow/extension/phoenix/router/base.ex
@@ -30,11 +30,11 @@ defmodule Pow.Extension.Phoenix.Router.Base do
     quote do
       @behaviour unquote(__MODULE__)
 
-      unquote(__MODULE__).__create_scope_routes_method__(unquote(extension))
+      unquote(__MODULE__).__create_scope_routes_function__(unquote(extension))
     end
   end
 
-  defmacro __create_scope_routes_method__(extension) do
+  defmacro __create_scope_routes_function__(extension) do
     quote do
       @doc false
       defmacro scoped_routes(config) do

--- a/lib/pow/operations.ex
+++ b/lib/pow/operations.ex
@@ -1,6 +1,6 @@
 defmodule Pow.Operations do
   @moduledoc """
-  Operation methods that glues operation calls to context module.
+  Operation functions that glues operation calls to context module.
 
   A custom context module can be used instead of the default `Pow.Ecto.Context`
   if a `:users_context` key is passed in the configuration.
@@ -24,7 +24,7 @@ defmodule Pow.Operations do
   @doc """
   Build a changeset from existing user struct.
 
-  It'll call the `changeset/2` method on the user struct.
+  It'll call the `changeset/2` function on the user struct.
   """
   @spec changeset(map(), map(), Config.t()) :: map()
   def changeset(user, params, _config) do
@@ -108,9 +108,9 @@ defmodule Pow.Operations do
   @doc """
   Retrieve a keyword list of primary key value(s) from the provided struct.
 
-  The keys will be fetched from the `__schema__/1` method in the struct module.
-  If no `__schema__/1` method exists, then it's expected that the struct has
-  `:id` as its only primary key.
+  The keys will be fetched from the `__schema__/1` function in the struct
+  module. If no `__schema__/1` function exists, then it's expected that the
+  struct has `:id` as its only primary key.
   """
   @spec fetch_primary_key_values(struct(), Config.t()) :: {:ok, keyword()} | {:error, term()}
   def fetch_primary_key_values(%mod{} = struct, _config) do

--- a/lib/pow/phoenix/controllers/controller.ex
+++ b/lib/pow/phoenix/controllers/controller.ex
@@ -44,12 +44,12 @@ defmodule Pow.Phoenix.Controller do
 
       defp pow_layout(conn, _config), do: ViewHelpers.layout(conn)
 
-      unquote(__MODULE__).__define_helper_methods__()
+      unquote(__MODULE__).__define_helper_functions__()
     end
   end
 
   @doc false
-  defmacro __define_helper_methods__ do
+  defmacro __define_helper_functions__ do
     quote do
       def messages(conn), do: unquote(__MODULE__).messages(conn, Messages)
 

--- a/lib/pow/phoenix/html/errors.ex
+++ b/lib/pow/phoenix/html/errors.ex
@@ -7,7 +7,7 @@ defmodule Pow.Phoenix.HTML.ErrorHelpers do
   @doc """
   Generates tag for inlined form input errors.
 
-  It'll call a simple mock method to interpolate, as translations should be
+  It'll call a simple mock function to interpolate, as translations should be
   handled in the Phoenix app implementing Pow.
   """
   def error_tag(form, field) do

--- a/lib/pow/phoenix/mailer/template.ex
+++ b/lib/pow/phoenix/mailer/template.ex
@@ -21,11 +21,11 @@ defmodule Pow.Phoenix.Mailer.Template do
   end
 
   @doc """
-  Generate template methods.
+  Generate template functions.
 
   This macro that will compile a mailer template from the provided binaries,
-  and add the compiled versions to `render/2` methods. The `text/1` and
-  `html/1` outputs the binaries. A `subject/1` method will be added too.
+  and add the compiled versions to `render/2` functions. The `text/1` and
+  `html/1` outputs the binaries. A `subject/1` function will be added too.
   """
   @spec template(atom(), binary(), binary(), binary()) :: Macro.t()
   defmacro template(action, subject, text, html) do

--- a/lib/pow/phoenix/mailer/view.ex
+++ b/lib/pow/phoenix/mailer/view.ex
@@ -1,7 +1,7 @@
 defmodule Pow.Phoenix.Mailer.View do
   @moduledoc """
-  View macros for `Pow.Phoenix.Mailer` that calls render methods generated with
-  `Pow.Phoenix.Mailer.Template`.
+  View macros for `Pow.Phoenix.Mailer` that calls render functions generated
+  with `Pow.Phoenix.Mailer.Template`.
 
   ## Usage
 

--- a/lib/pow/phoenix/template.ex
+++ b/lib/pow/phoenix/template.ex
@@ -27,11 +27,11 @@ defmodule Pow.Phoenix.Template do
   end
 
   @doc """
-  Generates template methods.
+  Generates template functions.
 
   This macro that will compile a phoenix view template from the provided
-  binary, and add the compiled version to a `render/2` method. The `html/1`
-  method outputs the binary.
+  binary, and add the compiled version to a `render/2` function. The `html/1`
+  function outputs the binary.
   """
   @spec template(atom(), atom(), binary() | {atom(), any()}) :: Macro.t()
   defmacro template(action, :html, content) do

--- a/lib/pow/phoenix/view.ex
+++ b/lib/pow/phoenix/view.ex
@@ -1,6 +1,6 @@
 defmodule Pow.Phoenix.View do
   @moduledoc """
-  View macros for Pow Phoenix, that calls render methods generated with
+  View macros for Pow Phoenix, that calls render functions generated with
   `Pow.Phoenix.Template`.
 
   ## Usage

--- a/lib/pow/plug.ex
+++ b/lib/pow/plug.ex
@@ -1,6 +1,6 @@
 defmodule Pow.Plug do
   @moduledoc """
-  Plug helper methods.
+  Plug helper functions.
   """
   alias Plug.Conn
   alias Pow.{Config, Operations, Plug.MessageVerifier}

--- a/lib/pow/plug/base.ex
+++ b/lib/pow/plug/base.ex
@@ -6,7 +6,7 @@ defmodule Pow.Plug.Base do
 
   Any writes to backend store or client should occur in `:before_send` callback
   as defined in `Plug.Conn`. To ensure that the callbacks are called in the
-  order they were set, a `register_before_send/2` method is used to set
+  order they were set, a `register_before_send/2` function is used to set
   callbacks instead of `Plug.Conn.register_before_send/2`.
 
   ## Configuration options

--- a/lib/pow/plug/session.ex
+++ b/lib/pow/plug/session.ex
@@ -76,7 +76,7 @@ defmodule Pow.Plug.Session do
   session metadata, while `:ip` and `:user_agent` will be updated each time the
   session is created.
 
-  The method should be called after `Pow.Plug.Session.call/2` has been called
+  The function should be called after `Pow.Plug.Session.call/2` has been called
   to ensure that the metadata, if any, has been fetched.
 
   ## Session expiration
@@ -126,7 +126,7 @@ defmodule Pow.Plug.Session do
   `:pow_session_metadata` key in the conn so it may be used in `create/3`.
 
   If the credentials cache returns a `nil` value the session will be
-  immediately deleted as it means the context method could not find the
+  immediately deleted as it means the context function could not find the
   associated user.
 
   The session id will be decoded and verified with `Pow.Plug.verify_token/4`.

--- a/lib/pow/store/backend/mnesia_cache.ex
+++ b/lib/pow/store/backend/mnesia_cache.ex
@@ -49,7 +49,7 @@ defmodule Pow.Store.Backend.MnesiaCache do
 
   ## Usage
 
-  To start the GenServer, add it to your application `start/2` method:
+  To start the GenServer, add it to your application `start/2` function:
 
       defmodule MyApp.Application do
         use Application

--- a/lib/pow/store/backend/mnesia_cache/unsplit.ex
+++ b/lib/pow/store/backend/mnesia_cache/unsplit.ex
@@ -19,7 +19,7 @@ defmodule Pow.Store.Backend.MnesiaCache.Unsplit do
 
   ## Usage
 
-  To start the GenServer, add it to your application `start/2` method:
+  To start the GenServer, add it to your application `start/2` function:
 
       defmodule MyApp.Application do
         use Application

--- a/lib/pow/store/credentials_cache.ex
+++ b/lib/pow/store/credentials_cache.ex
@@ -7,7 +7,7 @@ defmodule Pow.Store.CredentialsCache do
   `{credentials, session_metadata}`, where session metadata is data exclusive
   to the session id.
 
-  This module also adds two utility methods:
+  This module also adds two utility functions:
 
     * `users/2` - to list all current users
     * `sessions/2` - to list all current sessions
@@ -18,8 +18,8 @@ defmodule Pow.Store.CredentialsCache do
 
   ## Custom credentials cache module
 
-  Pow may use the utility methods in this module. To ensure all required
-  methods has been implemented in a custom credentials cache module, the
+  Pow may use the utility functions in this module. To ensure all required
+  functions has been implemented in a custom credentials cache module, the
   `@behaviour` of this module should be used:
 
       defmodule MyApp.CredentialsStore do

--- a/test/extensions/email_confirmation/ecto/schema_test.exs
+++ b/test/extensions/email_confirmation/ecto/schema_test.exs
@@ -8,7 +8,7 @@ defmodule PowEmailConfirmation.Ecto.SchemaTest do
   @password     "secret1234"
   @valid_params %{email: "test@example.com", password: @password, password_confirmation: @password, current_password: @password}
 
-  defmodule OverridenMethodsUser do
+  defmodule OverridenChangesetUser do
     @moduledoc false
     use Ecto.Schema
     use Pow.Ecto.Schema
@@ -191,17 +191,17 @@ defmodule PowEmailConfirmation.Ecto.SchemaTest do
       assert changeset.changes == %{}
     end
 
-    test "with overridden method" do
+    test "with overridden changeset" do
       {:ok, user} =
-        %OverridenMethodsUser{}
-        |> OverridenMethodsUser.changeset(@valid_params)
+        %OverridenChangesetUser{}
+        |> OverridenChangesetUser.changeset(@valid_params)
         |> RepoMock.insert([])
 
-      changeset = OverridenMethodsUser.confirm_email_changeset(user, %{})
+      changeset = OverridenChangesetUser.confirm_email_changeset(user, %{})
 
       refute changeset.valid?
 
-      changeset = OverridenMethodsUser.confirm_email_changeset(user, %{"current_password" => @password})
+      changeset = OverridenChangesetUser.confirm_email_changeset(user, %{"current_password" => @password})
 
       assert changeset.valid?
     end

--- a/test/extensions/invitation/ecto/schema_test.exs
+++ b/test/extensions/invitation/ecto/schema_test.exs
@@ -6,7 +6,7 @@ defmodule PowInvitation.Ecto.SchemaTest do
   alias PowInvitation.PowEmailConfirmation.Test.Users.User, as: UserEmailConfirmation
   alias PowInvitation.Test.Users.User
 
-  defmodule OverridenMethodsUser do
+  defmodule OverridenChangesetsUser do
     @moduledoc false
     use Ecto.Schema
     use Pow.Ecto.Schema
@@ -67,8 +67,8 @@ defmodule PowInvitation.Ecto.SchemaTest do
       assert changeset.errors[:email]
     end
 
-    test "with overridden method" do
-      changeset = OverridenMethodsUser.invite_changeset(%OverridenMethodsUser{}, @invited_by, @valid_params)
+    test "with overridden changesets" do
+      changeset = OverridenChangesetsUser.invite_changeset(%OverridenChangesetsUser{}, @invited_by, @valid_params)
 
       assert changeset.valid?
       assert changeset.changes.organization_id == 1
@@ -112,8 +112,8 @@ defmodule PowInvitation.Ecto.SchemaTest do
       assert changeset.changes[:unconfirmed_email] == "new@example.com"
     end
 
-    test "with overridden method" do
-      changeset = OverridenMethodsUser.accept_invitation_changeset(%OverridenMethodsUser{}, @valid_params)
+    test "with overridden changesets" do
+      changeset = OverridenChangesetsUser.accept_invitation_changeset(%OverridenChangesetsUser{}, @valid_params)
 
       assert changeset.valid?
       assert changeset.changes.invitation_accepted_ip == "127.0.0.1"

--- a/test/extensions/reset_password/ecto/context_test.exs
+++ b/test/extensions/reset_password/ecto/context_test.exs
@@ -30,7 +30,7 @@ defmodule PowResetPassword.Ecto.ContextTest do
   end
 
   describe "update_password/2" do
-    test "updates with compiled password hash methods" do
+    test "updates with compiled password hash functions" do
       assert {:ok, user} = Context.update_password(@user, %{password: @password, password_confirmation: @password}, @config)
       assert Password.pbkdf2_verify(@password, user.password_hash)
     end

--- a/test/extensions/reset_password/ecto/schema_test.exs
+++ b/test/extensions/reset_password/ecto/schema_test.exs
@@ -5,7 +5,7 @@ defmodule PowResetPassword.Ecto.SchemaTest do
   alias PowResetPassword.Ecto.Schema
   alias PowResetPassword.Test.Users.User
 
-  defmodule OverridenMethodUser do
+  defmodule OverridenChangesetUser do
     @moduledoc false
     use Ecto.Schema
     use Pow.Ecto.Schema
@@ -39,8 +39,8 @@ defmodule PowResetPassword.Ecto.SchemaTest do
       assert changeset.changes.password_hash
     end
 
-    test "with overridden method" do
-      changeset = OverridenMethodUser.reset_password_changeset(%OverridenMethodUser{}, @valid_params)
+    test "with overridden changeset" do
+      changeset = OverridenChangesetUser.reset_password_changeset(%OverridenChangesetUser{}, @valid_params)
 
       assert changeset.valid?
       assert changeset.changes.password_reset_at

--- a/test/pow/ecto/schema/changeset_test.exs
+++ b/test/pow/ecto/schema/changeset_test.exs
@@ -210,7 +210,7 @@ defmodule Pow.Ecto.Schema.ChangesetTest do
       end) =~ "passing `confirm_password` value to `Pow.Ecto.Schema.Changeset.confirm_password_changeset/3` has been deprecated, please use `password_confirmation` instead"
     end
 
-    test "can use custom password hash methods" do
+    test "can use custom password hash functions" do
       password_hash = &(&1 <> "123")
       password_verify = &(&1 == &2 <> "123")
       config = [password_hash_methods: {password_hash, password_verify}]

--- a/test/pow/extension/ecto/schema_test.exs
+++ b/test/pow/extension/ecto/schema_test.exs
@@ -48,7 +48,7 @@ defmodule Pow.Extension.Ecto.SchemaTest do
     @impl true
     defmacro __using__(_config) do
       quote do
-        def custom_method, do: true
+        def custom_function, do: true
       end
     end
   end
@@ -127,9 +127,9 @@ defmodule Pow.Extension.Ecto.SchemaTest do
     assert changeset.errors[:custom] == {"custom error", []}
   end
 
-  test "has custom method definitions" do
-    assert Kernel.function_exported?(User, :custom_method, 0)
-    assert User.custom_method()
+  test "has custom function definitions" do
+    assert Kernel.function_exported?(User, :custom_function, 0)
+    assert User.custom_function()
   end
 
   test "validates attributes" do


### PR DESCRIPTION
Just a simple renaming of method to function in docs and private functions.