### PR TITLE
Automatically inject files for mix tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Enhancements
 
 * [`Mix.Pow`] `Mix.Pow.parse_options/3` now merges option defaults with `:otp_app, :generators` configuration
+* [`Mix.Pow.Mix.Tasks.Pow.Phoenix.Mailer.Gen.Templates`] Now injects `config/config.exs` and `WEB_PATH/WEB_APP.ex`
+* [`Mix.Pow.Mix.Tasks.Pow.Phoenix.Gen.Templates`] Now injects `config/config.exs`
+* [`Mix.Tasks.Pow.Phoenix.Install`] Now injects `config/config.exs`, `WEB_PATH/endpoint.ex`, and `WEB_PATH/router.ex`
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -51,65 +51,15 @@ LIB_PATH/users/user.ex
 PRIV_PATH/repo/migrations/TIMESTAMP_create_users.ex
 ```
 
-Add the following to `config/config.exs`:
+And also update the following files:
 
-```elixir
-use Mix.Config
-
-# ... existing config
-  
-config :my_app, :pow,
-  user: MyApp.Users.User,
-  repo: MyApp.Repo
-
-# ... import_config
+```bash
+config/config.exs
+WEB_PATH/endpoint.ex
+WEB_PATH/router.ex
 ```
 
-Set up `WEB_PATH/endpoint.ex` to enable session based authentication (`Pow.Plug.Session` is added after `Plug.Session`):
-
-```elixir
-defmodule MyAppWeb.Endpoint do
-  use Phoenix.Endpoint, otp_app: :my_app
-
-  # ...
-
-  plug Plug.Session, @session_options
-  plug Pow.Plug.Session, otp_app: :my_app
-  plug MyAppWeb.Router
-end
-```
-
-Add Pow routes to `WEB_PATH/router.ex`:
-
-```elixir
-defmodule MyAppWeb.Router do
-  use MyAppWeb, :router
-  use Pow.Phoenix.Router
-
-  # ... pipelines
-
-  pipeline :protected do
-    plug Pow.Plug.RequireAuthenticated,
-      error_handler: Pow.Phoenix.PlugErrorHandler
-  end
-
-  scope "/" do
-    pipe_through :browser
-
-    pow_routes()
-  end
-
-  scope "/", MyAppWeb do
-    pipe_through [:browser, :protected]
-
-    # Add your protected routes here
-  end
-
-  # ... routes
-end
-```
-
-That's it! Run `mix ecto.setup` and you can now visit `http://localhost:4000/registration/new`, and create a new user.
+Run `mix ecto.setup` and you can now visit `http://localhost:4000/registration/new`, and create a new user.
 
 ### Modify templates
 
@@ -121,13 +71,7 @@ If you wish to modify the templates, you can generate them (and the view files) 
 mix pow.phoenix.gen.templates
 ```
 
-Remember to add `web_module: MyAppWeb` to the configuration so that the view you've just generated will be used instead:
-
-```elixir
-config :my_app, :pow,
-  # ...
-  web_module: MyAppWeb
-```
+This will also add `web_module: MyAppWeb` to the configuration in `config/config.exs`.
 
 ## Extensions
 
@@ -248,41 +192,13 @@ This mailer module will only output the mail to your log, so you can e.g. try ou
 
 #### Modify mailer templates
 
-Since Phoenix doesn't ship with a mailer setup by default you should first modify `my_app_web.ex` with a `:mailer_view` macro:
-
-```elixir
-defmodule MyAppWeb do
-  # ...
-
-  def mailer_view do
-    quote do
-      use Phoenix.View, root: "lib/my_app_web/templates",
-                        namespace: MyAppWeb
-
-      use Phoenix.HTML
-    end
-  end
-
-  # ...
-
-end
-```
-
-Now generate the view and template files:
+Generate the view and template files:
 
 ```bash
 mix pow.extension.phoenix.mailer.gen.templates --extension PowResetPassword --extension PowEmailConfirmation
 ```
 
-This will generate view files in `WEB_PATH/views/POW_EXTENSION/mailer/`, and html and text templates in `WEB_PATH/templates/POW_EXTENSION/mailer/` directory.
-
-Add `web_mailer_module: MyAppWeb` to the configuration so Pow will use the views you've just generated:
-
-```elixir
-config :my_app, :pow,
-  # ...
-  web_mailer_module: MyAppWeb
-```
+This will generate view files in `WEB_PATH/views/POW_EXTENSION/mailer/`, and html and text templates in `WEB_PATH/templates/POW_EXTENSION/mailer/` directory. This will also add the necessary ` mailer_view/0` macro to `WEB_PATH/my_app_web.ex` and update the pow config with ``web_mailer_module: MyAppWeb`.
 
 The generated view files contain the subject lines for the emails.
 

--- a/lib/mix/tasks/phoenix/pow.phoenix.install.ex
+++ b/lib/mix/tasks/phoenix/pow.phoenix.install.ex
@@ -23,7 +23,6 @@ defmodule Mix.Tasks.Pow.Phoenix.Install do
   """
   use Mix.Task
 
-  alias Pow.Config
   alias Mix.{Pow, Pow.Phoenix}
   alias Mix.Tasks.Pow.Extension.Phoenix.Gen.Templates, as: PhoenixExtensionTemplatesTask
   alias Mix.Tasks.Pow.Phoenix.Gen.Templates, as: PhoenixTemplatesTask
@@ -43,13 +42,131 @@ defmodule Mix.Tasks.Pow.Phoenix.Install do
     args
     |> Pow.parse_options(@switches, @default_opts)
     |> parse_structure()
+    |> print_shell_instructions(schema_opts)
     |> maybe_run_gen_templates(args)
     |> maybe_run_extensions_gen_templates(args)
-    |> print_shell_instructions(schema_opts)
   end
 
   defp parse_structure({config, _parsed, _invalid}) do
     Map.put(config, :structure, Phoenix.parse_structure(config))
+  end
+
+  defp print_shell_instructions(%{structure: structure} = config, schema_opts) do
+    [
+      config_file_injection(structure, schema_opts),
+      phoenix_endpoint_file_injection(structure),
+      phoenix_router_file_injection(structure)
+    ]
+    |> Pow.inject_files()
+    |> case do
+      :ok ->
+        Mix.shell().info("Pow has been installed in your Phoenix app!")
+        config
+
+      :error ->
+        Mix.raise "Couldn't install Pow! Did you run this inside your Phoenix app?"
+    end
+  end
+
+  defp config_file_injection(structure, schema_opts) do
+    file = Path.expand(Keyword.fetch!(Mix.Project.config(), :config_path))
+
+    content =
+      """
+      config #{inspect(structure.web_app)}, :pow,
+        user: #{inspect(structure.context_base)}.#{schema_opts.schema_name},
+        repo: #{inspect(structure.context_base)}.Repo
+      """
+
+    %{
+      file: file,
+      injections: [%{
+        content: content,
+        test: "config #{inspect(structure.web_app)}, :pow",
+        needle: "import_config",
+        prepend: true
+      }],
+      instructions:
+        """
+        Append this to #{Path.relative_to_cwd(file)}:
+
+        #{content}
+        """
+    }
+  end
+
+  defp phoenix_endpoint_file_injection(structure) do
+    file = Path.expand("#{structure.web_prefix}/endpoint.ex")
+    content = "  plug Pow.Plug.Session, otp_app: #{inspect(structure.web_app)}"
+
+    %{
+      file: file,
+      injections: [%{
+        content: content,
+        test: "plug Pow.Plug.Session",
+        needle: "plug Plug.Session"
+      }],
+      instructions:
+        """
+        Add the `Pow.Plug.Session` plug to #{Path.relative_to_cwd(file)} after the `Plug.Session` plug:
+
+        defmodule #{inspect(structure.web_module)}.Endpoint do
+          use Phoenix.Endpoint, otp_app: #{inspect(structure.web_app)}
+
+          # ...
+
+          plug Plug.Session, @session_options
+        #{content}
+          plug #{inspect(structure.web_module)}.Router
+        end
+        """
+    }
+  end
+
+  defp phoenix_router_file_injection(structure) do
+    file = Path.expand("#{structure.web_prefix}/router.ex")
+
+    router_use_content = "  use Pow.Phoenix.Router"
+    router_scope_content =
+      """
+        scope "/" do
+          pipe_through :browser
+
+          pow_routes()
+        end
+      """
+
+    %{
+      file: file,
+      injections: [
+        %{
+          content: router_use_content,
+          test: "use Pow.Phoenix.Router",
+          needle: "use #{inspect(structure.web_module)}, :router"
+        },
+        %{
+          content: router_scope_content,
+          test: "pow_routes()",
+          needle: "scope ",
+          prepend: true,
+        }
+      ],
+      instructions:
+        """
+        Update `#{Path.relative_to_cwd(file)}` with the Pow routes:
+
+        defmodule #{inspect(structure.web_module)}.Router do
+          use #{inspect(structure.web_module)}, :router
+        #{router_use_content}
+
+          # ... pipelines
+
+        #{router_scope_content}
+
+          # ... routes
+        end
+        """
+    }
   end
 
   defp maybe_run_gen_templates(%{templates: true} = config, args) do
@@ -65,61 +182,4 @@ defmodule Mix.Tasks.Pow.Phoenix.Install do
     config
   end
   defp maybe_run_extensions_gen_templates(config, _args), do: config
-
-  defp print_shell_instructions(%{structure: %{context_base: context_base, web_module: web_base, web_prefix: web_prefix, web_app: web_app}}, %{schema_name: schema_name}) do
-    case config_set?(web_app) do
-      true ->
-        :ok
-
-      false ->
-        Mix.shell().info(
-          """
-          Pow has been installed in your phoenix app!
-
-          There are three files you'll need to configure first before you can use Pow.
-
-          First, append this to `config/config.exs`:
-
-          config #{inspect(web_app)}, :pow,
-            user: #{inspect(context_base)}.#{schema_name},
-            repo: #{inspect(context_base)}.Repo
-
-          Next, add `Pow.Plug.Session` plug to `#{web_prefix}/endpoint.ex` after `plug Plug.Session`:
-
-          defmodule #{inspect(web_base)}.Endpoint do
-            use Phoenix.Endpoint, otp_app: #{inspect(web_app)}
-
-            # ...
-
-            plug Plug.Session, @session_options
-            plug Pow.Plug.Session, otp_app: #{inspect(web_app)}
-            plug #{inspect(web_base)}.Router
-          end
-
-          Last, update `#{web_prefix}/router.ex` with the Pow routes:
-
-          defmodule #{inspect(web_base)}.Router do
-            use #{inspect(web_base)}, :router
-            use Pow.Phoenix.Router
-
-            # ... pipelines
-
-            scope "/" do
-              pipe_through :browser
-
-              pow_routes()
-            end
-
-            # ... routes
-          end
-          """)
-    end
-  end
-
-  defp config_set?(web_app) do
-    user = Config.get([otp_app: web_app], :user)
-    repo = Config.get([otp_app: web_app], :repo)
-
-    not is_nil(user) && not is_nil(repo)
-  end
 end

--- a/test/mix/tasks/ecto/pow.ecto.gen.schema_test.exs
+++ b/test/mix/tasks/ecto/pow.ecto.gen.schema_test.exs
@@ -3,18 +3,10 @@ defmodule Mix.Tasks.Pow.Ecto.Gen.SchemaTest do
 
   alias Mix.Tasks.Pow.Ecto.Gen.Schema
 
-  @tmp_path      Path.join(["tmp", inspect(Schema)])
   @expected_file Path.join(["lib", "pow", "users", "user.ex"])
 
-  setup do
-    File.rm_rf!(@tmp_path)
-    File.mkdir_p!(@tmp_path)
-
-    :ok
-  end
-
-  test "generates schema file" do
-    File.cd!(@tmp_path, fn ->
+  test "generates schema file", context do
+    File.cd!(context.tmp_path, fn ->
       Schema.run([])
 
       assert File.exists?(@expected_file)
@@ -24,10 +16,10 @@ defmodule Mix.Tasks.Pow.Ecto.Gen.SchemaTest do
     end)
   end
 
-  test "generates with `:binary_id` and `:context_app`" do
+  test "generates with `:binary_id` and `:context_app`", context do
     options = ~w(--binary-id --context-app pow)
 
-    File.cd!(@tmp_path, fn ->
+    File.cd!(context.tmp_path, fn ->
       Schema.run(options)
 
       assert File.exists?(@expected_file)
@@ -38,8 +30,8 @@ defmodule Mix.Tasks.Pow.Ecto.Gen.SchemaTest do
     end)
   end
 
-  test "doesn't make duplicate files" do
-    File.cd!(@tmp_path, fn ->
+  test "doesn't make duplicate files", context do
+    File.cd!(context.tmp_path, fn ->
       Schema.run([])
 
       assert_raise Mix.Error, "schema file can't be created, there is already a schema file in lib/pow/users/user.ex.", fn ->
@@ -48,7 +40,7 @@ defmodule Mix.Tasks.Pow.Ecto.Gen.SchemaTest do
     end)
   end
 
-  test "generates with `:generators` config" do
+  test "generates with `:generators` config", context do
     Application.put_env(:pow, :generators, binary_id: true, context_app: {:my_app, "my_app"})
     on_exit(fn ->
       Application.delete_env(:pow, :generators)
@@ -56,7 +48,7 @@ defmodule Mix.Tasks.Pow.Ecto.Gen.SchemaTest do
 
     file = Path.join(["my_app", "lib", "my_app", "users", "user.ex"])
 
-    File.cd!(@tmp_path, fn ->
+    File.cd!(context.tmp_path, fn ->
       Schema.run([])
 
       assert File.exists?(file)

--- a/test/mix/tasks/extension/phoenix/pow.extension.phoenix.gen.templates_test.exs
+++ b/test/mix/tasks/extension/phoenix/pow.extension.phoenix.gen.templates_test.exs
@@ -3,7 +3,6 @@ defmodule Mix.Tasks.Pow.Extension.Phoenix.Gen.TemplatesTest do
 
   alias Mix.Tasks.Pow.Extension.Phoenix.Gen.Templates
 
-  @tmp_path Path.join(["tmp", inspect(Templates)])
   @expected_template_files [
     {PowResetPassword, %{
       "reset_password" => ["edit.html.eex", "new.html.eex"]
@@ -14,15 +13,8 @@ defmodule Mix.Tasks.Pow.Extension.Phoenix.Gen.TemplatesTest do
   ]
   @options Enum.flat_map(@expected_template_files, &["--extension", inspect(elem(&1, 0))])
 
-  setup do
-    File.rm_rf!(@tmp_path)
-    File.mkdir_p!(@tmp_path)
-
-    :ok
-  end
-
-  test "generates templates" do
-    File.cd!(@tmp_path, fn ->
+  test "generates templates", context do
+    File.cd!(context.tmp_path, fn ->
       Templates.run(@options)
 
       for {module, expected_templates} <- @expected_template_files do
@@ -51,16 +43,16 @@ defmodule Mix.Tasks.Pow.Extension.Phoenix.Gen.TemplatesTest do
     end)
   end
 
-  test "warns if no extensions" do
-    File.cd!(@tmp_path, fn ->
+  test "warns if no extensions", context do
+    File.cd!(context.tmp_path, fn ->
       Templates.run([])
 
       assert_received {:mix_shell, :error, ["No extensions was provided as arguments, or found in `config :pow, :pow` configuration."]}
     end)
   end
 
-  test "warns no templates" do
-    File.cd!(@tmp_path, fn ->
+  test "warns no templates", context do
+    File.cd!(context.tmp_path, fn ->
       Templates.run(~w(--extension PowPersistentSession))
 
       assert_received {:mix_shell, :info, ["Notice: No view or template files will be generated for PowPersistentSession as this extension doesn't have any views defined."]}
@@ -75,8 +67,8 @@ defmodule Mix.Tasks.Pow.Extension.Phoenix.Gen.TemplatesTest do
       end)
     end
 
-    test "generates templates" do
-      File.cd!(@tmp_path, fn ->
+    test "generates templates", context do
+      File.cd!(context.tmp_path, fn ->
         Templates.run([])
 
         for {module, expected_templates} <- @expected_template_files do

--- a/test/mix/tasks/phoenix/pow.phoenix.install_test.exs
+++ b/test/mix/tasks/phoenix/pow.phoenix.install_test.exs
@@ -3,92 +3,196 @@ defmodule Mix.Tasks.Pow.Phoenix.InstallTest do
 
   alias Mix.Tasks.Pow.Phoenix.Install
 
-  @tmp_path       Path.join(["tmp", inspect(Install)])
   @options        []
-  @web_path       Path.join(["lib", "pow_web"])
-  @templates_path Path.join([@web_path, "templates", "pow"])
-  @views_path     Path.join([@web_path, "views", "pow"])
-  @expected_msg   "Pow has been installed in your phoenix app!"
+  @success_msg    "Pow has been installed in your Phoenix app!"
 
-  setup do
-    File.rm_rf!(@tmp_path)
-    File.mkdir_p!(@tmp_path)
-
-    :ok
-  end
-
-  test "default" do
-    File.cd!(@tmp_path, fn ->
+  test "default", context do
+    File.cd!(context.tmp_path, fn ->
       Install.run(@options)
 
-      refute File.exists?(@templates_path)
-      refute File.exists?(@views_path)
+      refute File.exists?(context.paths.templates_path)
+      refute File.exists?(context.paths.views_path)
 
-      assert_received {:mix_shell, :info, [@expected_msg <> msg]}
+      injecting_config_message = "* injecting #{context.paths.config_path}"
+      injecting_endpoint_message = "* injecting #{context.paths.endpoint_path}"
+      injecting_router_path_message = "* injecting #{context.paths.router_path}"
+
+      assert_received {:mix_shell, :info, [^injecting_config_message]}
+      assert_received {:mix_shell, :info, [^injecting_endpoint_message]}
+      assert_received {:mix_shell, :info, [^injecting_router_path_message]}
+      assert_received {:mix_shell, :info, [@success_msg]}
+
+      expected_config =
+        """
+        config :pow, :pow,
+          user: Pow.Users.User,
+          repo: Pow.Repo
+
+        # Import environment specific config. This must remain at the bottom
+        """
+
+      expected_endpoint =
+        """
+          plug Plug.Session, @session_options
+          plug Pow.Plug.Session, otp_app: :pow
+        """
+
+      expected_router_head =
+        """
+          use PowWeb, :router
+          use Pow.Phoenix.Router
+        """
+
+      expected_router_body =
+        """
+          scope "/" do
+            pipe_through :browser
+
+            pow_routes()
+          end
+
+          scope "/", PowWeb do
+        """
+
+      assert File.read!(context.paths.config_path) =~ expected_config
+      assert File.read!(context.paths.endpoint_path) =~ expected_endpoint
+      assert File.read!(context.paths.router_path) =~ expected_router_head
+      assert File.read!(context.paths.router_path) =~ expected_router_body
+    end)
+  end
+
+  test "when files don't exist", context do
+    File.cd!(context.tmp_path, fn ->
+      File.rm_rf!(context.paths.web_path)
+      File.rm_rf!(context.paths.config_path)
+
+      assert_raise Mix.Error, "Couldn't install Pow! Did you run this inside your Phoenix app?", fn ->
+        Install.run(@options)
+      end
+
+      assert_received {:mix_shell, :error, [msg]}
+      assert msg =~ "Could not find the following file(s)"
+      assert msg =~ context.paths.config_path
+      assert msg =~ context.paths.endpoint_path
+      assert msg =~ context.paths.router_path
+    end)
+  end
+
+  test "when files can't be configured", context do
+    File.cd!(context.tmp_path, fn ->
+      File.write!(context.paths.config_path, "")
+      File.write!(context.paths.endpoint_path, "")
+      File.write!(context.paths.router_path, "")
+
+      Install.run(@options)
+
+      assert_received {:mix_shell, :error, [msg]}
+      assert msg =~ "Could not configure the following files"
+      assert msg =~ context.paths.config_path
+      assert msg =~ context.paths.endpoint_path
+      assert msg =~ context.paths.router_path
+
+      assert_received {:mix_shell, :info, [msg]}
+      assert msg =~ "To complete please do the following"
+      assert msg =~ "Append this to config/config.exs:"
       assert msg =~ "config :pow, :pow,"
       assert msg =~ "user: Pow.Users.User,"
+      assert msg =~ "repo: Pow.Repo"
+      assert msg =~ "Add the `Pow.Plug.Session` plug to lib/pow_web/endpoint.ex after the `Plug.Session` plug:"
       assert msg =~ "plug Pow.Plug.Session, otp_app: :pow"
+      assert msg =~ "Update `lib/pow_web/router.ex` with the Pow routes:"
       assert msg =~ "use Pow.Phoenix.Router"
       assert msg =~ "pow_routes()"
     end)
   end
 
-  test "with templates" do
-    options = @options ++ ~w(--templates)
+  test "when files already configured", context do
+    File.cd!(context.tmp_path, fn ->
+      Install.run(@options)
 
-    File.cd!(@tmp_path, fn ->
-      Install.run(options)
+      assert_received {:mix_shell, :info, _}
+      assert_received {:mix_shell, :info, _}
+      assert_received {:mix_shell, :info, _}
+      assert_received {:mix_shell, :info, [@success_msg]}
 
-      assert File.exists?(@templates_path)
-      assert [_one, _two] = File.ls!(@templates_path)
-      assert File.exists?(@views_path)
-      assert [_one, _two] = File.ls!(@views_path)
+      Install.run(@options)
+
+      for path <- [context.paths.config_path, context.paths.endpoint_path, context.paths.router_path] do
+        message = "* already configured #{path}"
+        assert_received {:mix_shell, :info, [^message]}
+      end
+
+      assert_received {:mix_shell, :info, [@success_msg]}
     end)
   end
 
-  test "with extension templates" do
-    options = @options ++ ~w(--templates --extension PowResetPassword --extension PowEmailConfirmation)
+  test "with templates", context do
+    options = @options ++ ~w(--templates)
 
-    File.cd!(@tmp_path, fn ->
+    File.cd!(context.tmp_path, fn ->
       Install.run(options)
 
-      assert File.exists?(@templates_path)
-      reset_password_templates = Path.join(["lib", "pow_web", "templates", "pow_reset_password"])
+      assert File.exists?(context.paths.templates_path)
+      assert [_one, _two] = File.ls!(context.paths.templates_path)
+      assert File.exists?(context.paths.views_path)
+      assert [_one, _two] = File.ls!(context.paths.views_path)
+    end)
+  end
+
+  test "with extension templates", context do
+    options = @options ++ ~w(--templates --extension PowResetPassword --extension PowEmailConfirmation)
+
+    File.cd!(context.tmp_path, fn ->
+      Install.run(options)
+
+      assert File.exists?(context.paths.templates_path)
+      reset_password_templates = Path.join([context.paths.web_path, "templates", "pow_reset_password"])
       assert [_one] = File.ls!(reset_password_templates)
-      reset_password_views = Path.join(["lib", "pow_web", "views", "pow_reset_password"])
+      reset_password_views = Path.join([context.paths.web_path, "views", "pow_reset_password"])
       assert File.exists?(reset_password_views)
       assert [_one] = File.ls!(reset_password_views)
     end)
   end
 
-  test "with `:context_app`" do
-    File.cd!(@tmp_path, fn ->
+  @tag web_module: "Pow", context_module: "Test"
+  test "with `:context_app`", context do
+    File.cd!(context.tmp_path, fn ->
       Install.run(@options ++ ~w(--context-app test --templates))
 
-      assert_received {:mix_shell, :info, [@expected_msg <> msg]}
-      assert msg =~ "user: Test.Users.User,"
+      assert_received {:mix_shell, :info, ["* injecting config/config.exs"]}
+      assert_received {:mix_shell, :info, [@success_msg]}
+      assert_received {:mix_shell, :info, ["Pow Phoenix templates and views has been generated."]}
+      assert_received {:mix_shell, :info, ["* injecting config/config.exs"]}
 
-      assert_received {:mix_shell, :info, ["Pow Phoenix templates and views has been generated." <> msg]}
-      assert msg =~ "user: Test.Users.User"
+      assert config_content = File.read!(context.paths.config_path)
+
+      assert config_content =~ "user: Test.Users.User,"
+      assert config_content =~ "web_module: Pow,"
     end)
   end
 
-  test "generates with `:generators` config" do
-    Application.put_env(:pow, :generators, context_app: {:my_app, "my_app"})
-    on_exit(fn ->
-      Application.delete_env(:pow, :generators)
-    end)
+  @tag web_module: "Pow", context_module: "MyApp"
+  describe "with `:generators` config set" do
+    setup do
+      Application.put_env(:pow, :generators, context_app: {:my_app, "my_app"})
+      on_exit(fn ->
+        Application.delete_env(:pow, :generators)
+      end)
+    end
 
-    File.cd!(@tmp_path, fn ->
-      Install.run(@options)
+    test "generates", context do
+      File.cd!(context.tmp_path, fn ->
+        Install.run(@options)
 
-      assert_received {:mix_shell, :info, [@expected_msg <> msg]}
-      assert msg =~ "user: MyApp.Users.User,"
-    end)
+        assert_received {:mix_shell, :info, [@success_msg]}
+        assert_received {:mix_shell, :info, ["* injecting config/config.exs"]}
+        assert File.read!(context.paths.config_path) =~  "user: MyApp.Users.User,"
+      end)
+    end
   end
 
-  test "raises error in app with no top level phoenix dep" do
-    File.cd!(@tmp_path, fn ->
+  test "raises error in app with no top level phoenix dep", context do
+    File.cd!(context.tmp_path, fn ->
       File.write!("mix.exs", """
       defmodule MissingTopLevelPhoenixDep.MixProject do
         use Mix.Project
@@ -127,29 +231,13 @@ defmodule Mix.Tasks.Pow.Phoenix.InstallTest do
         end), "Phoenix not loaded by dependency"
 
         assert_raise Mix.Error, "mix pow.phoenix.install can only be run inside an application directory that has :phoenix as dependency", fn ->
-          Install.run([])
+          Install.run(@options)
         end
       end)
     end)
   end
 
-  describe "with `:user` and `:repo` environment config set" do
-    setup do
-      Application.put_env(:pow, :pow, user: Pow.Users.User, repo: Pow.Repo)
-      on_exit(fn ->
-        Application.delete_env(:pow, :pow)
-      end)
-    end
-
-    test "doesn't print instructions" do
-      File.cd!(@tmp_path, fn ->
-        Install.run([])
-
-        refute_received {:mix_shell, :info, [@expected_msg <> _msg]}
-      end)
-    end
-  end
-
+  @tag web_module: "POWWeb", context_module: "POW"
   describe "with `:namespace` environment config set" do
     setup do
       Application.put_env(:pow, :namespace, POW)
@@ -158,32 +246,35 @@ defmodule Mix.Tasks.Pow.Phoenix.InstallTest do
       end)
     end
 
-    test "uses namespace for context and web module names" do
-      File.cd!(@tmp_path, fn ->
+    test "uses namespace for context and web module names", context do
+      File.cd!(context.tmp_path, fn ->
         Install.run(~w(--templates --extension PowResetPassword))
 
-        assert_received {:mix_shell, :info, [@expected_msg <> msg]}
-        assert msg =~ "user: POW.Users.User,"
-        assert msg =~ "defmodule POWWeb.Endpoint do"
+        assert_received {:mix_shell, :info, [@success_msg]}
+        assert_received {:mix_shell, :info, ["* injecting config/config.exs"]}
+        assert_received {:mix_shell, :info, ["Pow Phoenix templates and views has been generated."]}
+        assert_received {:mix_shell, :info, ["* injecting config/config.exs"]}
 
-        assert_received {:mix_shell, :info, ["Pow Phoenix templates and views has been generated." <> msg]}
-        assert msg =~ "user: POW.Users.User"
-        assert msg =~ "web_module: POWWeb"
+        assert config_content = File.read!(context.paths.config_path)
 
-        view_file = Path.join(["lib", "pow_web", "views", "pow", "session_view.ex"])
+        assert config_content =~ "user: POW.Users.User,"
+        assert config_content =~ "web_module: POWWeb,"
+
+        view_file = Path.join([context.paths.web_path, "views", "pow", "session_view.ex"])
         assert File.exists?(view_file)
         assert File.read!(view_file) =~ "defmodule POWWeb.Pow.SessionView do"
 
-        view_file = Path.join(["lib", "pow_web", "views", "pow_reset_password", "reset_password_view.ex"])
+        view_file = Path.join([context.paths.web_path, "views", "pow_reset_password", "reset_password_view.ex"])
         assert File.exists?(view_file)
         assert File.read!(view_file) =~ "defmodule POWWeb.PowResetPassword.ResetPasswordView do"
       end)
     end
   end
 
-  test "uses web app inside Phoenix umbrella app" do
+  @tag web_module: "MyAppWeb", context_module: "MyApp"
+  test "uses web app inside Phoenix umbrella app", context do
     options = @options ++ ~w(--templates --extension PowResetPassword --extension PowEmailConfirmation)
-    File.cd!(@tmp_path, fn ->
+    File.cd!(context.tmp_path, fn ->
       File.write!("mix.exs", """
       defmodule MyAppWeb.MixProject do
         use Mix.Project
@@ -204,21 +295,26 @@ defmodule Mix.Tasks.Pow.Phoenix.InstallTest do
       Mix.Project.in_project(:my_app_web, ".", fn _ ->
         Install.run(options)
 
-        assert_received {:mix_shell, :info, [@expected_msg <> msg]}
-        assert msg =~ "config :my_app_web, :pow,"
-        assert msg =~ "user: MyApp.Users.User,"
-        assert msg =~ "plug Pow.Plug.Session, otp_app: :my_app_web"
+        assert_received {:mix_shell, :info, [@success_msg]}
+        assert_received {:mix_shell, :info, ["* injecting config/config.exs"]}
+        assert_received {:mix_shell, :info, ["Pow Phoenix templates and views has been generated."]}
 
-        assert_received {:mix_shell, :info, ["Pow Phoenix templates and views has been generated." <> msg]}
-        assert msg =~ "repo: MyApp.Repo"
-        assert msg =~ "user: MyApp.Users.User"
-        assert msg =~ "web_module: MyAppWeb"
+        assert File.read!(context.paths.config_path) =~
+          """
+          config :my_app_web, :pow,
+            web_module: MyAppWeb,
+            user: MyApp.Users.User,
+            repo: MyApp.Repo
+          """
 
-        assert File.exists?(Path.join(["lib", "my_app_web", "templates", "pow"]))
-        assert File.exists?(Path.join(["lib", "my_app_web", "views", "pow"]))
+        assert_received {:mix_shell, :info, ["* injecting lib/my_app_web/endpoint.ex"]}
+        assert File.read!(context.paths.endpoint_path) =~ "plug Pow.Plug.Session, otp_app: :my_app_web"
 
-        assert File.exists?(Path.join(["lib", "my_app_web", "templates", "pow_reset_password"]))
-        assert File.exists?(Path.join(["lib", "my_app_web", "views", "pow_reset_password"]))
+        assert File.exists?(Path.join([context.paths.web_path, "templates", "pow"]))
+        assert File.exists?(Path.join([context.paths.web_path, "views", "pow"]))
+
+        assert File.exists?(Path.join([context.paths.web_path, "templates", "pow_reset_password"]))
+        assert File.exists?(Path.join([context.paths.web_path, "views", "pow_reset_password"]))
       end)
     end)
   end

--- a/test/mix/tasks/pow.install_test.exs
+++ b/test/mix/tasks/pow.install_test.exs
@@ -3,36 +3,27 @@ defmodule Mix.Tasks.Pow.InstallTest do
 
   alias Mix.Tasks.Pow.Install
 
-  @tmp_path Path.join(["tmp", inspect(Install)])
-
-  setup do
-    File.rm_rf!(@tmp_path)
-    File.mkdir_p!(@tmp_path)
-
-    :ok
-  end
-
-  test "generates files" do
-    File.cd!(@tmp_path, fn ->
+  test "generates files", context do
+    File.cd!(context.tmp_path, fn ->
       Install.run([])
 
       assert File.ls!("lib/pow/users") == ["user.ex"]
     end)
   end
 
-  test "with schema name and table" do
+  test "with schema name and table", context do
     options = ~w(Accounts.Organization users)
 
-    File.cd!(@tmp_path, fn ->
+    File.cd!(context.tmp_path, fn ->
       Install.run(options)
 
-      assert_received {:mix_shell, :info, ["Pow has been installed in your phoenix app!" <> msg]}
-      assert msg =~ "user: Pow.Accounts.Organization"
+      assert_received {:mix_shell, :info, ["Pow has been installed in your Phoenix app!"]}
+      assert File.read!(context.paths.config_path) =~ "user: Pow.Accounts.Organization"
     end)
   end
 
-  test "raises error in umbrella app" do
-    File.cd!(@tmp_path, fn ->
+  test "raises error in umbrella app", context do
+    File.cd!(context.tmp_path, fn ->
       File.write!("mix.exs", """
       defmodule Umbrella.MixProject do
         use Mix.Project
@@ -51,8 +42,8 @@ defmodule Mix.Tasks.Pow.InstallTest do
     end)
   end
 
-  test "raises error on invalid schema name or table" do
-    File.cd!(@tmp_path, fn ->
+  test "raises error on invalid schema name or table", context do
+    File.cd!(context.tmp_path, fn ->
       assert_raise Mix.Error, ~r/Invalid arguments/, fn ->
         Install.run(~w(Users.User))
       end

--- a/test/mix/tasks/pow_test.exs
+++ b/test/mix/tasks/pow_test.exs
@@ -3,17 +3,8 @@ defmodule Mix.Tasks.PowTest do
 
   alias Mix.Tasks.Pow
 
-  @tmp_path Path.join(["tmp", inspect(Pow)])
-
-  setup do
-    File.rm_rf!(@tmp_path)
-    File.mkdir_p!(@tmp_path)
-
-    :ok
-  end
-
-  test "prints information" do
-    File.cd!(@tmp_path, fn ->
+  test "prints information", context do
+    File.cd!(context.tmp_path, fn ->
       File.write!("mix.exs", """
       defmodule MyApp.MixProject do
         use Mix.Project

--- a/test/support/mix/test_case.ex
+++ b/test/support/mix/test_case.ex
@@ -8,7 +8,7 @@ defmodule Pow.Test.Mix.TestCase do
     :ok
   end
 
-  setup do
+  setup context do
     current_shell = Mix.shell()
 
     on_exit fn ->
@@ -17,8 +17,114 @@ defmodule Pow.Test.Mix.TestCase do
 
     Mix.shell(Mix.Shell.Process)
 
-    :ok
+    context =
+      context
+      |> Map.put(:tmp_path, Path.join(["tmp", inspect(context.case)]))
+      |> build_context()
+      |> init_phoenix_app_dir()
+
+    {:ok, context}
   end
 
   defp clear_tmp_files, do: File.rm_rf!("tmp")
+
+  defp build_context(context) do
+    context_module = context[:context_module] || "Pow"
+    web_module = context[:web_module] || "PowWeb"
+    web_path = Path.join(["lib", Macro.underscore(web_module)])
+
+    paths =
+      %{
+        web_path: web_path,
+        templates_path: Path.join([web_path, "templates", "pow"]),
+        views_path: Path.join([web_path, "views", "pow"]),
+        config_path: Path.join(["config", "config.exs"]),
+        endpoint_path: Path.join([web_path, "endpoint.ex"]),
+        router_path: Path.join([web_path, "router.ex"])
+      }
+
+    Map.merge(context, %{context_module: context_module, web_module: web_module, paths: paths})
+  end
+
+  defp init_phoenix_app_dir(context) do
+    File.rm_rf!(context.tmp_path)
+    File.mkdir_p!(context.tmp_path)
+
+    File.cd!(context.tmp_path, fn ->
+      File.mkdir_p!(Path.dirname(context.paths.config_path))
+
+      File.write!(
+        context.paths.config_path,
+        """
+        import Config
+
+        # Configure Mix tasks and generators
+        config :#{Macro.underscore(context.context_module)},
+          ecto_repos: [#{context.context_module}.Repo]
+
+        config :#{Macro.underscore(context.context_module)},
+          ecto_repos: [#{context.context_module}.Repo],
+          generators: [context_app: :#{Macro.underscore(context.context_module)}]
+
+        # Import environment specific config. This must remain at the bottom
+        # of this file so it overrides the configuration defined above.
+        import_config "\#{config_env()}.exs"
+        """)
+
+      File.mkdir_p!(context.paths.web_path)
+
+      File.write!(
+        context.paths.endpoint_path,
+        """
+        defmodule #{context.web_module}.Endpoint do
+          @moduledoc false
+          use Phoenix.Endpoint, otp_app: :#{Macro.underscore(context.context_module)}
+
+          @session_options [
+            store: :cookie,
+            key: "_binaryid_key",
+            signing_salt: "secret"
+          ]
+
+          plug Plug.RequestId
+          plug Plug.Logger
+
+          plug Plug.Parsers,
+            parsers: [:urlencoded, :multipart, :json],
+            pass: ["*/*"],
+            json_decoder: Phoenix.json_library()
+
+          plug Plug.MethodOverride
+          plug Plug.Head
+          plug Plug.Session, @session_options
+          plug #{context.web_module}.Router
+        end
+        """)
+
+      File.write!(
+        context.paths.router_path,
+        """
+        defmodule #{context.web_module}.Router do
+          @moduledoc false
+          use #{context.web_module}, :router
+
+          pipeline :browser do
+            plug :accepts, ["html"]
+            plug :fetch_session
+            plug :fetch_flash
+            plug :protect_from_forgery
+            plug :put_secure_browser_headers
+          end
+
+          scope "/", #{context.web_module} do
+            pipe_through :browser
+
+            get "/", PageController, :index
+          end
+        end
+        """)
+
+      context
+    end)
+  end
 end


### PR DESCRIPTION
This improves mix tasks by automatically attempting to inject updates to existing files rather than prompting the end user to do it.