### PR TITLE
Test latest otp elixir

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,8 +27,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - elixir: 1.13.3
-            otp: 24.2
+          - elixir: 1.13.4
+            otp: 25.0.4
           - elixir: 1.11.0
             otp: 22.0.2
     name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 if Mix.env() == :test do
   import_config "test.exs"

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 endpoint_config = [
   secret_key_base: String.duplicate("abcdefghijklmnopqrstuvxyz0123456789", 2),


### PR DESCRIPTION
Updated mnesia distribution test to use the new [`:peer`](https://erlang.org/documentation/doc-13.0-rc1/lib/stdlib-4.0/doc/html/peer.html) module in OTP 25