### PR TITLE
Compiler is not necessary since 1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 * [`Mix.Tasks.Pow.Phoenix.Install`] Now injects `config/config.exs`, `WEB_PATH/endpoint.ex`, and `WEB_PATH/router.ex`
 * [`Phoenix.Router.Route`] Updated to support Phoenix 1.7 breaking changes
 
+### Bug fixes
+
+* `:phoenix` removed from the compilers
+
 ### Documentation
 
 * Updated [api guide](guides/api.md) to correctly return updated `conn` for delete calls

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@ defmodule Pow.MixProject do
       elixir: "~> 1.11",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
-      compilers: [:phoenix] ++ Mix.compilers(),
+      compilers: Mix.compilers(),
       deps: deps(),
       xref: [exclude: [:mnesia]],
 


### PR DESCRIPTION
As Pow requires Elixir 1.11+, so it's not necessary to specify the compilers.

Solves #683