### PR TITLE
Handle Phoenix 1.7 deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@
 * [`Mix.Pow.Mix.Tasks.Pow.Phoenix.Mailer.Gen.Templates`] Now injects `config/config.exs` and `WEB_PATH/WEB_APP.ex`
 * [`Mix.Pow.Mix.Tasks.Pow.Phoenix.Gen.Templates`] Now injects `config/config.exs`
 * [`Mix.Tasks.Pow.Phoenix.Install`] Now injects `config/config.exs`, `WEB_PATH/endpoint.ex`, and `WEB_PATH/router.ex`
-* [`Phoenix.Router.Route`] Updated to support Phoenix 1.7 breaking changes
+* [`Pow.Phoenix.Router`] Updated to support Phoenix 1.7 breaking changes
+* [`Pow.Phoenix.Template`] Updated to support Phoenix 1.7 verified routes
+* [`Pow.Phoenix.Routes`] Updated to support Phoenix 1.7 verified routes
+* [`Pow.Phoenix.ViewHelpers`] Updated to handle Phoenix 1.7 components layout
 
 ### Bug fixes
 

--- a/README.md
+++ b/README.md
@@ -384,9 +384,9 @@ You can customize callback routes by creating the following module:
 ```elixir
 defmodule MyAppWeb.Pow.Routes do
   use Pow.Phoenix.Routes
-  alias MyAppWeb.Router.Helpers, as: Routes
+  use MyAppWeb, :verified_routes
 
-  def after_sign_in_path(conn), do: Routes.some_path(conn, :index)
+  def after_sign_in_path(conn), do: ~p"/home"
 end
 ```
 
@@ -421,10 +421,10 @@ This can be used to show the sign in or sign out links in your Phoenix template:
 
 ```elixir
 <%= if Pow.Plug.current_user(@conn) do %>
-  <span><%= link "Sign out", to: Routes.pow_session_path(@conn, :delete), method: :delete %></span>
+  <span><%= link "Sign out", to: ~p"/session", method: :delete %></span>
 <% else %>
-  <span><%= link "Register", to: Routes.pow_registration_path(@conn, :new) %></span>
-  <span><%= link "Sign in", to: Routes.pow_session_path(@conn, :new) %></span>
+  <span><%= link "Register", to: ~p"/registration" %></span>
+  <span><%= link "Sign in", to: ~p"/session" %></span>
 <% end %>
 ```
 

--- a/guides/api.md
+++ b/guides/api.md
@@ -390,7 +390,7 @@ defmodule MyAppWeb.API.V1.RegistrationControllerTest do
     @invalid_params %{"user" => %{"email" => "invalid", "password" => @password, "password_confirmation" => ""}}
 
     test "with valid params", %{conn: conn} do
-      conn = post(conn, Routes.api_v1_registration_path(conn, :create, @valid_params))
+      conn = post(conn, ~p"/registration", @valid_params)
 
       assert json = json_response(conn, 200)
       assert json["data"]["access_token"]
@@ -398,7 +398,7 @@ defmodule MyAppWeb.API.V1.RegistrationControllerTest do
     end
 
     test "with invalid params", %{conn: conn} do
-      conn = post(conn, Routes.api_v1_registration_path(conn, :create, @invalid_params))
+      conn = post(conn, ~p"/registration", @invalid_params)
 
       assert json = json_response(conn, 500)
       assert json["error"]["message"] == "Couldn't create user"
@@ -433,7 +433,7 @@ defmodule MyAppWeb.API.V1.SessionControllerTest do
     @invalid_params %{"user" => %{"email" => "test@example.com", "password" => "invalid"}}
 
     test "with valid params", %{conn: conn} do
-      conn = post(conn, Routes.api_v1_session_path(conn, :create, @valid_params))
+      conn = post(conn, ~p"/api/v1/session", @valid_params)
 
       assert json = json_response(conn, 200)
       assert json["data"]["access_token"]
@@ -441,7 +441,7 @@ defmodule MyAppWeb.API.V1.SessionControllerTest do
     end
 
     test "with invalid params", %{conn: conn} do
-      conn = post(conn, Routes.api_v1_session_path(conn, :create, @invalid_params))
+      conn = post(conn, ~p"/api/v1/session", @invalid_params)
 
       assert json = json_response(conn, 401)
       assert json["error"]["message"] == "Invalid email or password"
@@ -451,7 +451,7 @@ defmodule MyAppWeb.API.V1.SessionControllerTest do
 
   describe "renew/2" do
     setup %{conn: conn} do
-      authed_conn = post(conn, Routes.api_v1_session_path(conn, :create, @valid_params))
+      authed_conn = post(conn, ~p"/api/v1/session", @valid_params)
 
       {:ok, renewal_token: authed_conn.private[:api_renewal_token]}
     end
@@ -460,7 +460,7 @@ defmodule MyAppWeb.API.V1.SessionControllerTest do
       conn =
         conn
         |> Plug.Conn.put_req_header("authorization", token)
-        |> post(Routes.api_v1_session_path(conn, :renew))
+        |> post(~p"/api/v1/session/renew")
 
       assert json = json_response(conn, 200)
       assert json["data"]["access_token"]
@@ -471,7 +471,7 @@ defmodule MyAppWeb.API.V1.SessionControllerTest do
       conn =
         conn
         |> Plug.Conn.put_req_header("authorization", "invalid")
-        |> post(Routes.api_v1_session_path(conn, :renew))
+        |> post(~p"/api/v1/session/renew")
 
       assert json = json_response(conn, 401)
       assert json["error"]["message"] == "Invalid token"
@@ -481,7 +481,7 @@ defmodule MyAppWeb.API.V1.SessionControllerTest do
 
   describe "delete/2" do
     setup %{conn: conn} do
-      authed_conn = post(conn, Routes.api_v1_session_path(conn, :create, @valid_params))
+      authed_conn = post(conn, ~p"/api/v1/session/", @valid_params)
 
       {:ok, access_token: authed_conn.private[:api_access_token]}
     end
@@ -490,7 +490,7 @@ defmodule MyAppWeb.API.V1.SessionControllerTest do
       conn =
         conn
         |> Plug.Conn.put_req_header("authorization", token)
-        |> delete(Routes.api_v1_session_path(conn, :delete))
+        |> delete( ~p"/api/v1/session/")
 
       assert json = json_response(conn, 200)
       assert json["data"] == %{}

--- a/guides/custom_controllers.md
+++ b/guides/custom_controllers.md
@@ -56,14 +56,14 @@ defmodule MyAppWeb.AuthErrorHandler do
   def call(conn, :not_authenticated) do
     conn
     |> put_flash(:error, "You've to be authenticated first")
-    |> redirect(to: Routes.login_path(conn, :new))
+    |> redirect(to: ~p"/login")
   end
 
   @spec call(Conn.t(), atom()) :: Conn.t()
   def call(conn, :already_authenticated) do
     conn
     |> put_flash(:error, "You're already authenticated")
-    |> redirect(to: Routes.page_path(conn, :index))
+    |> redirect(to: ~p"/")
   end
 end
 ```
@@ -102,7 +102,7 @@ defmodule MyAppWeb.RegistrationController do
       {:ok, user, conn} ->
         conn
         |> put_flash(:info, "Welcome!")
-        |> redirect(to: Routes.page_path(conn, :index))
+        |> redirect(to: ~p"/")
 
       {:error, changeset, conn} ->
         render(conn, "new.html", changeset: changeset)
@@ -130,7 +130,7 @@ defmodule MyAppWeb.SessionController do
       {:ok, conn} ->
         conn
         |> put_flash(:info, "Welcome back!")
-        |> redirect(to: Routes.page_path(conn, :index))
+        |> redirect(to: ~p"/")
 
       {:error, conn} ->
         changeset = Pow.Plug.change_user(conn, conn.params["user"])
@@ -144,7 +144,7 @@ defmodule MyAppWeb.SessionController do
   def delete(conn, _params) do
     conn
     |> Pow.Plug.delete()
-    |> redirect(to: Routes.page_path(conn, :index))
+    |> redirect(to: ~p"/")
   end
 end
 ```
@@ -154,7 +154,7 @@ end
 Create `WEB_PATH/templates/registration/new.html.eex`:
 
 ```elixir
-<%= form_for @changeset, Routes.signup_path(@conn, :create), fn f -> %>
+<%= form_for @changeset, ~p"/signup", fn f -> %>
   <%= label f, :email %>
   <%= email_input f, :email %>
   <%= error_tag f, :email %>
@@ -176,7 +176,7 @@ Create `WEB_PATH/templates/session/new.html.eex`:
 ```elixir
 <h1>Log in</h1>
 
-<%= form_for @changeset, Routes.login_path(@conn, :create), fn f -> %>
+<%= form_for @changeset, ~p"/login", fn f -> %>
   <%= text_input f, :email %>
   <%= password_input f, :password %>
   <%= submit "Log in" %>
@@ -209,13 +209,13 @@ defmodule MyAppWeb.SessionController do
       true ->
         conn
         |> put_flash(:info, "Welcome back!")
-        |> redirect(to: Routes.page_path(conn, :index))
+        |> redirect(to: ~p"/")
 
       false ->
         conn
         |> Pow.Plug.delete()
         |> put_flash(:info, "Your e-mail address has not been confirmed.")
-        |> redirect(to: Routes.login_path(conn, :new))
+        |> redirect(to: ~p"/login")
     end
   end
   defp verify_confirmed({:error, conn}) do

--- a/guides/lock_users.md
+++ b/guides/lock_users.md
@@ -137,7 +137,7 @@ defmodule MyAppWeb.EnsureUserNotLockedPlug do
   """
   import Plug.Conn, only: [halt: 1]
 
-  alias MyAppWeb.Router.Helpers, as: Routes
+  use MyAppWeb, :verified_routes
   alias Phoenix.Controller
   alias Plug.Conn
   alias Pow.Plug
@@ -162,7 +162,7 @@ defmodule MyAppWeb.EnsureUserNotLockedPlug do
     conn
     |> Plug.delete()
     |> Controller.put_flash(:error, "Sorry, your account is locked.")
-    |> Controller.redirect(to: Routes.pow_session_path(conn, :new))
+    |> Controller.redirect(to: ~p"/session/new")
     |> halt()
   end
   defp maybe_halt(_any, conn), do: conn
@@ -280,7 +280,7 @@ defmodule MyAppWeb.Admin.UserControllerTest do
     test "locks user", %{conn: conn} do
       user = user_fixture()
 
-      conn = post(conn, Routes.admin_user_path(conn, :lock, user.id))
+      conn = post(conn, ~p"/admin/users/#{user.id}/lock")
 
       assert Phoenix.Flash.get(conn.assigns.flash, :info) == "User has been locked."
       assert redirected_to(conn) == "/"
@@ -289,7 +289,7 @@ defmodule MyAppWeb.Admin.UserControllerTest do
     test "with already locked user", %{conn: conn} do
       {:ok, user} = Users.lock(user_fixture())
 
-      conn = post(conn, Routes.admin_user_path(conn, :lock, user.id))
+      conn = post(conn, ~p"/admin/users/#{user.id}/lock")
 
       assert Phoenix.Flash.get(conn.assigns.flash, :error) == "User couldn't be locked."
       assert redirected_to(conn) == "/"
@@ -346,7 +346,7 @@ defmodule MyAppWeb.EnsureUserNotLockedPlugTest do
       |> EnsureUserNotLockedPlug.call(opts)
 
     assert Phoenix.Flash.get(conn.assigns.flash, :error) == "Sorry, your account is locked."
-    assert redirected_to(conn) == Routes.pow_session_path(conn, :new)
+    assert redirected_to(conn) == ~p"/session"
   end
 
   defp init_conn() do
@@ -375,10 +375,10 @@ defmodule MyAppWeb.ResetPasswordControllerTest do
     test "with user", %{conn: conn} do
       user = user_fixture()
 
-      conn = post(conn, Routes.reset_password_path(conn, :create, @valid_params))
+      conn = post(conn, ~p"/reset-password", @valid_params)
 
       assert Phoenix.Flash.get(conn.assigns.flash, :info)
-      assert redirected_to(conn) == Routes.pow_session_path(conn, :new)
+      assert redirected_to(conn) == ~p"/session"
 
       assert count_reset_password_tokens_for_user(conn, user) == 1
     end
@@ -386,10 +386,10 @@ defmodule MyAppWeb.ResetPasswordControllerTest do
     test "with locked user", %{conn: conn} do
       {:ok, user} = Users.lock(user_fixture())
 
-      conn = post(conn, Routes.reset_password_path(conn, :create, @valid_params))
+      conn = post(conn, ~p"/reset-password", @valid_params)
 
       assert Phoenix.Flash.get(conn.assigns.flash, :info)
-      assert redirected_to(conn) == Routes.pow_session_path(conn, :new)
+      assert redirected_to(conn) == ~p"/session"
 
       assert count_reset_password_tokens_for_user(conn, user) == 0
     end

--- a/guides/multitenancy.md
+++ b/guides/multitenancy.md
@@ -173,7 +173,7 @@ defmodule MyAppWeb.AccountController do
         conn
         |> Pow.Plug.create(user)
         |> put_flash(:info, "Welcome!")
-        |> redirect(to: Routes.page_path(conn, :index))
+        |> redirect(to: ~p"/")
 
       {:error, changeset} ->
         render(conn, "new.html", changeset: changeset)
@@ -302,17 +302,17 @@ defmodule MyAppWeb.AccountControllerTest do
     @invalid_params %{"account" => @tenant_id, "user" => %{"email" => "test@example.com", "password" => "secret1234"}}
 
     test "with invalid params", %{conn: conn} do
-      conn = post(conn, Routes.account_path(conn, :create, @invalid_params))
+      conn = post(conn, ~p"/account", @invalid_params)
 
       assert html_response(conn, 500)
       refute Pow.Plug.current_user(conn)
     end
 
     test "with valid params", %{conn: conn} do
-      conn = post(conn, Routes.account_path(conn, :create, @valid_params))
+      conn = post(conn, ~p"/account", @valid_params)
 
       assert Phoenix.Flash.get(conn.assigns.flash, :info) == "Welcome!"
-      assert redirected_to(conn) == Routes.page_path(conn, :index)
+      assert redirected_to(conn) == ~p"/"
 
       assert Pow.Plug.current_user(conn)
     end

--- a/guides/sync_user.md
+++ b/guides/sync_user.md
@@ -121,7 +121,7 @@ defmodule MyAppWeb.PlanController do
         conn
         |> sync_user(user) # Update the user in the credentials cache
         |> put_flash(:info, "Plan updated successfully.")
-        |> redirect(to: Routes.profile_path(conn, :show))
+        |> redirect(to: ~p"/profile")
 
       {:error, %Ecto.Changeset{} = changeset} ->
         render(conn, "plan.html", changeset: changeset)

--- a/guides/user_roles.md
+++ b/guides/user_roles.md
@@ -77,7 +77,8 @@ defmodule MyAppWeb.EnsureRolePlug do
   """
   import Plug.Conn, only: [halt: 1]
 
-  alias MyAppWeb.Router.Helpers, as: Routes
+  use MyAppWeb, :verified_routes
+
   alias Phoenix.Controller
   alias Plug.Conn
   alias Pow.Plug
@@ -105,7 +106,7 @@ defmodule MyAppWeb.EnsureRolePlug do
   defp maybe_halt(_any, conn) do
     conn
     |> Controller.put_flash(:error, "Unauthorized access")
-    |> Controller.redirect(to: Routes.page_path(conn, :index))
+    |> Controller.redirect(to: ~p"/")
     |> halt()
   end
 end
@@ -267,7 +268,7 @@ defmodule MyAppWeb.EnsureRolePlugTest do
     conn = EnsureRolePlug.call(conn, opts)
 
     assert conn.halted
-    assert redirected_to(conn) == Routes.page_path(conn, :index)
+    assert redirected_to(conn) == ~p"/"
   end
 
   test "call/2 with non-admin user", %{conn: conn} do
@@ -278,7 +279,7 @@ defmodule MyAppWeb.EnsureRolePlugTest do
       |> EnsureRolePlug.call(opts)
 
     assert conn.halted
-    assert redirected_to(conn) == Routes.page_path(conn, :index)
+    assert redirected_to(conn) == ~p"/"
   end
 
   test "call/2 with non-admin user and multiple roles", %{conn: conn} do

--- a/lib/extensions/invitation/phoenix/templates/invitation_template.ex
+++ b/lib/extensions/invitation/phoenix/templates/invitation_template.ex
@@ -21,7 +21,7 @@ defmodule PowInvitation.Phoenix.InvitationTemplate do
     {:password, :password_confirmation}
   ]) %>
 
-  <span><%%= link "Sign in", to: Routes.<%= Pow.Phoenix.Controller.route_helper(Pow.Phoenix.SessionController) %>_path(@conn, :new) %></span>
+  <span><%%= link "Sign in", to: <%= Pow.Phoenix.Template.__inline_route__(Pow.Phoenix.SessionController, :new) %>%></span>
   """
 
   template :show, :html,

--- a/lib/extensions/reset_password/README.md
+++ b/lib/extensions/reset_password/README.md
@@ -13,5 +13,5 @@ Follow the instructions for extensions in [README.md](../../../README.md#add-ext
 Add the following link to your `WEB_PATH/templates/pow/session/new.html.eex` template (you may need to generate the templates first):
 
 ```elixir
-link("Reset password", to: Routes.pow_reset_password_reset_password_path(@conn, :new))
+link("Reset password", to: ~p"/reset-password")
 ```

--- a/lib/extensions/reset_password/phoenix/templates/reset_password_template.ex
+++ b/lib/extensions/reset_password/phoenix/templates/reset_password_template.ex
@@ -20,6 +20,6 @@ defmodule PowResetPassword.Phoenix.ResetPasswordTemplate do
     {:password, :password_confirmation}
   ]) %>
 
-  <span><%%= link "Sign in", to: Routes.<%= Pow.Phoenix.Controller.route_helper(Pow.Phoenix.SessionController) %>_path(@conn, :new) %></span>
+  <span><%%= link "Sign in", to: <%= Pow.Phoenix.Template.__inline_route__(Pow.Phoenix.SessionController, :new) %>%></span>
   """
 end

--- a/lib/pow/phoenix/controllers/controller.ex
+++ b/lib/pow/phoenix/controllers/controller.ex
@@ -116,15 +116,6 @@ defmodule Pow.Phoenix.Controller do
     |> Config.get(:routes_backend, fallback)
   end
 
-  @spec route_helper(atom()) :: binary()
-  def route_helper(plug) do
-    as             = Phoenix.Naming.resource_name(plug, "Controller")
-    [base | _rest] = Module.split(plug)
-    base           = Macro.underscore(base)
-
-    "#{base}_#{as}"
-  end
-
   @doc """
   Ensures that user has been authenticated.
 
@@ -167,5 +158,15 @@ defmodule Pow.Phoenix.Controller do
       @default_cache_control_header -> Conn.put_resp_header(conn, "cache-control", @no_cache_control_header)
       _any                          -> conn
     end
+  end
+
+  # TODO: Remove when Phoenix 1.7 is required
+  @spec route_helper(atom()) :: binary()
+  def route_helper(plug) do
+    as             = Phoenix.Naming.resource_name(plug, "Controller")
+    [base | _rest] = Module.split(plug)
+    base           = Macro.underscore(base)
+
+    "#{base}_#{as}"
   end
 end

--- a/lib/pow/phoenix/routes.ex
+++ b/lib/pow/phoenix/routes.ex
@@ -6,10 +6,10 @@ defmodule Pow.Phoenix.Routes do
 
       defmodule MyAppWeb.Pow.Routes do
         use Pow.Phoenix.Routes
-        alias MyAppWeb.Router.Helpers, as: Routes
+        use MyAppWeb, :verified_routes
 
         @impl true
-        def after_sign_out_path(conn), do: Routes.some_path(conn, :index)
+        def after_sign_out_path(conn), do: ~p"/some-path"
       end
 
   Update configuration with `routes_backend: MyAppWeb.Pow.Routes`.
@@ -18,12 +18,12 @@ defmodule Pow.Phoenix.Routes do
 
       defmodule MyAppWeb.Pow.Routes do
         use Pow.Phoenix.Routes
-        alias MyAppWeb.Router.Helpers, as: Routes
+        use MyAppWeb, :verified_routes
 
         @impl true
         def url_for(conn, verb, vars \\ [], query_params \\ [])
         def url_for(conn, PowEmailConfirmation.Phoenix.ConfirmationController, :show, [token], _query_params),
-          do: Routes.custom_confirmation_url(conn, :new, token)
+          do: ~p"/custom-confirmation/\#{token}"
         def url_for(conn, plug, verb, vars, query_params),
           do: Pow.Phoenix.Routes.url_for(conn, plug, verb, vars, query_params)
       end
@@ -168,12 +168,12 @@ defmodule Pow.Phoenix.Routes do
     gen_route(:url, conn, plug, verb, vars, query_params)
   end
 
-  defp gen_route(type, conn, plug, verb, vars, query_params) do
-    alias  = Controller.route_helper(plug)
-    helper = :"#{alias}_#{type}"
-    router = Module.concat([conn.private.phoenix_router, Helpers])
-    args   = [conn, verb] ++ vars ++ [query_params]
+    defp gen_route(type, conn, plug, verb, vars, query_params) do
+      alias  = Controller.route_helper(plug)
+      helper = :"#{alias}_#{type}"
+      router = Module.concat([conn.private.phoenix_router, Helpers])
+      args   = [conn, verb] ++ vars ++ [query_params]
 
-    apply(router, helper, args)
+      apply(router, helper, args)
+    end
   end
-end

--- a/lib/pow/phoenix/template.ex
+++ b/lib/pow/phoenix/template.ex
@@ -22,7 +22,14 @@ defmodule Pow.Phoenix.Template do
       import Pow.Phoenix.HTML.ErrorHelpers, only: [error_tag: 2]
       import Phoenix.HTML.{Form, Link}
 
-      alias Pow.Phoenix.Router.Helpers, as: Routes
+      unquote do
+        # TODO: Remove when Phoenix 1.7 is required
+        unless Code.ensure_loaded?(Phoenix.VerifiedRoutes) do
+          quote do
+            alias Pow.Phoenix.Router.Helpers, as: Routes
+          end
+        end
+      end
     end
   end
 
@@ -49,6 +56,17 @@ defmodule Pow.Phoenix.Template do
       end
 
       def html(unquote(action)), do: unquote(content)
+    end
+  end
+
+  if Code.ensure_loaded?(Phoenix.VerifiedRoutes) do
+    def __inline_route__(plug, plug_opts) do
+      "Pow.Phoenix.Routes.path_for(@conn, #{inspect plug}, #{inspect plug_opts})"
+    end
+  else
+    # TODO: Remove when Phoenix 1.7 is required
+    def __inline_route__(plug, plug_opts) do
+      "Routes.#{Pow.Phoenix.Controller.route_helper(plug)}_path(@conn, #{inspect plug_opts}) %>"
     end
   end
 end

--- a/lib/pow/phoenix/templates/registration_template.ex
+++ b/lib/pow/phoenix/templates/registration_template.ex
@@ -13,7 +13,7 @@ defmodule Pow.Phoenix.RegistrationTemplate do
   ],
   button_label: "Register") %>
 
-  <span><%%= link "Sign in", to: Routes.<%= Pow.Phoenix.Controller.route_helper(Pow.Phoenix.SessionController) %>_path(@conn, :new) %></span>
+  <span><%%= link "Sign in", to: <%= Pow.Phoenix.Template.__inline_route__(Pow.Phoenix.SessionController, :new) %>%></span>
   """
 
   template :edit, :html,

--- a/lib/pow/phoenix/templates/session_template.ex
+++ b/lib/pow/phoenix/templates/session_template.ex
@@ -12,6 +12,6 @@ defmodule Pow.Phoenix.SessionTemplate do
   ],
   button_label: "Sign in") %>
 
-  <span><%%= link "Register", to: Routes.<%= Pow.Phoenix.Controller.route_helper(Pow.Phoenix.RegistrationController) %>_path(@conn, :new) %></span>
+  <span><%%= link "Register", to: <%= Pow.Phoenix.Template.__inline_route__(Pow.Phoenix.RegistrationController, :new) %>%></span>
   """
 end

--- a/lib/pow/phoenix/views/view_helpers.ex
+++ b/lib/pow/phoenix/views/view_helpers.ex
@@ -107,9 +107,14 @@ defmodule Pow.Phoenix.ViewHelpers do
   end
 
   defp build_layout({Pow.Phoenix.LayoutView, template}, web_module) do
-    view = Module.concat([web_module, LayoutView])
+    layouts = Module.concat([web_module, Layouts])
 
-    {view, template}
+    if Code.ensure_loaded?(layouts) do
+      {layouts, template}
+    else
+      # TODO: Remove this when Phoenix 1.7 is required
+      {Module.concat([web_module, LayoutView]), template}
+    end
   end
   defp build_layout(layout, _web_module), do: layout
 

--- a/test/pow/phoenix/routes_test.exs
+++ b/test/pow/phoenix/routes_test.exs
@@ -15,6 +15,7 @@ defmodule Pow.Phoenix.RoutesTest do
     {:ok, conn: conn}
   end
 
+  # TODO: Refactor when Phoenix 1.7 has been released
   test "can customize routes", %{conn: conn} do
     conn = Plug.Conn.put_private(conn, :pow_config, [])
     assert Routes.after_sign_in_path(conn) == "/"


### PR DESCRIPTION
This handles deprecations to how routes and layouts are handled in Phoenix 1.7. Next up will be a rewrite for views and templates to be conform with Phoenix 1.7 structure and use the core components module.